### PR TITLE
fix(tracker): broaden stripPeriodSuffix regex + cleanup compound suffixes

### DIFF
--- a/app/data-room/actions-intelligence.ts
+++ b/app/data-room/actions-intelligence.ts
@@ -791,14 +791,30 @@ export async function generateHistoricalCompliances(
     // Strip the period suffix that the rules engine appends so we can
     // (a) dedupe to one source row per base rule, and (b) rebuild the
     // requirement name with the HISTORICAL period_label rather than
-    // copying the source row's (current-FY) period verbatim. Without
-    // this, historical entries inherited names like "ESI — For Dec 2026"
-    // even though their due_date was Jul 2025.
-    const stripPeriodSuffix = (name: string): string =>
-      name
-        .replace(/\s*[—–-]\s*(For\s+[A-Za-z]+\s*\d{2,4}|Q[1-4][^\n]*?\d{2,4}|H[12][^\n]*?\d{2,4})\s*$/i, '')
-        .replace(/\s*[—–-]\s*(Annual|Quarterly|Monthly|Half-Yearly|Half-yearly)?\s*[—–-]\s*For\s+[A-Za-z]+\s*\d{2,4}\s*$/i, '')
-        .trim()
+    // copying the source row's (current-FY) period verbatim.
+    //
+    // Strips ANY of:
+    //   "— For Apr 2026"   (with "For" prefix)
+    //   "— Apr 2026"       (plain "<Mon> <Year>")
+    //   "— Q1 Apr 2026"    (with quarter prefix)
+    //   "— H1 Apr 2026"    (with half-year prefix)
+    //   "— Monthly — For Apr 2026" (frequency + period)
+    //
+    // And iterates: a re-run that left compound suffixes
+    // ("— Dec 2024 — Sep 2024") gets fully stripped on subsequent runs.
+    const SUFFIX_RE = /\s*[—–-]\s*(?:Monthly|Quarterly|Annual|Half-Yearly|Half-yearly|For\s+|Q[1-4]\s+|H[12]\s+)*(?:For\s+)?(?:Q[1-4]\s+)?(?:H[12]\s+)?[A-Za-z]{3,9}\s+\d{4}\s*$/i
+    const stripPeriodSuffix = (name: string): string => {
+      let prev = name
+      let next = name.replace(SUFFIX_RE, '').trim()
+      // Iterate: keep stripping until no more period suffix is present.
+      // Bounded to 8 iterations as a safety net.
+      let i = 0
+      while (next !== prev && i++ < 8) {
+        prev = next
+        next = next.replace(SUFFIX_RE, '').trim()
+      }
+      return next
+    }
 
     type RuleSource = (typeof existingRules)[number] & { baseName: string }
     const uniqueRulesByKey = new Map<string, RuleSource>()

--- a/scripts/fix-historical-names.js
+++ b/scripts/fix-historical-names.js
@@ -48,8 +48,17 @@ function parseArgs(argv) {
 //   "Advance Tax — Q1 Instalment (15%) — Jun 2026"
 // must keep the "Q1 Instalment (15%)" part as base; only "— Jun 2026"
 // is stripped.
-const SUFFIX_RE = /\s*[—–-]\s*(?:For\s+)?(?:Q[1-4]\s+)?[A-Za-z]{3,9}\s+\d{4}\s*$/
-const stripPeriodSuffix = (name) => name.replace(SUFFIX_RE, '').trim()
+const SUFFIX_RE = /\s*[—–-]\s*(?:Monthly|Quarterly|Annual|Half-Yearly|Half-yearly|For\s+|Q[1-4]\s+|H[12]\s+)*(?:For\s+)?(?:Q[1-4]\s+)?(?:H[12]\s+)?[A-Za-z]{3,9}\s+\d{4}\s*$/i
+const stripPeriodSuffix = (name) => {
+  let prev = name
+  let next = name.replace(SUFFIX_RE, '').trim()
+  let i = 0
+  while (next !== prev && i++ < 8) {
+    prev = next
+    next = next.replace(SUFFIX_RE, '').trim()
+  }
+  return next
+}
 
 ;(async () => {
   const args = parseArgs(process.argv)
@@ -93,13 +102,18 @@ const stripPeriodSuffix = (name) => name.replace(SUFFIX_RE, '').trim()
   const samples = []
 
   for (const r of rows) {
-    const expectedSuffix = ` — ${r.period_label}`
-    if (r.requirement.endsWith(expectedSuffix)) continue
-    if (!SUFFIX_RE.test(r.requirement)) continue
+    // Compute the canonical name: full strip → base → append period_label.
+    // This catches BOTH cases:
+    //   1. Trailing suffix wrong: "...— Dec 2026" with period_label "Jul 2025"
+    //   2. Compound stray suffix: "...— Dec 2024 — Sep 2024" (ends with the
+    //      right period_label but has a stray "Dec 2024" before it)
+    if (!SUFFIX_RE.test(r.requirement)) continue // no period suffix at all → leave alone
 
     const baseName = stripPeriodSuffix(r.requirement)
     if (!baseName) { skipped++; continue }
     const correctName = `${baseName} — ${r.period_label}`
+
+    if (r.requirement === correctName) continue // already canonical
     needFix++
 
     const key = `${r.company_id}|${r.period_key}`


### PR DESCRIPTION
Smoke-testing PR #58 on production: the period-suffix stripper matched \`— For Apr 2026\` but NOT plain \`— Apr 2026\` / \`— Dec 2024\` (the format Board Meetings, Advance Tax, DIR-3 KYC, DPT-3 use). Re-runs produced compound suffixes:

\`\`\`
DPT-3 — Return of Deposits and Loans — Jun 2025 — Jun 2024
                                       ^^^^^^^^   ^^^^^^^^
                                       stray      correct period_label
\`\`\`

## Fixes
1. **actions-intelligence.ts**: SUFFIX_RE matches plain \`— Apr 2026\` too. Iterates strip up to 8× so compound suffixes get fully cleaned in one pass.
2. **scripts/fix-historical-names.js**: same broader regex + canonical-name comparison. Catches both wrong-suffix-at-end AND compound-stray-suffix cases.

Cleanup applied to production: **144 rows fixed (10 renamed, 134 duplicates deleted)**. Final grid for TRILLION:

| CAT | 2024-25 | 2025-26 | 2026-27 | 2027-28 |
|---|---|---|---|---|
| GST | 18 | 20 | 5 | · |
| Payroll | 24 | 26 | 26 | 26 |
| State Compliance | 14 | 16 | 11 | 1 |
| RoC | 8 | 8 | 8 | 12 |
| Income Tax | 8 | 8 | 19 | 23 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved name normalization logic for historical records to handle an expanded range of suffix patterns and ensure complete cleanup through enhanced processing, resulting in cleaner and more consistent data display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->