### PR TITLE
fix(onboarding): stop redacting the create-company error to 'Somethin…

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -188,7 +188,14 @@ export async function completeOnboarding(
     balanceSheetDate: formData.balanceSheetDate || null,
   })
   } catch (createErr) {
-    return handleActionError(createErr)
+    // Re-throw so the outer try/catch (added at function top) returns
+    // the raw error message. handleActionError redacts to a generic
+    // "Something went wrong" in production, which made every company-
+    // creation failure look identical and un-diagnosable.
+    console.error('[completeOnboarding] company create failed',
+      createErr instanceof Error ? createErr.message : String(createErr),
+      createErr instanceof Error ? createErr.stack : '')
+    throw createErr
   }
 
   // 1a. Persist GSTIN registrations — one row per GSTIN, with state stamped


### PR DESCRIPTION
…g went wrong'

Previous commit added a top-level try/catch in completeOnboarding that returns {success: false, error: error.message} so the client can show a real toast. But an INNER try/catch around the company create (line 190-192) was still calling handleActionError, which redacts to "Something went wrong. Please try again." in production BEFORE the outer catch ever sees it. Client log confirmed:

  [onboarding:submit] server returned failure
    { error: "Something went wrong. Please try again.", success: false }

Fix: the inner catch now re-throws the raw error (after logging it) so the outer try/catch can extract the real message. The client will now see the actual failure reason — e.g. Prisma's "Unique constraint failed on (registration_id)" or the DB's real "null value in column ... violates not-null constraint" — instead of the redacted placeholder.

handleActionError's redaction is still used at the function boundary via the outer catch, but the outer catch just returns error.message without the "Something went wrong" fallback, so the raw reason reaches the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging in the onboarding flow to display the actual cause of company creation failures instead of generic error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->