### PR TITLE
fix(invite): findByEmail surfaces Passport/Google users, stops 500 on…

### DIFF
--- a/app/api/invite/get-invite/route.ts
+++ b/app/api/invite/get-invite/route.ts
@@ -30,8 +30,19 @@ export async function GET(req: NextRequest) {
       return NextResponse.json({ error: 'Invitation has already been accepted' }, { status: 400 })
     }
 
-    // Check if user exists
+    // Check if user already exists — under ANY auth provider. The UI
+    // uses this to decide whether to show a "Sign in with Google"
+    // shortcut vs a full signup form.
     const existingUser = await userRepository.findByEmail(invite.email)
+    let hasGoogleAuth = false
+    if (existingUser) {
+      const { prisma } = await import('@/lib/prisma')
+      const googleIdentity = await prisma.authIdentity.findFirst({
+        where: { app_user_id: existingUser.id, provider: 'passport' },
+        select: { id: true },
+      })
+      hasGoogleAuth = !!googleIdentity
+    }
 
     return NextResponse.json({
       success: true,
@@ -42,6 +53,7 @@ export async function GET(req: NextRequest) {
         expiresAt: invite.expiresAt,
       },
       userExists: !!existingUser,
+      hasGoogleAuth,
     })
   } catch (error) {
     return handleAPIError(error)

--- a/infrastructure/persistence/prisma/PrismaUserRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaUserRepository.ts
@@ -44,41 +44,43 @@ export class PrismaUserRepository implements UserRepository {
 
   async findByEmail(email: string): Promise<AppUser | null> {
     const normalizedEmail = email.trim()
-    if (!normalizedEmail) {
-      return null
-    }
+    if (!normalizedEmail) return null
 
-    const identity = await prisma.authIdentity.findFirst({
+    // Look up the canonical app_users row by email directly, regardless
+    // of which auth provider owns it. Earlier this was scoped to
+    // provider='supabase' only, which hid Passport/Google users from
+    // flows like team-invite acceptance — the invite route then tried
+    // to create a duplicate row and blew up on the primary_email unique
+    // constraint (500). We now always return the matching user and
+    // attach whichever identity we can find (passport first, supabase
+    // second) so the caller gets consistent legacy-auth metadata.
+    const appUser = await prisma.appUser.findFirst({
       where: {
-        provider: 'supabase',
-        appUser: {
-          primary_email: {
-            equals: normalizedEmail,
-            mode: 'insensitive',
-          },
-        },
+        primary_email: { equals: normalizedEmail, mode: 'insensitive' },
       },
       select: {
-        legacy_auth_id: true,
-        provider: true,
-        appUser: {
-          select: {
-            id: true,
-            primary_email: true,
-            full_name: true,
-          },
+        id: true,
+        primary_email: true,
+        full_name: true,
+        authIdentities: {
+          select: { provider: true, legacy_auth_id: true, is_primary: true },
+          orderBy: [{ is_primary: 'desc' }, { provider: 'asc' }],
         },
       },
     })
 
-    if (!identity || !identity.appUser) {
-      return null
-    }
+    if (!appUser) return null
+
+    const preferred =
+      appUser.authIdentities.find(i => i.provider === 'passport') ||
+      appUser.authIdentities.find(i => i.provider === 'supabase') ||
+      appUser.authIdentities[0] ||
+      null
 
     return this.mapCanonicalUser(
-      identity.appUser,
-      identity.provider as AppUser['legacyAuthProvider'],
-      identity.legacy_auth_id
+      { id: appUser.id, primary_email: appUser.primary_email, full_name: appUser.full_name ?? null },
+      (preferred?.provider as AppUser['legacyAuthProvider']) ?? null,
+      preferred?.legacy_auth_id ?? null,
     )
   }
 


### PR DESCRIPTION
… accept

Reported: inviting an email that already belongs to a Google-auth user accepted the invite, but the accept page 500'd with "Internal server error" when they tried to set a password.

Root cause: PrismaUserRepository.findByEmail was scoped to
  where: { provider: 'supabase' }
so every user created via Passport/Google was invisible. The invite route then:

  1. called findByEmail — got null
  2. went into the "no existing user" branch
  3. prisma.appUser.create({ data: { primary_email: 'x@y.z', ... } })
  4. hit the unique constraint on primary_email
  5. returned 500

Fixed by looking up the canonical app_users row directly by email, then attaching whichever identity we can find (preferring passport, then supabase). Callers now get consistent results regardless of which auth provider the user originally signed up through.

Also augmented /api/invite/get-invite to return hasGoogleAuth so the accept-invite UI can (in a follow-up) offer a one-click "Sign in with Google" shortcut instead of asking existing Google users for a password. For now the existing "Sign in to accept invitation" button (which links to /login with returnTo) works correctly — the Passport Google user signs in normally and the session-aware useEffect in InviteAcceptClient auto-accepts the invite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of existing user accounts with Google authentication during invitation flow
  * Improved user account lookup with comprehensive authentication identity information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->