### PR TITLE
fix(onboarding): fall back to 'Other' + raw description when agent ca…

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -409,22 +409,42 @@ export default function OnboardingPage() {
 
     const phoneNumber = companyData?.mobileNumber || companyData?.phoneNumber || companyData?.contactNumber || ''
 
-    // Determine industry from NIC code (parsed CIN) or entity detection
-    const nicIndustry = detection.industryPrimary
-    const isKnownIndustry = nicIndustry && INDUSTRIES.includes(nicIndustry as any)
-    const selectedIndustries = isKnownIndustry
-      ? [nicIndustry as any]
-      : nicIndustry && nicIndustry !== 'Other'
-        ? ['Other' as any]
-        : []
-
-    const needsOtherCategoryText = formCategories.includes('Other')
+    // Determine industry from NIC code (parsed CIN) or entity detection.
+    // Principle: if the API/NIC gave us ANY signal about what this
+    // company does, fill the fields. If the signal doesn't match a
+    // predefined option, select "Other" and stash the raw description
+    // in otherIndustryCategory so nothing is left blank.
     const rawApiDescription = companyData?.principalBusinessActivity ||
                               companyData?.industrialClass ||
                               companyData?.mainDivision ||
-                              // Fallback: use NIC description from parsed CIN
                               parsed.nicDetails?.description ||
                               detection.industryPrimary || ''
+
+    const nicIndustry = detection.industryPrimary
+    const isKnownIndustry = !!nicIndustry && INDUSTRIES.includes(nicIndustry as any)
+    const haveAnyIndustrySignal = Boolean(
+      (nicIndustry && nicIndustry !== 'Other') || rawApiDescription.trim()
+    )
+    const selectedIndustries: string[] = isKnownIndustry
+      ? [nicIndustry as any]
+      : haveAnyIndustrySignal
+        ? ['Other']
+        : []
+
+    // Categories: same fallback — if the mapper returned nothing but
+    // we have a description, mark Other so the form doesn't stay empty.
+    const finalCategories: string[] = formCategories.length > 0
+      ? formCategories
+      : haveAnyIndustrySignal
+        ? ['Other']
+        : []
+
+    // otherIndustryCategory is shown whenever either list contains
+    // Other. We always write the raw description when it's available,
+    // even if the mapping managed to find a known category — so the
+    // user sees the agent's actual finding, not just a generic label.
+    const needsOtherCategoryText =
+      selectedIndustries.includes('Other') || finalCategories.includes('Other')
 
     // Use parsed CIN year as fallback for date of incorporation
     const apiDate = companyData?.dateOfIncorporation ? formatDate(companyData.dateOfIncorporation) : ''
@@ -443,8 +463,11 @@ export default function OnboardingPage() {
       phoneNumber: phoneNumber || prev.phoneNumber,
       email: companyData?.emailAddress || prev.email,
       cinNumber: companyData?.cin || formData.cinNumber,
-      industryCategories: formCategories.length > 0 ? formCategories : prev.industryCategories,
-      otherIndustryCategory: needsOtherCategoryText ? rawApiDescription : prev.otherIndustryCategory,
+      industryCategories: finalCategories.length > 0 ? finalCategories : prev.industryCategories,
+      otherIndustryCategory:
+        needsOtherCategoryText && rawApiDescription.trim()
+          ? rawApiDescription.trim()
+          : prev.otherIndustryCategory,
       // CIN API fields
       authorisedCapital: companyData?.authorisedCapital || prev.authorisedCapital,
       paidUpCapital: companyData?.paidUpCapital || prev.paidUpCapital,


### PR DESCRIPTION
…n't map industry

Before: if the Perplexity / MCA lookup returned a principalBusinessActivity but the NIC-based detection didn't map it to one of the predefined INDUSTRIES or compliance categories, the form silently left both lists empty. User had to fill those two required fields manually despite the agent having already discovered the business activity.

Now: any industry signal from the lookup (principalBusinessActivity, industrialClass, mainDivision, parsed NIC description, or the detection's industryPrimary) triggers the 'Other' fallback on both lists and writes the raw description into otherIndustryCategory. Nothing gets left blank unless the agent truly returned nothing.

applyParsedCINData now computes:
  - selectedIndustries = [matched] if known, else ['Other'] if any description exists, else []
  - finalCategories   = mapped categories if any, else ['Other'] when
    a description exists, else []
  - needsOtherCategoryText fires on either list → otherIndustryCategory
    is always populated when Other is selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced industry auto-population during onboarding to better detect industries from multiple data sources and improve handling of unknown industry types and descriptive information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->