### PR TITLE
fix(tracker): historical-gen name correctness + 'FY FY' display + Generating... timeout

### DIFF
--- a/app/data-room/actions-intelligence.ts
+++ b/app/data-room/actions-intelligence.ts
@@ -767,9 +767,12 @@ export async function generateHistoricalCompliances(
     // Never go before incorporation
     const effectiveStart = startDate < incorpDate ? incorpDate : startDate
 
-    // Get all existing distinct requirements with their formulas
+    // Get existing recurring requirements with their formulas. We dedupe
+    // by (base_name, due_date_formula) below — the DB has many rows per
+    // base rule (one per period: "TDS Payment — Monthly — For Apr 2026",
+    // "— For May 2026", etc.) and we want ONE source per logical rule.
     const existingRules = await prisma.$queryRaw<any[]>(
-      Prisma.sql`SELECT DISTINCT ON (requirement)
+      Prisma.sql`SELECT
         requirement, category, description, penalty, is_critical,
         compliance_type, year_type, country_code, required_documents,
         source, confidence_score, needs_ca_review, source_url,
@@ -778,18 +781,44 @@ export async function generateHistoricalCompliances(
       WHERE company_id = ${companyId}::uuid
         AND due_date_formula IS NOT NULL
         AND compliance_type IN ('monthly', 'quarterly', 'half-yearly', 'annual')
-      ORDER BY requirement, created_at DESC`
+      ORDER BY created_at DESC`
     )
 
     if (!existingRules || existingRules.length === 0) {
       return { success: false, error: 'No recurring requirements found. Generate compliances first.' }
     }
 
+    // Strip the period suffix that the rules engine appends so we can
+    // (a) dedupe to one source row per base rule, and (b) rebuild the
+    // requirement name with the HISTORICAL period_label rather than
+    // copying the source row's (current-FY) period verbatim. Without
+    // this, historical entries inherited names like "ESI — For Dec 2026"
+    // even though their due_date was Jul 2025.
+    const stripPeriodSuffix = (name: string): string =>
+      name
+        .replace(/\s*[—–-]\s*(For\s+[A-Za-z]+\s*\d{2,4}|Q[1-4][^\n]*?\d{2,4}|H[12][^\n]*?\d{2,4})\s*$/i, '')
+        .replace(/\s*[—–-]\s*(Annual|Quarterly|Monthly|Half-Yearly|Half-yearly)?\s*[—–-]\s*For\s+[A-Za-z]+\s*\d{2,4}\s*$/i, '')
+        .trim()
+
+    type RuleSource = (typeof existingRules)[number] & { baseName: string }
+    const uniqueRulesByKey = new Map<string, RuleSource>()
+    for (const r of existingRules as any[]) {
+      const baseName = stripPeriodSuffix(String(r.requirement || ''))
+      const key = `${baseName}|${r.due_date_formula}`
+      if (!uniqueRulesByKey.has(key)) {
+        uniqueRulesByKey.set(key, { ...r, baseName })
+      }
+    }
+    console.log('[generateHistoricalCompliances] dedupe', {
+      sourceRows: existingRules.length,
+      uniqueBaseRules: uniqueRulesByKey.size,
+      yearsBack: actualYearsBack,
+    })
+
     const fyProfile = buildIndianFYProfile(incorpDate)
     let totalGenerated = 0
 
-    // Sequential inserts (no interactive transaction — compatible with PgBouncer)
-    for (const rule of existingRules) {
+    for (const rule of Array.from(uniqueRulesByKey.values())) {
       if (!rule.due_date_formula) continue
 
       const monthsBack = actualYearsBack * 12
@@ -806,6 +835,8 @@ export async function generateHistoricalCompliances(
         const dueDate = dl.date.toISOString().split('T')[0]
         const periodKey = dl.period || null
         const periodLabel = dl.label || null
+        // Rebuild the requirement name with THIS period's label.
+        const reqName = periodLabel ? `${rule.baseName} — ${periodLabel}` : rule.baseName
         const reqDocs = Array.isArray(rule.required_documents) ? rule.required_documents : []
         const reqDocsArray = `{${reqDocs.map((d: string) => `"${d.replace(/"/g, '\\"')}"`).join(',')}}`
 
@@ -821,7 +852,7 @@ export async function generateHistoricalCompliances(
               period_key, period_label,
               app_created_by, app_updated_by, created_at, updated_at
             ) VALUES (
-              ${companyId}::uuid, ${rule.category}::text, ${rule.requirement}::text,
+              ${companyId}::uuid, ${rule.category}::text, ${reqName}::text,
               ${rule.description || null}::text, 'overdue'::text, ${dueDate}::date,
               ${rule.penalty || null}::text, ${rule.is_critical || false}::boolean,
               ${rule.compliance_type || null}::text, ${rule.year_type || 'FY'}::text,

--- a/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
+++ b/app/data-room/components/tracker/ComplianceIntelligencePanel.tsx
@@ -330,22 +330,47 @@ export default function ComplianceIntelligencePanel({
     setShowHistorySelector(false)
     setHistoryResult(null)
 
-    const result = await generateHistoricalCompliances(companyId, years)
+    // Hard client-side bail-out so the "Generating..." button can't be
+    // stuck forever if the server hangs. Mirror the same Promise.race
+    // pattern handleGenerate uses; on cap, refresh the tracker so the
+    // user sees whatever historical entries DID land.
+    const TIMEOUT_MS = 120_000
+    const timeoutSignal = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error('HISTORICAL_GEN_TIMEOUT')), TIMEOUT_MS)
+    )
 
-    if (result.success) {
-      setHistoryResult({
-        generated: result.generated || 0,
-        yearsBack: result.yearsBack || years,
-        capped: result.cappedAtIncorporation || false,
-      })
-      if ((result.generated || 0) > 0) {
-        onRequirementsApproved()
+    try {
+      console.log('[CIP:handleGenerateHistory] starting', { companyId, years })
+      const result = await Promise.race([
+        generateHistoricalCompliances(companyId, years),
+        timeoutSignal,
+      ])
+
+      if (result.success) {
+        setHistoryResult({
+          generated: result.generated || 0,
+          yearsBack: result.yearsBack || years,
+          capped: result.cappedAtIncorporation || false,
+        })
+        if ((result.generated || 0) > 0) {
+          onRequirementsApproved()
+        }
+      } else {
+        setError(result.error || 'Historical generation failed')
       }
-    } else {
-      setError(result.error || 'Historical generation failed')
+    } catch (err) {
+      console.error('[CIP:handleGenerateHistory] threw',
+        err instanceof Error ? err.message : String(err))
+      const isTimeout = err instanceof Error && err.message === 'HISTORICAL_GEN_TIMEOUT'
+      setError(isTimeout
+        ? 'Historical generation took longer than expected (2m+). Any entries that did land are visible in the tracker — refresh to see them.'
+        : (err instanceof Error ? err.message : 'Historical generation failed'))
+      // Even on timeout the server may have committed rows — refresh
+      // the tracker so the user sees whatever did land.
+      try { onRequirementsApproved() } catch {}
+    } finally {
+      setIsGeneratingHistory(false)
     }
-
-    setIsGeneratingHistory(false)
   }, [companyId, onRequirementsApproved])
 
   // Check for pending items on mount

--- a/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
+++ b/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
@@ -169,7 +169,7 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
           <svg className="w-3.5 h-3.5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
           </svg>
-          <span>Compliance applicability is up to date for FY {financialYear}.</span>
+          <span>Compliance applicability is up to date for {financialYear}.</span>
         </div>
         <button
           onClick={() => handleEvaluate()}


### PR DESCRIPTION
Three bugs surfaced while exercising "Previous Years → 2 Years" on TRILLION VENTURES.

## Bug #1 — historical entries got wrong year in requirement name

Direct DB query proof:

\`\`\`
requirement:  "ESI Contribution — Monthly Payment — For Dec 2026"
period_label: "For Jul 2025"
due_date:     "2025-08-15"
\`\`\`

\`generateHistoricalCompliances\` selected \`DISTINCT ON (requirement)\` (one source per period-decorated name → 24× over-counted) and then INSERTed with \`rule.requirement\` verbatim (already had wrong period suffix baked in from a current-FY row).

**Fix:** strip the trailing \`— For <Month> <Year>\` suffix to get a base name, dedupe source rows by \`(baseName, due_date_formula)\`, and INSERT each historical row with \`\${baseName} — \${periodLabel}\` so the name matches its due_date.

## Bug #3 — "Compliance applicability is up to date for FY FY 2026-27."

\`TrackerEvaluationPanel\` rendered \`FY {financialYear}\` where \`financialYear\` was already \`"FY 2026-27"\`. Removed the redundant prefix.

## Bug #4 — "Generating..." button stuck

\`handleGenerateHistory\` had no client-side timeout. Added a 120s \`Promise.race\` mirror of \`handleGenerate\` — on timeout, tears down the spinner, surfaces an error, and refreshes the tracker so any historical entries that DID land are visible.

## Test plan
- [ ] Click Previous Years → 1 Year → confirm new historical entries have correct period in name (e.g. "ESI Contribution — Monthly Payment — For Jul 2025" with due_date 2025-08-15)
- [ ] Switch to FY 2025-26 → no rows show year mismatches
- [ ] If server hangs, "Generating..." button caps at 120s and surfaces error
- [ ] No "FY FY" duplicate prefix anywhere in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)