### PR TITLE
fix(tracker): Quarter filter case mismatch — Q1/Q2/Q3/Q4 always returned 0 rows

### DIFF
--- a/contexts/TrackerContext.tsx
+++ b/contexts/TrackerContext.tsx
@@ -280,11 +280,15 @@ export function TrackerContextProvider({
     }
 
     if (selectedQuarter) {
+      // The dropdown stores quarter values as 'Q1' / 'Q2' / 'Q3' / 'Q4'
+      // (uppercase). The filter previously computed lowercase 'q1' etc
+      // so EVERY selection returned 0 rows. Compare uppercase to match
+      // the source of truth (TrackerTab's `quarters` array).
       filtered = filtered.filter((req) => {
         const d = parseDate(req.dueDate)
         if (!d) return false
         const m = d.getUTCMonth()
-        const q = m >= 3 && m <= 5 ? 'q1' : m >= 6 && m <= 8 ? 'q2' : m >= 9 && m <= 11 ? 'q3' : 'q4'
+        const q = m >= 3 && m <= 5 ? 'Q1' : m >= 6 && m <= 8 ? 'Q2' : m >= 9 && m <= 11 ? 'Q3' : 'Q4'
         return q === selectedQuarter
       })
     }


### PR DESCRIPTION
Smoke test against production caught a silently broken filter.

The Quarter dropdown stores values as \`Q1\` / \`Q2\` / \`Q3\` / \`Q4\` (uppercase, defined in TrackerTab's \`quarters\` array). The TrackerContext filter computed lowercase \`q1\` / \`q2\` / etc and compared strict-equal against the dropdown value. Every comparison returned false → every quarter selection collapsed the table to 0 rows.

**Smoke test**: FY 2026-27 baseline 59 rows → selecting Q2 → 0 rows. With case-corrected comparison, the filter works as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)