### PR TITLE
fix(tracker): real timeout + intake refresh event; ux(cia): chat fullscreen

### DIFF
--- a/app/data-room/components/cia/CIAChatPanel.tsx
+++ b/app/data-room/components/cia/CIAChatPanel.tsx
@@ -22,6 +22,7 @@ export default function CIAChatPanel({ companyId, isOpen, onClose, suggestedQues
   const [streamingContent, setStreamingContent] = useState('')
   const [pendingSources, setPendingSources] = useState<Source[]>([])
   const [uploadOpen, setUploadOpen] = useState(false)
+  const [isFullscreen, setIsFullscreen] = useState(false)
   const contentAccumulator = useRef('')
 
   // Refs mirror the active conversation + its assistant message ID so the
@@ -136,9 +137,11 @@ export default function CIAChatPanel({ companyId, isOpen, onClose, suggestedQues
 
       {/* Panel */}
       <div
-        className={`fixed inset-y-0 right-0 w-full sm:w-[520px] z-50 flex transform transition-transform duration-300 ease-out ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
-        }`}
+        className={`fixed z-50 flex transform transition-all duration-300 ease-out ${
+          isFullscreen
+            ? 'inset-0 w-full'
+            : 'inset-y-0 right-0 w-full sm:w-[520px]'
+        } ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
         <div className="flex-1 flex flex-col bg-[#0c111b] border-l border-white/10 shadow-2xl">
           {/* Header */}
@@ -158,14 +161,33 @@ export default function CIAChatPanel({ companyId, isOpen, onClose, suggestedQues
                 <p className="text-[10px] text-gray-500">CIA Agent</p>
               </div>
             </div>
-            <button
-              onClick={onClose}
-              className="w-7 h-7 rounded-md hover:bg-white/10 flex items-center justify-center text-gray-400 hover:text-white transition-colors"
-            >
-              <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-                <path d="M3 3l8 8M11 3l-8 8" />
-              </svg>
-            </button>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => setIsFullscreen(v => !v)}
+                title={isFullscreen ? 'Collapse to side panel' : 'Expand to fullscreen'}
+                aria-label={isFullscreen ? 'Collapse chat' : 'Expand chat'}
+                className="w-7 h-7 rounded-md hover:bg-white/10 flex items-center justify-center text-gray-400 hover:text-white transition-colors"
+              >
+                {isFullscreen ? (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M9 5h-4v-4M5 9h4v4M9 5l4-4M5 9l-4 4" />
+                  </svg>
+                ) : (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M9 1h4v4M5 13H1V9M13 1L9 5M1 13l4-4" />
+                  </svg>
+                )}
+              </button>
+              <button
+                onClick={onClose}
+                aria-label="Close chat"
+                className="w-7 h-7 rounded-md hover:bg-white/10 flex items-center justify-center text-gray-400 hover:text-white transition-colors"
+              >
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
+                  <path d="M3 3l8 8M11 3l-8 8" />
+                </svg>
+              </button>
+            </div>
           </div>
 
           {/* Body: sidebar + main */}

--- a/app/data-room/components/tracker/ComplianceIntakeForm.tsx
+++ b/app/data-room/components/tracker/ComplianceIntakeForm.tsx
@@ -131,6 +131,15 @@ export default function ComplianceIntakeForm({ companyId, financialYear, onCompl
       }
       console.log('[IntakeForm] save ok', { factIds: res.factIds })
 
+      // Dispatch a global event so any other panel/component watching
+      // for facts (TrackerEvaluationPanel, CIP's needsIntake gate, etc.)
+      // refreshes immediately. Without this, a panel that loaded BEFORE
+      // the user completed intake would keep its stale "needsIntake=true"
+      // state until its own re-mount or its own deps changed.
+      if (typeof window !== 'undefined') {
+        window.dispatchEvent(new CustomEvent('cia:data-changed'))
+      }
+
       showToast('Business details saved — evaluating compliances...', 'success')
       onComplete()
     } catch (err) {

--- a/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
+++ b/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
@@ -81,14 +81,35 @@ export default function ComplianceIntelligencePanel({
       const fyEnd = `${fyEndYear}-03-31`
       const res = await listFacts(companyId, fyStart, fyEnd)
       const userDeclared = (res.facts || []).filter(f => f.sourceKind === 'user_declared').length
-      setNeedsIntake(userDeclared === 0)
+      const next = userDeclared === 0
+      console.log('[CIP:refreshIntakeStatus]', {
+        companyId,
+        financialYear,
+        userDeclaredCount: userDeclared,
+        needsIntake: next,
+        sample: (res.facts || []).slice(0, 3).map(f => ({ kind: f.kind, source: f.sourceKind })),
+      })
+      setNeedsIntake(next)
     } catch (err) {
-      console.warn('[CIP] intake status check failed', err instanceof Error ? err.message : err)
+      console.warn('[CIP:refreshIntakeStatus] threw', err instanceof Error ? err.message : err)
       setNeedsIntake(false) // fail open — don't block Generate on a status-check error
     }
   }, [companyId, financialYear])
   useEffect(() => {
     refreshIntakeStatus()
+  }, [refreshIntakeStatus])
+
+  // Re-check intake status whenever facts change anywhere in the app
+  // (intake form save, evaluator run, agent mutation). Without this,
+  // a stale needsIntake=true could survive after the user completed
+  // intake — leading to "still asking for intake form after saving".
+  useEffect(() => {
+    const handler = () => {
+      console.log('[CIP] cia:data-changed received — refreshing intake status')
+      refreshIntakeStatus()
+    }
+    window.addEventListener('cia:data-changed', handler)
+    return () => window.removeEventListener('cia:data-changed', handler)
   }, [refreshIntakeStatus])
   const [requirements, setRequirements] = useState<AIRequirementForReview[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -136,31 +157,22 @@ export default function ComplianceIntelligencePanel({
     setViewState('generating')
     setError(null)
 
-    // Hard client-side bail-out. The server action can hit Vercel's
-    // ~60s function timeout when AI validation is slow, and the
-    // resulting promise can hang or throw a network error that the
-    // caller used to swallow — leaving the UI stuck on the generating
-    // spinner forever (until the user refreshed).
-    let timedOut = false
-    const timeoutHandle = setTimeout(() => {
-      timedOut = true
-    }, 90_000)
+    // Hard client-side bail-out via Promise.race. The previous
+    // implementation flipped a `timedOut` boolean but kept awaiting
+    // the same hung promise — useless, the UI stayed stuck on the
+    // spinner. With Promise.race, whichever resolves first wins; if
+    // the timeout fires we throw and land in the catch block.
+    const TIMEOUT_MS = 90_000
+    const timeoutSignal = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('CIP_GENERATE_TIMEOUT')), TIMEOUT_MS)
+    )
 
     try {
       console.log('[CIP:handleGenerate] starting', { companyId })
-      const result = await generateComplianceForCompany(companyId)
-      clearTimeout(timeoutHandle)
-      if (timedOut) {
-        // Server may have completed but we already timed out the UI;
-        // recover by checking whether requirements actually landed.
-        const reviewResult = await getAIRequirementsPendingReview(companyId)
-        if (reviewResult.success) {
-          onRequirementsApproved()
-          setViewState('idle')
-          return
-        }
-        throw new Error('Generation timed out after 90s')
-      }
+      const result = await Promise.race([
+        generateComplianceForCompany(companyId),
+        timeoutSignal,
+      ])
 
       if (!result.success) {
         console.error('[CIP:handleGenerate] server returned failure', result.error)
@@ -204,19 +216,35 @@ export default function ComplianceIntelligencePanel({
         }
       }
     } catch (err) {
-      clearTimeout(timeoutHandle)
+      const isTimeout = err instanceof Error && err.message === 'CIP_GENERATE_TIMEOUT'
       console.error('[CIP:handleGenerate] threw',
         err instanceof Error ? err.message : String(err),
         err instanceof Error ? err.stack : '')
-      // Even on failure, the server may have written some requirements.
-      // Refresh the tracker so the user sees what landed instead of a
-      // blank "Generation failed" page that contradicts reality.
+
+      // Even on timeout / failure, the server may have written some
+      // requirements before the client gave up. Refresh the tracker
+      // so the user sees what landed instead of a blank "Generation
+      // failed" page that contradicts reality. Then explicitly check
+      // the AI review queue too — if those landed, jump straight to
+      // the review state.
       try {
         onRequirementsApproved()
       } catch {}
+
+      if (isTimeout) {
+        try {
+          const reviewResult = await getAIRequirementsPendingReview(companyId)
+          if (reviewResult.success && reviewResult.requirements && reviewResult.requirements.length > 0) {
+            setRequirements(reviewResult.requirements)
+            setViewState('reviewing')
+            return
+          }
+        } catch {}
+      }
+
       const msg = err instanceof Error ? err.message : 'Generation failed'
-      setError(timedOut
-        ? 'Generation took longer than expected. Some compliances may have been saved — please refresh to see them, or click Re-evaluate to try again.'
+      setError(isTimeout
+        ? 'Generation took longer than expected (90s+). Any compliances that did land are now visible in the tracker below — click Re-evaluate to retry.'
         : msg)
       setViewState('error')
     }


### PR DESCRIPTION
## Summary

Three reported issues:

1. **Compliance generation spinner runs forever.** The 90s "timeout" in PR #39 only set a `timedOut` boolean and kept awaiting the same hung server-action promise — so the UI never recovered. Replaced with `Promise.race(generateComplianceForCompany, 90s timeoutSignal)` so the await actually unblocks. On timeout we still try the AI review queue and surface anything that did land instead of a blank error.

2. **Intake form re-prompts after save.** `needsIntake` was checked once on mount in `ComplianceIntelligencePanel`; after the user filled the intake, the panel kept its stale `needsIntake = true`. Fix: intake form dispatches a `cia:data-changed` window event after a successful save; CIP listens for it and re-runs `refreshIntakeStatus`. Added structured logging on both sides so the next regression is one log line away from a root cause.

3. **CIA chat panel fullscreen toggle.** New expand/collapse button in the chat header — toggles between the existing 520px slide-in and a full-viewport (`inset-0 w-full`) layout. Icon flips between the two states.

## Files

- `app/data-room/components/tracker/ComplianceIntelligencePanel.tsx` — Promise.race timeout + cia:data-changed listener + intake-status logging
- `app/data-room/components/tracker/ComplianceIntakeForm.tsx` — dispatch cia:data-changed after save
- `app/data-room/components/cia/CIAChatPanel.tsx` — fullscreen state + toggle button + conditional className

## Test plan

- [ ] Fresh company → tracker tab → Generate compliance — if it hangs past 90s, error surfaces with whatever did land (no infinite spinner)
- [ ] Fresh company → tracker tab → fill intake form → Save → CIP no longer asks for intake again, jumps straight to evaluation
- [ ] Open CIA chat → click expand icon → panel fills viewport; click again → collapses back to 520px
- [ ] Existing chat behaviour (open/close, suggestions, streaming) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)