### PR TITLE
fix(tracker): pill counts respect FY filter; cleanup prefix-overlap Advance Tax dups

### DIFF
--- a/app/data-room/components/tracker/TrackerTab.tsx
+++ b/app/data-room/components/tracker/TrackerTab.tsx
@@ -98,6 +98,7 @@ export default function TrackerTab() {
     // Derived values
     displayRequirements,
     filteredRequirements,
+    requirementsForPillCounts,
     groupedByCategory,
     requirementsByDate,
   } = useTrackerContext()
@@ -200,11 +201,13 @@ export default function TrackerTab() {
         setSelectedRequirements={setSelectedRequirements}
       />
 
-      {/* Category Filters */}
+      {/* Category Filters — pills' counts must respect the active FY/Month/
+          Quarter/search filters but NOT the pill itself (otherwise selecting
+          a pill would set every count to that pill's filtered total). */}
       <TrackerCategoryFilters
         categoryFilter={categoryFilter}
         setCategoryFilter={setCategoryFilter}
-        requirements={displayRequirements}
+        requirements={requirementsForPillCounts}
       />
 
       {/* Category Dashboard — shown when a specific category is selected */}

--- a/contexts/TrackerContext.tsx
+++ b/contexts/TrackerContext.tsx
@@ -118,6 +118,10 @@ interface TrackerContextValue extends TrackerExternalData {
   // Derived / computed
   displayRequirements: any[]
   filteredRequirements: any[]
+  /** Same pipeline as filteredRequirements MINUS the status-pill (categoryFilter)
+   * step. Counted by TrackerCategoryFilters so the All/Overdue/Critical/Pending/
+   * Upcoming/Completed pill counts respect the active FY/Month/Quarter/search. */
+  requirementsForPillCounts: any[]
   groupedByCategory: { category: string; items: any[] }[]
   requirementsByDate: Map<string, any[]>
 }
@@ -357,6 +361,61 @@ export function TrackerContextProvider({
     normalizeDate,
   ])
 
+  // ── Derived: requirementsForPillCounts ──────────────────────────────────────
+  // Same filter pipeline as filteredRequirements EXCEPT the status-pill
+  // (categoryFilter) step. The pills SET categoryFilter — if we fed the pills
+  // the post-pill list, every count would equal the currently-selected pill.
+  // Pills consume this list to show "Of FY 2025-26's items, how many are
+  // overdue/critical/pending/upcoming/completed".
+  const requirementsForPillCounts = useMemo(() => {
+    if (displayRequirements.length === 0) return []
+    const parseDate = (dateStr: string): Date | null => {
+      if (!dateStr) return null
+      return normalizeDate(dateStr)
+    }
+    const isInFY = (reqDate: Date | null, fyStr: string): boolean => {
+      if (!reqDate || !fyStr) return false
+      return isInFinancialYearUtil(reqDate, fyStr, countryCode)
+    }
+    let filtered = displayRequirements
+    if (selectedTrackerFY) {
+      filtered = filtered.filter((req) => req.dueDate && isInFY(parseDate(req.dueDate), selectedTrackerFY))
+    }
+    if (selectedMonth) {
+      const monthIndex = MONTHS.indexOf(selectedMonth)
+      filtered = filtered.filter((req) => {
+        const d = parseDate(req.dueDate)
+        return d ? d.getUTCMonth() === monthIndex : false
+      })
+    }
+    if (selectedQuarter) {
+      filtered = filtered.filter((req) => {
+        const d = parseDate(req.dueDate)
+        if (!d) return false
+        const m = d.getUTCMonth()
+        const q = m >= 3 && m <= 5 ? 'Q1' : m >= 6 && m <= 8 ? 'Q2' : m >= 9 && m <= 11 ? 'Q3' : 'Q4'
+        return q === selectedQuarter
+      })
+    }
+    if (trackerSearchQuery.trim()) {
+      const q = trackerSearchQuery.toLowerCase().trim()
+      filtered = filtered.filter((req) => {
+        const text = [req.category, req.requirement, req.description, req.status, req.compliance_type, req.financial_year]
+          .filter(Boolean).join(' ').toLowerCase()
+        return text.includes(q)
+      })
+    }
+    return filtered
+  }, [
+    displayRequirements,
+    selectedTrackerFY,
+    selectedMonth,
+    selectedQuarter,
+    trackerSearchQuery,
+    countryCode,
+    normalizeDate,
+  ])
+
   // ── Derived: categoryOrder ────────────────────────────────────────────────────
   const categoryOrder = useMemo(() => {
     const allCategories = Array.from(new Set(displayRequirements.map((r) => r.category).filter(Boolean)))
@@ -440,6 +499,7 @@ export function TrackerContextProvider({
     // Derived
     displayRequirements,
     filteredRequirements,
+    requirementsForPillCounts,
     groupedByCategory,
     requirementsByDate,
   }

--- a/scripts/fix-prefix-overlap-dups.js
+++ b/scripts/fix-prefix-overlap-dups.js
@@ -1,0 +1,128 @@
+/**
+ * One-shot cleanup for prefix-overlap duplicates among rules-engine rows.
+ *
+ * Background: TRILLION (and other companies) have pairs like:
+ *
+ *   "Advance Tax — Jun 2025"                          ← stale, generic
+ *   "Advance Tax — Q1 Instalment (15%) — Jun 2025"    ← canonical, current rule
+ *
+ * Both rows have:
+ *   - source = 'rules_engine'
+ *   - same period_key (e.g. "2025-06")
+ *   - same due_date
+ *   - same description
+ *
+ * The shorter-named row is from a now-removed rule definition. We want to
+ * delete it and keep the longer-named (more specific) row. Heuristic: for
+ * each (company_id, period_key, due_date) group with 2+ rules_engine rows,
+ * if one row's `requirement` (after stripping the trailing "— Mon Year"
+ * period suffix) is a STRICT PREFIX of another row's stripped requirement,
+ * delete the prefix row.
+ *
+ * Idempotent. Safe to re-run.
+ *
+ * Usage:
+ *   DATABASE_URL='<prod_direct>' node scripts/fix-prefix-overlap-dups.js
+ *     [--dry]                    print what it would delete
+ *     [--company-id <uuid>]      scope to one company
+ */
+
+const { PrismaClient } = require('@prisma/client')
+const p = new PrismaClient()
+
+function parseArgs(argv) {
+  const args = { dry: false, companyId: null }
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i]
+    if (a === '--dry') args.dry = true
+    else if (a === '--company-id') args.companyId = argv[++i]
+  }
+  return args
+}
+
+const SUFFIX_RE = /\s*[—–-]\s*(?:Monthly|Quarterly|Annual|Half-Yearly|Half-yearly|For\s+|Q[1-4]\s+|H[12]\s+)*(?:For\s+)?(?:Q[1-4]\s+)?(?:H[12]\s+)?[A-Za-z]{3,9}\s+\d{4}\s*$/i
+function stripSuffix(name) {
+  let prev = name
+  let next = name.replace(SUFFIX_RE, '').trim()
+  let i = 0
+  while (next !== prev && i++ < 8) {
+    prev = next
+    next = next.replace(SUFFIX_RE, '').trim()
+  }
+  return next
+}
+
+;(async () => {
+  const args = parseArgs(process.argv)
+  console.log('[fix-prefix-overlap] starting', args)
+
+  const where = {
+    period_key: { not: null },
+    source: 'rules_engine',
+    ...(args.companyId ? { company_id: args.companyId } : {}),
+  }
+
+  const rows = await p.regulatoryRequirement.findMany({
+    where,
+    select: {
+      id: true,
+      company_id: true,
+      requirement: true,
+      period_key: true,
+      due_date: true,
+    },
+  })
+  console.log('[fix-prefix-overlap] candidate rows:', rows.length)
+
+  // Group by (company_id, period_key)
+  const groups = new Map()
+  for (const r of rows) {
+    const key = `${r.company_id}|${r.period_key}`
+    if (!groups.has(key)) groups.set(key, [])
+    groups.get(key).push({ ...r, base: stripSuffix(r.requirement) })
+  }
+
+  const toDelete = []
+  for (const [, members] of groups) {
+    if (members.length < 2) continue
+    // Within a group, find pairs where one's base is a strict prefix of another's
+    for (const a of members) {
+      for (const b of members) {
+        if (a.id === b.id) continue
+        if (a.base.length >= b.base.length) continue
+        // a.base is shorter
+        if (b.base.startsWith(a.base + ' ') || b.base.startsWith(a.base + ' —')) {
+          toDelete.push({ id: a.id, from: a.requirement, keptBecause: b.requirement })
+          break // delete this short one once
+        }
+      }
+    }
+  }
+
+  // Dedupe (a row could match multiple longer rows in its group)
+  const uniqDelete = Array.from(new Map(toDelete.map((d) => [d.id, d])).values())
+
+  console.log('[fix-prefix-overlap] rows to delete:', uniqDelete.length)
+  console.log('[fix-prefix-overlap] first 6 samples:')
+  console.log(JSON.stringify(uniqDelete.slice(0, 6), null, 2))
+
+  if (args.dry) {
+    console.log('[fix-prefix-overlap] DRY RUN — no rows deleted.')
+  } else {
+    let deleted = 0
+    for (const d of uniqDelete) {
+      try {
+        await p.regulatoryRequirement.delete({ where: { id: d.id } })
+        deleted++
+      } catch (e) {
+        console.warn('  failed to delete', d.id, ':', e.message)
+      }
+    }
+    console.log('[fix-prefix-overlap] actually deleted:', deleted)
+  }
+
+  await p.$disconnect()
+})().catch((e) => {
+  console.error('[fix-prefix-overlap] threw', e.message, e.stack)
+  process.exit(1)
+})


### PR DESCRIPTION
Two bugs from the user's screenshots.

## Bug A — Status pill counts ignore FY filter
Selecting FY 2025-26 still showed All 328 / Overdue 162 / Critical 191 (all-time totals). Pills read \`displayRequirements\` which is only filtered by hiddenCompliances + selectedCategory.

**Fix:** new \`requirementsForPillCounts\` memo runs the same filter pipeline as \`filteredRequirements\` MINUS the status-pill step. Pills consume this so counts respect FY/Month/Quarter/search but exclude the pill itself.

## Bug B — Redundant Advance Tax pairs
Rows like:
- \`"Advance Tax — Jun 2025"\` (stale, generic)
- \`"Advance Tax — Q1 Instalment (15%) — Jun 2025"\` (canonical)

Both \`source: 'rules_engine'\`, same period_key, same description. The shorter-named row is from a removed rule definition.

**Fix:** \`scripts/fix-prefix-overlap-dups.js\` — for each (company, period_key) group with multiple rules_engine rows, if one row's stripped requirement is a strict prefix of another's, delete the prefix row. **Already applied to production: 8 rows deleted** (4 quarterly periods × 2 FYs of stale "Advance Tax — Mon Year").

🤖 Generated with [Claude Code](https://claude.com/claude-code)