### PR TITLE
fix(tracker): the actual root cause — client fyStart parsing was producing invalid Date strings

### DIFF
--- a/app/data-room/actions-facts.ts
+++ b/app/data-room/actions-facts.ts
@@ -199,3 +199,47 @@ export async function listFacts(
     return handleActionError(error)
   }
 }
+
+/**
+ * FY-aware variant of listFacts. Takes the financialYear string the
+ * UI already has (e.g. "FY 2026-27" or "2026-27") and resolves the
+ * window server-side via fyWindow — the SAME function recordUserFact
+ * and recordOnboardingFacts use to write the period_start/period_end
+ * columns. This keeps reads aligned with writes.
+ *
+ * The previous read path had each caller (CIP, IntakeForm) compute
+ * `fyStart = financialYear.slice(0, 4) + "-04-01"`. That works for
+ * "2026-27" but for "FY 2026-27" returns "FY 2-04-01" — an invalid
+ * date string. listFacts then casts it via `new Date(...)` which
+ * yields Invalid Date, and the resulting Prisma date comparison
+ * never matches anything. Result: facts existed in the DB but the
+ * UI saw 0 of them, which made the panel regress to "STEP 1 of 2"
+ * after every reload despite a successful save.
+ */
+export async function listFactsForFY(
+  companyId: string,
+  financialYear: string,
+  kinds?: string[],
+): Promise<ReturnType<typeof listFacts> extends Promise<infer R> ? R : never> {
+  try {
+    await assertCompanyAccess(companyId)
+    const { periodStart, periodEnd } = fyWindow(financialYear)
+    const rows = await getFactsForPeriod({ companyId, periodStart, periodEnd, kinds })
+    return {
+      success: true,
+      facts: rows.map((r) => ({
+        id: r.id,
+        kind: r.kind,
+        amount: r.amount ? Number(r.amount) : null,
+        unit: r.unit,
+        periodStart: r.period_start.toISOString().slice(0, 10),
+        periodEnd: r.period_end.toISOString().slice(0, 10),
+        counterparty: r.counterparty,
+        sourceKind: r.source_kind,
+        confidence: r.confidence,
+      })),
+    }
+  } catch (error) {
+    return handleActionError(error)
+  }
+}

--- a/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
+++ b/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
@@ -13,7 +13,7 @@ import {
   type AIRequirementForReview,
   type ValidateComplianceResult,
 } from '../../actions-intelligence'
-import { listFacts } from '../../actions-facts'
+import { listFactsForFY } from '../../actions-facts'
 import { queryKeys } from '@/lib/react-query/query-keys'
 import ComplianceIntakeForm from './ComplianceIntakeForm'
 
@@ -81,10 +81,15 @@ export default function ComplianceIntelligencePanel({
     queryKey: factsQueryKey,
     queryFn: async () => {
       if (!financialYear) return []
-      const fyStart = `${financialYear.slice(0, 4)}-04-01`
-      const fyEndYear = parseInt(financialYear.slice(0, 4), 10) + 1
-      const fyEnd = `${fyEndYear}-03-31`
-      const res = await listFacts(companyId, fyStart, fyEnd)
+      // Use the FY-aware server action — it parses the financialYear
+      // string with the same regex fyWindow() uses on the write path.
+      // The previous client-side `slice(0, 4)` parsing returned "FY 2"
+      // for "FY 2026-27" and produced Invalid Date strings that never
+      // matched anything in the DB.
+      const res = await listFactsForFY(companyId, financialYear)
+      if (!res.success) {
+        console.warn('[CIP:loadFacts] server returned error:', res.error)
+      }
       const list: ClientFact[] = (res.facts || []).map((f) => ({
         kind: f.kind,
         amount: f.amount,

--- a/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
+++ b/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { runApplicabilityEvaluation, listAssessments, overrideAssessment } from '../../actions-evaluator'
-import { listFacts, recordUserFact } from '../../actions-facts'
+import { listFactsForFY, recordUserFact } from '../../actions-facts'
 import { showToast } from '@/components/ui/Toast'
 import {
   TRIGGER_QUESTIONS,
@@ -67,10 +67,10 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
       // the intake even though their data was already saved. Now we
       // treat ANY user_declared fact for this FY as proof the intake
       // has been done at least once.
-      const fyStart = `${financialYear.slice(0, 4)}-04-01`
-      const fyEndYear = parseInt(financialYear.slice(0, 4), 10) + 1
-      const fyEnd = `${fyEndYear}-03-31`
-      const factsRes = await listFacts(companyId, fyStart, fyEnd)
+      // Use the FY-aware variant — `financialYear` is "FY 2026-27" not
+      // "2026-27", so client-side `slice(0, 4)` parsing produces invalid
+      // date strings that match nothing.
+      const factsRes = await listFactsForFY(companyId, financialYear)
       const allFacts = factsRes.facts || []
       const userDeclaredCount = allFacts.filter(f => f.sourceKind === 'user_declared').length
       setNeedsIntake(userDeclaredCount === 0)


### PR DESCRIPTION
**The actual bug.** Every previous PR (#50–#54) was patching symptoms downstream of this.

\`selectedTrackerFY\` is \`"FY 2026-27"\` (with the "FY " prefix). Client-side parsing did:

\`\`\`ts
const fyStart = \`\${financialYear.slice(0, 4)}-04-01\`
// "FY 2026-27".slice(0, 4) === "FY 2"  →  fyStart = "FY 2-04-01"
// parseInt("FY 2", 10) === NaN          →  fyEnd  = "NaN-03-31"
\`\`\`

Bogus strings → server's \`new Date(...)\` → Invalid Date → Prisma matched zero rows. Direct verification: ran \`getFactsForPeriod\` with \`new Date('2026-04-01')\` against the production DB → returned 10 facts. The DB always had the data; the read query was malformed.

The regex-based \`fyWindow()\` used by \`recordUserFact\` / \`recordOnboardingFacts\` on the write path correctly parsed "FY 2026-27" — which is why writes always worked. Reads just used the wrong parser.

## Fix

New server action \`listFactsForFY(companyId, financialYear)\` resolves the period window via \`fyWindow()\` — same function the write path uses. CIP and TrackerEvaluationPanel switched to it. **Reads now align with writes.**

Once deployed, the entire chain of regression-suppression patches (React Query cache, optimistic pin, queryFn guard) becomes belt-and-suspenders rather than load-bearing — they were all working around symptoms of this bug.

## Test plan
- [ ] Hard reload TRILLION tracker after intake save → confirm panel shows "UP TO DATE" / Re-evaluate, NOT STEP 1
- [ ] [CIP:loadFacts] log should show \`total: 10, userDeclared: 8\` (or whatever count is in DB)
- [ ] IntakeForm opened on a company with onboarding-recorded facts → fields prefill correctly with the new header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Introduced a new server operation for retrieving financial facts by financial year. Updated compliance tracking and evaluation components to use this operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->