### PR TITLE
fix(db): parse agent-sourced dates safely across all Prisma writes

### DIFF
--- a/infrastructure/persistence/prisma/PrismaCompanyRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaCompanyRepository.ts
@@ -5,29 +5,7 @@ import type {
 } from '@/application/interfaces/CompanyRepository'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
-
-/**
- * Parse date strings the Perplexity / MCA agent tends to return in a
- * mix of formats: "DD/MM/YYYY", "YYYY-MM-DD", ISO 8601, or free-form
- * garbage like "Not available". Returns a valid Date or null — never
- * an Invalid Date object (which Prisma rejects).
- */
-function parseFlexibleDate(value: string | null | undefined): Date | null {
-  if (!value) return null
-  const trimmed = String(value).trim()
-  if (!trimmed || /^(n\/?a|not available|none|unknown|-)$/i.test(trimmed)) return null
-
-  // Try DD/MM/YYYY or DD-MM-YYYY first — Indian form default
-  const dmy = trimmed.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/)
-  if (dmy) {
-    const d = new Date(Date.UTC(parseInt(dmy[3], 10), parseInt(dmy[2], 10) - 1, parseInt(dmy[1], 10)))
-    if (!isNaN(d.getTime())) return d
-  }
-
-  // Fall back to native parsing (handles ISO, YYYY-MM-DD, etc.)
-  const native = new Date(trimmed)
-  return isNaN(native.getTime()) ? null : native
-}
+import { parseFlexibleDate } from '@/lib/utils/parse-date'
 
 export class PrismaCompanyRepository implements CompanyRepository {
   async getDetailsById(companyId: string): Promise<CompanyDetailsRecord | null> {

--- a/infrastructure/persistence/prisma/PrismaDirectorRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaDirectorRepository.ts
@@ -4,6 +4,7 @@ import type {
     CreateDirectorInput,
 } from '@/application/interfaces/DirectorRepository'
 import { prisma } from '@/lib/prisma'
+import { parseFlexibleDate } from '@/lib/utils/parse-date'
 
 export class PrismaDirectorRepository implements DirectorRepository {
     async getByCompanyId(companyId: string): Promise<DirectorRecord[]> {
@@ -39,7 +40,10 @@ export class PrismaDirectorRepository implements DirectorRepository {
                 middle_name: dir.middleName || null,
                 director_id: dir.din || null,
                 designation: dir.designation || null,
-                dob: dir.dob ? new Date(dir.dob) : null,
+                // Agent-sourced DOB can be "DD/MM/YYYY", "Not Available",
+                // empty, etc. parseFlexibleDate returns null for anything
+                // unparseable instead of an Invalid Date that Prisma rejects.
+                dob: parseFlexibleDate(dir.dob),
                 tax_id: dir.pan || null,
                 email: dir.email || null,
                 mobile: dir.mobile || null,

--- a/infrastructure/persistence/prisma/PrismaDocumentRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaDocumentRepository.ts
@@ -5,6 +5,7 @@ import type {
     NewCompanyDocumentRecord,
 } from '@/application/interfaces/DocumentRepository'
 import { prisma } from '@/lib/prisma'
+import { parseFlexibleDate } from '@/lib/utils/parse-date'
 
 export class PrismaDocumentRepository implements DocumentRepository {
     async getTemplateMappings(): Promise<DocumentTemplateRecord[]> {
@@ -34,8 +35,9 @@ export class PrismaDocumentRepository implements DocumentRepository {
                         folder_id: doc.folderId ?? null,
                         file_path: doc.filePath,
                         file_name: doc.fileName,
-                        registration_date: doc.registrationDate ? new Date(doc.registrationDate) : null,
-                        expiry_date: doc.expiryDate ? new Date(doc.expiryDate) : null,
+                        // Agent-sourced dates can arrive in arbitrary formats.
+                        registration_date: parseFlexibleDate(doc.registrationDate),
+                        expiry_date: parseFlexibleDate(doc.expiryDate),
                         is_portal_required: doc.isPortalRequired,
                         portal_email: doc.portalEmail,
                         portal_password: doc.portalPassword,
@@ -43,8 +45,8 @@ export class PrismaDocumentRepository implements DocumentRepository {
                         period_type: doc.periodType,
                         period_financial_year: doc.periodFinancialYear,
                         period_key: doc.periodKey,
-                        period_start: doc.periodStart ? new Date(doc.periodStart) : null,
-                        period_end: doc.periodEnd ? new Date(doc.periodEnd) : null,
+                        period_start: parseFlexibleDate(doc.periodStart),
+                        period_end: parseFlexibleDate(doc.periodEnd),
                         requirement_id: doc.requirementId,
                     },
                 })

--- a/lib/utils/parse-date.ts
+++ b/lib/utils/parse-date.ts
@@ -1,0 +1,42 @@
+/**
+ * Parse date strings the agent / form input layer hands us in a mix
+ * of formats: "DD/MM/YYYY" (Indian default), "YYYY-MM-DD", ISO 8601,
+ * or free-form garbage like "Not available". Returns a valid Date or
+ * null — never an Invalid Date object (which Prisma rejects with
+ * "Provided Date object is invalid").
+ *
+ * Use this anywhere a user- or agent-sourced date string enters a
+ * Prisma write. Server-controlled dates (Date.now() etc.) don't need
+ * it.
+ */
+export function parseFlexibleDate(value: string | Date | null | undefined): Date | null {
+  if (!value) return null
+  if (value instanceof Date) return isNaN(value.getTime()) ? null : value
+
+  const trimmed = String(value).trim()
+  if (!trimmed) return null
+  if (/^(n\/?a|not available|none|unknown|na|-+)$/i.test(trimmed)) return null
+
+  // DD/MM/YYYY or DD-MM-YYYY (Indian default — try first)
+  const dmy = trimmed.match(/^(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})$/)
+  if (dmy) {
+    const day = parseInt(dmy[1], 10)
+    const month = parseInt(dmy[2], 10)
+    const year = parseInt(dmy[3], 10)
+    if (month >= 1 && month <= 12 && day >= 1 && day <= 31) {
+      const d = new Date(Date.UTC(year, month - 1, day))
+      if (!isNaN(d.getTime())) return d
+    }
+  }
+
+  // YYYY/MM/DD with slashes
+  const ymd = trimmed.match(/^(\d{4})[\/\-](\d{1,2})[\/\-](\d{1,2})$/)
+  if (ymd) {
+    const d = new Date(Date.UTC(parseInt(ymd[1], 10), parseInt(ymd[2], 10) - 1, parseInt(ymd[3], 10)))
+    if (!isNaN(d.getTime())) return d
+  }
+
+  // Native parse for ISO and friends
+  const native = new Date(trimmed)
+  return isNaN(native.getTime()) ? null : native
+}


### PR DESCRIPTION
## Summary
- Lift `parseFlexibleDate` into `lib/utils/parse-date.ts` and apply it everywhere agent/Perplexity-sourced date strings hit Prisma writes
- Covers Company (incorporation/AGM/balance-sheet), Director (DOB), and CompanyDocument (registration/expiry/period start+end)
- Returns `null` for "Not available", `"DD/MM/YYYY"` parses correctly (Indian default), avoids the `Invalid Date` Prisma rejection that was crashing company creation

## Test plan
- [x] Onboarding with Perplexity-fetched company (DD/MM/YYYY incorporation date) completes without "Provided Date object is invalid"
- [x] Director rows with "Not Available" DOB persist as null instead of failing the createMany
- [ ] Document upload with agent-extracted registration/expiry dates persists cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved date input validation and parsing across company, director, and document records
  * Enhanced support for multiple date formats (DD/MM/YYYY, YYYY/MM/DD, ISO formats)
  * Invalid or unparseable dates now safely return null instead of causing errors

<!-- end of auto-generated comment: release notes by coderabbit.ai -->