### PR TITLE
fix(tracker): close the optimistic-write vs invalidate-refetch race

### DIFF
--- a/app/data-room/components/tracker/ComplianceIntakeForm.tsx
+++ b/app/data-room/components/tracker/ComplianceIntakeForm.tsx
@@ -191,15 +191,21 @@ export default function ComplianceIntakeForm({ companyId, financialYear, initial
         sourceKind: 'user_declared',
       }))
 
-      // Notify other listeners (chat, evaluator panel) that facts changed.
-      // CIP no longer relies on this for its OWN state — it gets the facts
-      // directly from onComplete — but other components still benefit.
+      // CRITICAL: call onComplete (which writes the just-saved facts
+      // straight into the React Query cache) BEFORE dispatching the
+      // global cia:data-changed event. dispatchEvent is synchronous and
+      // any listener that invalidates the same cache key would trigger
+      // a re-fetch which can race against PgBouncer transaction-mode
+      // and return 0 facts — overwriting our optimistic write. The
+      // ordering here keeps the optimistic value durable: when the
+      // re-fetch (if any) completes, it'll see the post-commit state.
+      showToast('Business details saved — evaluating compliances...', 'success')
+      onComplete(savedFacts)
+      // Notify other listeners (chat agent UI, evaluator panel) — CIP
+      // doesn't need this; it already has the data via onComplete.
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('cia:data-changed'))
       }
-
-      showToast('Business details saved — evaluating compliances...', 'success')
-      onComplete(savedFacts)
     } catch (err) {
       console.error('[IntakeForm] threw',
         err instanceof Error ? err.message : String(err),

--- a/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
+++ b/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
@@ -90,11 +90,24 @@ export default function ComplianceIntelligencePanel({
         amount: f.amount,
         sourceKind: f.sourceKind,
       }))
+      // Regression guard: if the cache currently has user_declared facts
+      // and the server returned 0, that's almost certainly a PgBouncer
+      // transaction-mode race (read landed on a connection that hasn't
+      // seen our recent commit). Keep the cached value rather than
+      // letting the stale read clobber it. Real "facts genuinely deleted"
+      // events go through explicit setQueryData, never an empty fetch.
+      const cached = queryClient.getQueryData<ClientFact[]>(factsQueryKey)
+      const cachedUd = (cached || []).filter((f) => f.sourceKind === 'user_declared').length
+      const fetchedUd = list.filter((f) => f.sourceKind === 'user_declared').length
+      if (cachedUd > 0 && fetchedUd === 0) {
+        console.log('[CIP:loadFacts] suppressing 0-user_declared fetch as stale (cache has', cachedUd, ')')
+        return cached!
+      }
       console.log('[CIP:loadFacts]', {
         companyId,
         financialYear,
         total: list.length,
-        userDeclared: list.filter((f) => f.sourceKind === 'user_declared').length,
+        userDeclared: fetchedUd,
       })
       return list
     },


### PR DESCRIPTION
Production smoke test of PR #53 caught the actual race I missed.

## What happened

\`\`\`
[IntakeForm] save ok {factIds: Array(8)}
[CIP] cia:data-changed received — invalidating facts cache
[CIP:loadFacts] {total: 0, userDeclared: 0}        ← stale read wins
[CompliancePanel] Approve all → STEP 1 of 2        ← regression
\`\`\`

\`dispatchEvent\` is synchronous — CIP's listener runs FIRST and calls \`queryClient.invalidateQueries\`, which kicks off a re-fetch in flight. \`onComplete\` then runs \`setQueryData\` with the just-saved 8 facts. The in-flight re-fetch eventually returns 0 (PgBouncer transaction-mode read-after-write race) and clobbers our optimistic value.

## Two-part fix

1. **Reorder** in IntakeForm — call \`onComplete\` (which writes to cache) BEFORE dispatching \`cia:data-changed\`. CIP doesn't need the event because it gets the data via callback; other panels still get it.

2. **Regression guard in queryFn** — if cache has user_declared facts and a fetch returns 0, suppress and keep the cached value. Real deletions go through explicit \`setQueryData\`, never an empty fetch.

## Test plan
- [ ] Save intake → Generate → Approve All → confirm panel does NOT regress to STEP 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)