### PR TITLE
fix(tracker): real generate timeout + intake refresh race + banner flicker + onboarding↔intake sync

### DIFF
--- a/app/data-room/components/tracker/ComplianceIntakeForm.tsx
+++ b/app/data-room/components/tracker/ComplianceIntakeForm.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { showToast } from '@/components/ui/Toast'
-import { recordUserFacts } from '../../actions-facts'
+import { listFacts, recordUserFacts } from '../../actions-facts'
 
 /**
  * Quick intake form that collects the key operational facts BEFORE
@@ -60,6 +60,72 @@ const INITIAL: IntakeData = {
 export default function ComplianceIntakeForm({ companyId, financialYear, onComplete }: Props) {
   const [data, setData] = useState<IntakeData>(INITIAL)
   const [saving, setSaving] = useState(false)
+  const [hydrating, setHydrating] = useState(true)
+
+  // Pre-populate from facts already recorded by onboarding (recordOnboardingFacts)
+  // or a previous intake save. Without this, even users who answered
+  // these questions in onboarding see a blank intake form and have to
+  // retype turnover, employees, GST, MSME, imports/exports, etc.
+  // Mapping fact.kind → IntakeData field, kept conservative (only the
+  // overlap between onboarding and intake is hydrated).
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      if (!financialYear) {
+        setHydrating(false)
+        return
+      }
+      try {
+        const fyStart = `${financialYear.slice(0, 4)}-04-01`
+        const fyEndYear = parseInt(financialYear.slice(0, 4), 10) + 1
+        const fyEnd = `${fyEndYear}-03-31`
+        const res = await listFacts(companyId, fyStart, fyEnd)
+        if (cancelled) return
+        const facts = (res.facts || []).filter(f => f.sourceKind === 'user_declared')
+        if (facts.length === 0) {
+          setHydrating(false)
+          return
+        }
+        const byKind = new Map(facts.map(f => [f.kind, f]))
+        const next: IntakeData = { ...INITIAL }
+        const headcount = byKind.get('headcount.total')
+        if (headcount?.amount != null) next.employeeCount = String(headcount.amount)
+        const turnover = byKind.get('turnover.annual')
+        if (turnover?.amount != null) next.annualTurnover = String(turnover.amount)
+        const rent = byKind.get('rent.monthly_payment')
+        if (rent?.amount != null) {
+          next.paysRent = rent.amount > 0
+          if (rent.amount > 0) next.monthlyRentAmount = String(rent.amount)
+        }
+        const contractor = byKind.get('contractor.annual_spend')
+        if (contractor?.amount != null) {
+          next.hiresContractors = contractor.amount > 0
+          if (contractor.amount > 0) next.largestContractorPayment = String(contractor.amount)
+        }
+        const profFee = byKind.get('professional_fee.annual_spend')
+        if (profFee?.amount != null) {
+          next.paysProfessionalFees = profFee.amount > 0
+          if (profFee.amount > 0) next.largestProfFeePayment = String(profFee.amount)
+        }
+        const director = byKind.get('director.remuneration')
+        if (director?.amount != null) {
+          next.paysDirectorRemuneration = director.amount > 0
+          if (director.amount > 0) next.directorRemunerationAmount = String(director.amount)
+        }
+        console.log('[IntakeForm:hydrate]', {
+          companyId,
+          financialYear,
+          hydratedFromKinds: Array.from(byKind.keys()),
+        })
+        setData(next)
+      } catch (err) {
+        console.warn('[IntakeForm:hydrate] threw', err instanceof Error ? err.message : err)
+      } finally {
+        if (!cancelled) setHydrating(false)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [companyId, financialYear])
 
   const set = <K extends keyof IntakeData>(key: K, value: IntakeData[K]) =>
     setData(prev => ({ ...prev, [key]: value }))
@@ -152,12 +218,33 @@ export default function ComplianceIntakeForm({ companyId, financialYear, onCompl
     setSaving(false)
   }
 
+  if (hydrating) {
+    return (
+      <div className="max-w-2xl mx-auto p-6">
+        <div className="flex items-center gap-3 text-sm text-gray-400">
+          <div className="w-4 h-4 border-2 border-gray-600 border-t-white rounded-full animate-spin" />
+          Loading what you've already told us…
+        </div>
+      </div>
+    )
+  }
+
+  const hasPrefill =
+    data.employeeCount !== '' ||
+    data.annualTurnover !== '' ||
+    data.paysRent !== null ||
+    data.hiresContractors !== null ||
+    data.paysProfessionalFees !== null ||
+    data.paysDirectorRemuneration !== null
+
   return (
     <div className="max-w-2xl mx-auto p-6">
       <div className="mb-6">
         <h3 className="text-xl font-light text-white">Tell us about your business</h3>
         <p className="text-sm text-gray-400 mt-1">
-          We need a few details to show only the compliances that apply to you. Takes 2 minutes.
+          {hasPrefill
+            ? 'We pre-filled what you already shared during onboarding — confirm or update below.'
+            : 'We need a few details to show only the compliances that apply to you. Takes 2 minutes.'}
         </p>
       </div>
 

--- a/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
+++ b/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
@@ -75,11 +75,22 @@ export default function ComplianceIntelligencePanel({
       setNeedsIntake(false)
       return
     }
+    // Client-side timeout. Without this, a hung listFacts call would
+    // leave needsIntake = null forever, leaving the user staring at the
+    // "Checking your business profile…" placeholder spinner — which is
+    // exactly the "infinite loop" the user reported, just upstream of
+    // Generate.
+    const timeoutSignal = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('LIST_FACTS_TIMEOUT')), 8_000),
+    )
     try {
       const fyStart = `${financialYear.slice(0, 4)}-04-01`
       const fyEndYear = parseInt(financialYear.slice(0, 4), 10) + 1
       const fyEnd = `${fyEndYear}-03-31`
-      const res = await listFacts(companyId, fyStart, fyEnd)
+      const res = await Promise.race([
+        listFacts(companyId, fyStart, fyEnd),
+        timeoutSignal,
+      ])
       const userDeclared = (res.facts || []).filter(f => f.sourceKind === 'user_declared').length
       const next = userDeclared === 0
       console.log('[CIP:refreshIntakeStatus]', {
@@ -221,32 +232,41 @@ export default function ComplianceIntelligencePanel({
         err instanceof Error ? err.message : String(err),
         err instanceof Error ? err.stack : '')
 
-      // Even on timeout / failure, the server may have written some
-      // requirements before the client gave up. Refresh the tracker
-      // so the user sees what landed instead of a blank "Generation
-      // failed" page that contradicts reality. Then explicitly check
-      // the AI review queue too — if those landed, jump straight to
-      // the review state.
+      // CRITICAL: leave the spinner state IMMEDIATELY before any further
+      // async work. The previous version awaited getAIRequirementsPendingReview
+      // here without a timeout — when that second server call also stalled
+      // on a Vercel cold start, viewState stayed 'generating' and the
+      // spinner ran forever. That's the real "infinite loop" the user
+      // saw: not the original Promise.race, but the second hidden await.
+      const msg = err instanceof Error ? err.message : 'Generation failed'
+      setError(isTimeout
+        ? 'Generation took longer than expected (90s+). Any compliances that did land are now visible in the tracker below — click Re-evaluate to retry.'
+        : msg)
+      setViewState('error')
+
+      // Best-effort recovery — refresh the tracker (cheap, fire-and-forget)
+      // and probe the AI review queue (with its own timeout). Both run
+      // AFTER the spinner has been torn down, so a hang here is invisible
+      // to the user.
       try {
         onRequirementsApproved()
       } catch {}
 
       if (isTimeout) {
         try {
-          const reviewResult = await getAIRequirementsPendingReview(companyId)
+          const probeTimeout = new Promise<never>((_, reject) =>
+            setTimeout(() => reject(new Error('REVIEW_PROBE_TIMEOUT')), 8_000),
+          )
+          const reviewResult = await Promise.race([
+            getAIRequirementsPendingReview(companyId),
+            probeTimeout,
+          ])
           if (reviewResult.success && reviewResult.requirements && reviewResult.requirements.length > 0) {
             setRequirements(reviewResult.requirements)
             setViewState('reviewing')
-            return
           }
         } catch {}
       }
-
-      const msg = err instanceof Error ? err.message : 'Generation failed'
-      setError(isTimeout
-        ? 'Generation took longer than expected (90s+). Any compliances that did land are now visible in the tracker below — click Re-evaluate to retry.'
-        : msg)
-      setViewState('error')
     }
   }, [companyId, onRequirementsApproved])
 
@@ -421,9 +441,19 @@ export default function ComplianceIntelligencePanel({
         <ComplianceIntakeForm
           companyId={companyId}
           financialYear={financialYear}
-          onComplete={async () => {
-            await refreshIntakeStatus()
+          onComplete={() => {
+            // Optimistic — the intake form only calls onComplete on a
+            // SUCCESSFUL save (it surfaces errors itself and bails out).
+            // So we know facts are written. Setting needsIntake=false
+            // here avoids the read-after-write race where listFacts on
+            // PgBouncer transaction mode lands on a connection that
+            // hasn't seen the just-written rows yet — that race was
+            // exactly what re-prompted the intake form after save.
+            setNeedsIntake(false)
             setViewState('idle')
+            // Belt-and-suspenders: still refresh in the background so a
+            // partial write or external mutation gets reconciled.
+            void refreshIntakeStatus()
             // Trigger generate immediately so the user doesn't have
             // to click another button after completing intake.
             handleGenerate()

--- a/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
+++ b/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
@@ -149,6 +149,14 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
   const pendingCount = reviewItems.length
   const hasAnything = pendingCount > 0
 
+  // While the first load() is in flight we render nothing. The previous
+  // version showed the optimistic "up to date" strip here — which then
+  // flickered to a different banner once load() resolved (~3-5s on cold
+  // start), or vanished entirely if needsIntake came back true. That's
+  // the "old banner, then flickers to new banner card" the user reported.
+  // Single source of truth: render only after we KNOW the state.
+  if (loading) return null
+
   // If intake is required, hide this panel entirely. CIP is showing
   // its own intake CTA; surfacing a second strip here just adds noise.
   if (needsIntake) return null

--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -265,7 +265,13 @@ export async function completeOnboarding(
       isStartupDpiit: formData.isStartupDpiit ?? null,
     })
   } catch (factErr) {
-    console.error('[onboarding] Fact ingestion failed (non-fatal):', factErr instanceof Error ? factErr.message : factErr)
+    // Non-fatal but loud: a silent swallow here is exactly what made
+    // intake re-prompt for users who DID fill onboarding — facts never
+    // landed and refreshIntakeStatus correctly reported needsIntake=true.
+    // Log full stack so the failure mode is debuggable next time.
+    console.error('[onboarding] recordOnboardingFacts failed (non-fatal, but intake will re-prompt):',
+      factErr instanceof Error ? factErr.message : factErr,
+      factErr instanceof Error ? factErr.stack : '')
   }
 
   // 2. Insert Directors


### PR DESCRIPTION
Four bugs the user reported, all rooted in different parts of the same flow.

## 1. "Generate" runs forever (the actual hang the previous fix didn't catch)

Promise.race at the top of \`handleGenerate\` was correct — it does abort the await. The bug was in the **catch block**:

\`\`\`tsx
} catch (err) {
  // ...
  if (isTimeout) {
    const reviewResult = await getAIRequirementsPendingReview(companyId)  // ← unbounded
    // ...
  }
  setViewState('error')  // ← only reached AFTER the unbounded await
}
\`\`\`

When the timeout fired, the catch block tried to recover by probing the AI review queue. That second server call has no timeout, and on a Vercel cold start it would also stall. Result: \`viewState\` stayed \`'generating'\`, the spinner ran indefinitely.

**Fix:** tear down the spinner state FIRST, then run recovery, with its own 8s Promise.race.

## 2. \`refreshIntakeStatus\` could hang \`needsIntake\` at null

The "Checking your business profile…" placeholder shows when \`needsIntake === null\`. If \`listFacts\` stalled, it stayed null forever — another infinite spinner upstream of Generate.

**Fix:** 8s client-side timeout, fail-open to \`needsIntake=false\`.

## 3. Intake form re-asks after a successful save

\`refreshIntakeStatus\` queried \`listFacts\` immediately after \`recordUserFacts\` returned. PgBouncer in transaction mode can route the next query to a connection that hasn't seen the commit yet → 0 facts → \`needsIntake=true\` → form re-shown.

**Fix:** \`onComplete\` optimistically sets \`needsIntake=false\` (intake form only calls onComplete on success). Background refresh still runs as belt-and-suspenders.

## 4. \`TrackerEvaluationPanel\` banner flickers from old to new card

Defaulted \`needsIntake=false\` and rendered the "up to date" strip on mount, then snapped to a different banner once \`load()\` resolved 3-5s later.

**Fix:** \`if (loading) return null\` at the top — render only after we know the state.

## Bonus: onboarding ↔ intake sync

\`recordOnboardingFacts\` already runs at onboarding time and writes the same fact kinds the intake form collects. Two improvements:

- **Hydrate intake form from existing facts.** A user who already answered turnover / employees / rent during onboarding now sees those answers pre-filled. Header copy adapts: "We pre-filled what you already shared during onboarding — confirm or update below."
- **Stop swallowing onboarding fact failures silently.** The previous \`catch (factErr) { console.error('non-fatal') }\` made it impossible to debug why intake kept re-prompting for users who DID complete onboarding. Now logs full stack.

## Files
- \`app/data-room/components/tracker/ComplianceIntelligencePanel.tsx\` — catch-block reorder + refreshIntakeStatus timeout + optimistic onComplete
- \`app/data-room/components/tracker/TrackerEvaluationPanel.tsx\` — \`if (loading) return null\`
- \`app/data-room/components/tracker/ComplianceIntakeForm.tsx\` — fact hydration on mount
- \`app/onboarding/actions.ts\` — loud stack on fact-ingestion failure

## Test plan
- [ ] Trigger Generate on a slow connection / cold-start company → spinner caps at 90s, recovery shows error or review queue, never sticks
- [ ] Fresh company → fill intake → Save → confirm panel does NOT re-ask (even if browser reload immediately afterward)
- [ ] Onboard a new company providing turnover / employees / rent / contractor / professional fees / director remuneration → open tracker → confirm intake form is pre-filled, NOT blank
- [ ] Open tracker on a fresh company → confirm no flash of "up to date" strip before the real banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)