### PR TITLE
fix(tracker): facts in React Query cache + AI dedup + year-stripped names

### DIFF
--- a/app/data-room/actions-intelligence.ts
+++ b/app/data-room/actions-intelligence.ts
@@ -401,14 +401,65 @@ async function bulkInsertRulesEngineResults(
 
 // ── Bulk Insert AI Requirements ────────────────────────────────────────────
 
+/**
+ * Strip year tokens (4-digit years 19xx-21xx, `FY 2024-25`, `2023-24`,
+ * trailing " — For Apr 2026" period labels, etc) from an AI-generated
+ * compliance NAME so the name itself is year-agnostic. The actual year
+ * lives in due_date / period_key / period_label — names with hard-coded
+ * years break historical generation, where the same rule needs to apply
+ * to multiple FYs.
+ */
+function stripYearFromName(name: string): string {
+  let out = name
+  // Remove " — For <Month> <Year>" trailing labels
+  out = out.replace(/\s*[—–-]\s*for\s+[A-Za-z]+\s*\d{4}\s*$/i, '')
+  // Remove standalone "FY 2024-25" / "FY2024-25" / "F.Y. 2024-25"
+  out = out.replace(/\bF\.?Y\.?\s*\d{4}\s*[-–]\s*\d{2,4}\b/gi, '')
+  // Remove "2024-25" / "2024–25" pairs
+  out = out.replace(/\b\d{4}\s*[-–]\s*\d{2,4}\b/g, '')
+  // Remove standalone 4-digit years 19xx-21xx
+  out = out.replace(/\b(19|20|21)\d{2}\b/g, '')
+  // Cleanup leftover separators / double spaces
+  out = out.replace(/\s+[—–-]\s*$/g, '')
+  out = out.replace(/\s{2,}/g, ' ').trim()
+  return out || name // fallback to original if we stripped everything
+}
+
 async function bulkInsertAIRequirements(
   companyId: string,
   requirements: GeneratedRequirement[],
   userId: string
 ): Promise<void> {
   if (requirements.length === 0) return
+
+  // Sanitize names — strip year tokens so historical generation can
+  // re-deadline the same rule for any FY without baking the wrong year
+  // into the requirement name.
+  const sanitized = requirements.map((r) => ({ ...r, requirement: stripYearFromName(r.requirement) }))
+
+  // Idempotency: prefetch existing requirement names for this company
+  // and skip any AI items that match (case-insensitive). Prevents
+  // duplicates when the user clicks Generate / Re-evaluate again.
+  const existingRows = await prisma.$queryRaw<Array<{ requirement: string }>>(
+    Prisma.sql`SELECT DISTINCT requirement FROM regulatory_requirements WHERE company_id = ${companyId}::uuid`
+  )
+  const existingNorm = new Set(
+    (existingRows || []).map((r) => r.requirement.trim().toLowerCase())
+  )
+  const fresh = sanitized.filter((r) => !existingNorm.has(r.requirement.trim().toLowerCase()))
+  if (fresh.length === 0) {
+    console.log('[bulkInsertAIRequirements] all items already exist — nothing to insert')
+    return
+  }
+  console.log('[bulkInsertAIRequirements]', {
+    received: requirements.length,
+    sanitized: sanitized.length,
+    skippedDuplicates: sanitized.length - fresh.length,
+    inserting: fresh.length,
+  })
+
   // Single multi-VALUES INSERT (same pattern as rules engine bulk insert)
-  const valuesSql = requirements.map((req) => {
+  const valuesSql = fresh.map((req) => {
     const dueDateStr = req.due_date ? req.due_date.toISOString().split('T')[0] : null
     const reqDocs = req.required_documents || []
     const reqDocsArray = `{${reqDocs.map((d: string) => `"${d.replace(/"/g, '\\"')}"`).join(',')}}`

--- a/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
+++ b/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { useState, useCallback, useEffect } from 'react'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   generateComplianceForCompany,
   validateComplianceForCompany,
@@ -13,6 +14,7 @@ import {
   type ValidateComplianceResult,
 } from '../../actions-intelligence'
 import { listFacts } from '../../actions-facts'
+import { queryKeys } from '@/lib/react-query/query-keys'
 import ComplianceIntakeForm from './ComplianceIntakeForm'
 
 interface ComplianceIntelligencePanelProps {
@@ -65,94 +67,65 @@ export default function ComplianceIntelligencePanel({
   onRequirementsApproved,
 }: ComplianceIntelligencePanelProps) {
   const [viewState, setViewState] = useState<ViewState>('idle')
-  // SINGLE SOURCE OF TRUTH for facts in this panel + the IntakeForm
-  // it owns. We fetch ONCE on mount, then mutate locally as the user
-  // saves. The IntakeForm receives this via prop and hydrates synchronously
-  // — no second listFacts call, no read-after-write race, no second
-  // timeout-recovery layer. After the user saves the intake the new
-  // facts are appended to this state directly because the client knows
-  // exactly what it just sent to the server.
+
+  // Facts state lives in the React Query cache so it survives CIP
+  // re-mounts (e.g. when Approve All triggers refreshRequirements in the
+  // parent and React conditionally re-renders this subtree). The previous
+  // useState approach lost facts on every re-mount, which made
+  // needsIntake regress to true (false STEP 1 of 2) immediately after
+  // Approve All — the bug the user reported.
   type ClientFact = { kind: string; amount: number | null; sourceKind: string }
-  const [facts, setFacts] = useState<ClientFact[] | null>(null) // null = not yet loaded
+  const queryClient = useQueryClient()
+  const factsQueryKey = queryKeys.complianceFacts(companyId, financialYear ?? null)
+  const factsQuery = useQuery<ClientFact[]>({
+    queryKey: factsQueryKey,
+    queryFn: async () => {
+      if (!financialYear) return []
+      const fyStart = `${financialYear.slice(0, 4)}-04-01`
+      const fyEndYear = parseInt(financialYear.slice(0, 4), 10) + 1
+      const fyEnd = `${fyEndYear}-03-31`
+      const res = await listFacts(companyId, fyStart, fyEnd)
+      const list: ClientFact[] = (res.facts || []).map((f) => ({
+        kind: f.kind,
+        amount: f.amount,
+        sourceKind: f.sourceKind,
+      }))
+      console.log('[CIP:loadFacts]', {
+        companyId,
+        financialYear,
+        total: list.length,
+        userDeclared: list.filter((f) => f.sourceKind === 'user_declared').length,
+      })
+      return list
+    },
+    // Once loaded, treat as fresh for 5 minutes so a CIP re-mount does
+    // not cause a re-fetch (which can race against PgBouncer transaction
+    // mode and return stale data right after a write). Mutations call
+    // queryClient.setQueryData directly when they know what was written.
+    staleTime: 5 * 60_000,
+    gcTime: 30 * 60_000,
+  })
+
+  const facts: ClientFact[] | null =
+    factsQuery.data === undefined ? (factsQuery.isError ? [] : null) : factsQuery.data
   const needsIntake: boolean | null =
     facts === null
       ? null
       : facts.filter((f) => f.sourceKind === 'user_declared').length === 0
 
-  useEffect(() => {
-    let cancelled = false
-    if (!financialYear) {
-      setFacts([])
-      return
-    }
-    ;(async () => {
-      try {
-        const fyStart = `${financialYear.slice(0, 4)}-04-01`
-        const fyEndYear = parseInt(financialYear.slice(0, 4), 10) + 1
-        const fyEnd = `${fyEndYear}-03-31`
-        const res = await listFacts(companyId, fyStart, fyEnd)
-        if (cancelled) return
-        const list: ClientFact[] = (res.facts || []).map((f) => ({
-          kind: f.kind,
-          amount: f.amount,
-          sourceKind: f.sourceKind,
-        }))
-        console.log('[CIP:loadFacts]', {
-          companyId,
-          financialYear,
-          total: list.length,
-          userDeclared: list.filter((f) => f.sourceKind === 'user_declared').length,
-        })
-        setFacts(list)
-      } catch (err) {
-        // Fail open: empty list lets the user proceed (they can still
-        // open intake and fill manually). Generation isn't blocked on
-        // a successful facts read.
-        console.warn('[CIP:loadFacts] threw', err instanceof Error ? err.message : err)
-        if (!cancelled) setFacts([])
-      }
-    })()
-    return () => { cancelled = true }
-  }, [companyId, financialYear])
-
-  // Other parts of the app (chat agent, document ingestion, evaluator)
-  // can mutate facts. When that happens we re-fetch — but only when the
-  // user is NOT mid-intake-save (handled by the local append). This
-  // listener is a fallback for external mutations only.
+  // External mutations (chat agent, document ingestion) still fire
+  // cia:data-changed. We invalidate the cache rather than manually
+  // re-fetching — React Query handles the request, dedup, and the
+  // regression-suppression we used to do by hand.
   useEffect(() => {
     if (!financialYear) return
     const handler = () => {
-      console.log('[CIP] cia:data-changed received — re-fetching facts')
-      ;(async () => {
-        try {
-          const fyStart = `${financialYear.slice(0, 4)}-04-01`
-          const fyEndYear = parseInt(financialYear.slice(0, 4), 10) + 1
-          const fyEnd = `${fyEndYear}-03-31`
-          const res = await listFacts(companyId, fyStart, fyEnd)
-          const list: ClientFact[] = (res.facts || []).map((f) => ({
-            kind: f.kind,
-            amount: f.amount,
-            sourceKind: f.sourceKind,
-          }))
-          // Suppress regressions: if we have a richer local set and the
-          // server returns fewer user-declared facts (PgBouncer race), keep ours.
-          setFacts((prev) => {
-            const prevUd = (prev || []).filter((f) => f.sourceKind === 'user_declared').length
-            const nextUd = list.filter((f) => f.sourceKind === 'user_declared').length
-            if (prev && prevUd > 0 && nextUd === 0) {
-              console.log('[CIP] cia:data-changed read returned 0 user-declared — suppressing as stale')
-              return prev
-            }
-            return list
-          })
-        } catch (err) {
-          console.warn('[CIP] cia:data-changed re-fetch threw', err instanceof Error ? err.message : err)
-        }
-      })()
+      console.log('[CIP] cia:data-changed received — invalidating facts cache')
+      queryClient.invalidateQueries({ queryKey: factsQueryKey })
     }
     window.addEventListener('cia:data-changed', handler)
     return () => window.removeEventListener('cia:data-changed', handler)
-  }, [companyId, financialYear])
+  }, [queryClient, factsQueryKey, financialYear])
   const [requirements, setRequirements] = useState<AIRequirementForReview[]>([])
   const [error, setError] = useState<string | null>(null)
   const [stats, setStats] = useState<{
@@ -446,18 +419,17 @@ export default function ComplianceIntelligencePanel({
           // race, no separate timeout to manage.
           initialFacts={facts || []}
           onComplete={(savedFacts) => {
-            // The intake form only calls onComplete on SUCCESS and
-            // hands back the exact rows it just wrote. We append them
-            // directly to our local state — no need to re-fetch from
-            // the DB and no PgBouncer race to dodge.
-            setFacts((prev) => {
+            // Write the just-saved facts straight into the React Query
+            // cache. This bypasses the read-after-write race entirely
+            // (we know what we just wrote) AND survives any subsequent
+            // CIP re-mount — the cache outlives the component instance.
+            queryClient.setQueryData<ClientFact[]>(factsQueryKey, (prev) => {
               const base = prev || []
               const next = [...base]
               const seen = new Set(base.map((f) => `${f.kind}|${f.sourceKind}`))
               for (const sf of savedFacts) {
                 const key = `${sf.kind}|${sf.sourceKind}`
                 if (seen.has(key)) {
-                  // upsert: replace existing user_declared fact of same kind
                   const idx = next.findIndex((f) => f.kind === sf.kind && f.sourceKind === sf.sourceKind)
                   if (idx >= 0) next[idx] = sf
                 } else {

--- a/lib/react-query/query-keys.ts
+++ b/lib/react-query/query-keys.ts
@@ -38,4 +38,10 @@ export const queryKeys = {
   // Compliance templates
   complianceTemplates: () => ['compliance-templates'] as const,
   complianceTemplate: (templateId: string) => ['compliance-template', templateId] as const,
+
+  // Compliance facts (per company × FY) — owned by ComplianceIntelligencePanel
+  // and read by ComplianceIntakeForm. Survives CIP re-mount so panels don't
+  // regress to "STEP 1" after Approve All / re-fetches in the parent tree.
+  complianceFacts: (companyId: string, financialYear: string | null) =>
+    ['compliance-facts', companyId, financialYear] as const,
 } as const

--- a/lib/services/compliance-intelligence.ts
+++ b/lib/services/compliance-intelligence.ts
@@ -266,7 +266,12 @@ RULES:
 - "category" must be one of: "Industry-Specific", "State Compliance", "SEBI", "Labour Law", "Renewals", "RoC", "GST", "Income Tax", "Payroll", "Others"
 - "confidenceScore" 0.0 to 1.0 — be honest, mark uncertain items 0.85-0.90
 - Include sourceUrl to the official government/authority website
-- Prioritize industry-specific and state-specific items — that's where templates have gaps`
+- Prioritize industry-specific and state-specific items — that's where templates have gaps
+- **The "name" MUST be year-agnostic.** Do NOT include "2024", "FY 2024-25", "2023-24",
+  "for April 2026", or any other year/date token in "name". The same rule applies to
+  past, present, and future financial years; the year lives in dueDate, not in the name.
+  Examples — GOOD: "TDS Payment", "GSTR-3B Monthly Return", "FSSAI Annual Return".
+  BAD: "TDS Payment 2026", "GSTR-3B for FY 2024-25", "AOC-4 Filing 2023-24".`
 }
 
 const SYSTEM_INSTRUCTIONS = `You are a senior Indian compliance expert (CA/CS qualified) specializing in industry-specific and state-specific regulations.
@@ -458,13 +463,29 @@ export async function generateComplianceIntelligence(
     const incorporationDate = profile.incorporationDate || new Date()
     const dateProfile = buildIndianFYProfile(incorporationDate)
 
+    // Strip year tokens from AI-returned names. Even with the strict
+    // prompt rule, models occasionally slip "2026" or "FY 2024-25" into
+    // the name. We dedupe at insert time on lowercased name, so a
+    // year-suffixed duplicate of an existing rule would slip through —
+    // hence the belt-and-suspenders sanitization here.
+    const stripYearFromName = (name: string): string => {
+      let out = name
+      out = out.replace(/\s*[—–-]\s*for\s+[A-Za-z]+\s*\d{4}\s*$/i, '')
+      out = out.replace(/\bF\.?Y\.?\s*\d{4}\s*[-–]\s*\d{2,4}\b/gi, '')
+      out = out.replace(/\b\d{4}\s*[-–]\s*\d{2,4}\b/g, '')
+      out = out.replace(/\b(19|20|21)\d{2}\b/g, '')
+      out = out.replace(/\s+[—–-]\s*$/g, '')
+      out = out.replace(/\s{2,}/g, ' ').trim()
+      return out || name
+    }
+
     const requirements: GeneratedRequirement[] = novel.map(item => {
       const nextDeadline = computeNextDeadline(item.dueDateFormula, dateProfile)
       const needsReview = item.confidenceScore < 0.95
 
       return {
         category: item.category,
-        requirement: item.name,
+        requirement: stripYearFromName(item.name),
         description: `${item.act} — ${item.section}. ${item.applicabilityReason}`,
         status: 'pending_review',
         due_date: nextDeadline,


### PR DESCRIPTION
Closes the three bugs uncovered in the post-PR-#52 smoke test. All root-cause fixes, no patches.

## Bug 1 — Approve All regresses CIP to "STEP 1 of 2"

**Root cause:** facts state lived in CIP's local \`useState\`. After Approve All triggered \`onRequirementsApproved → refreshRequirements\` in the parent, the resulting re-render caused CIP to lose its in-memory facts. Re-mount → fresh \`listFacts\` → PgBouncer transaction-mode race returns 0 user_declared facts → derived \`needsIntake\` flips back to true → user sees "Tell us about your business" again *right after* approving everything.

**Fix:** facts now live in React Query cache (\`queryKey: complianceFacts(companyId, fy)\`). The cache outlives individual CIP mounts. \`staleTime: 5min\` means re-mounts use the cache, not a fresh fetch. Removes the cia:data-changed regression-suppression patch entirely.

The intake form's \`onComplete\` now writes \`savedFacts\` directly into the cache via \`queryClient.setQueryData\`. No re-fetch, no race, durable across re-mounts.

## Bug 2 — Re-clicking Generate created AI duplicates

**Root cause:** \`bulkInsertRulesEngineResults\` deduped against existing requirements; \`bulkInsertAIRequirements\` did not. Each Generate/Re-evaluate appended a fresh batch.

**Fix:** prefetch SELECT distinct existing names → filter AI items by lowercased-trimmed name → only INSERT fresh ones.

## Bug 3 — Historical generation puts wrong year in compliance name

**Root cause:** Perplexity sometimes returned names with year tokens baked in ("TDS Payment 2026", "GSTR-3B for FY 2024-25"). When \`generateHistoricalCompliances\` replayed the same rule for FY 2023-24, the name still said 2026.

**Fix at the source:**
1. AI prompt now explicitly forbids year tokens in \`name\`, with concrete good/bad examples.
2. Belt-and-suspenders sanitiser strips year tokens from AI-returned names ("TDS Payment 2026" → "TDS Payment").
3. Same sanitiser applied at INSERT time as final guard.

Year now lives only in \`due_date\` / \`period_key\` / \`period_label\` — the authoritative fields.

## Files

- \`app/data-room/components/tracker/ComplianceIntelligencePanel.tsx\` — facts state moved to React Query
- \`app/data-room/actions-intelligence.ts\` — AI dedup + name sanitiser at INSERT time
- \`lib/services/compliance-intelligence.ts\` — prompt rule against year tokens + client-side sanitiser
- \`lib/react-query/query-keys.ts\` — new \`complianceFacts\` key

## Test plan (will smoke after deploy)

- [ ] Save intake → Generate → Approve All → confirm panel does NOT regress to STEP 1
- [ ] Generate twice in a row → confirm second run does NOT create duplicate AI items
- [ ] Generate historical compliances for FY 2023-24 → confirm names contain no year tokens, due_date matches the FY

🤖 Generated with [Claude Code](https://claude.com/claude-code)