### PR TITLE
feat(tracker): 3-level accordion — Category > Frequency > Form > Table

### DIFF
--- a/app/data-room/components/tracker/TrackerCategoryAccordionView.tsx
+++ b/app/data-room/components/tracker/TrackerCategoryAccordionView.tsx
@@ -2,24 +2,23 @@
 
 import React, { useEffect, useMemo, useState } from 'react'
 import RequirementDesktopTableView from './RequirementDesktopTableView'
-import type { IRegulatoryService } from '../../services/RegulatoryService'
+import { stripPeriodSuffix } from '@/lib/utils/strip-period-suffix'
 
 /**
- * Category-accordion wrapper around the existing desktop table.
+ * Three-level nested accordion:
  *
- * Each top-level category becomes a collapsible card with:
- *   • Numbered, color-coded badge
- *   • Category name + count
- *   • Frequency-family chips (Monthly · Quarterly · Annual …)
- *   • Chevron + click-to-expand
+ *   Category (Income Tax, GST, RoC, …)
+ *   └── Frequency (Monthly · Quarterly · Half-Yearly · Annual · One-Time · Event-Based)
+ *       └── Form    (TDS Payment to Government, Advance Tax — Q1 Instalment (15%), …)
+ *           └── existing RequirementDesktopTableView scoped to those rows
  *
- * When expanded, the body renders RequirementDesktopTableView scoped to
- * that category's items only — reuses 100% of existing row/column logic.
- * No new columns, no new fields — pure visual reorganisation of what
- * was previously one long flat-grouped table.
+ * Levels 2 & 3 are derived purely from existing fields:
+ *   • Frequency  ← `compliance_type`
+ *   • Form       ← `requirement` after stripping its trailing period suffix
+ *                  (same regex used server-side in actions-intelligence.ts)
  *
- * Mobile keeps the existing RequirementMobileCardView (TrackerTab handles
- * the responsive switch).
+ * No new columns, no new data. Mobile keeps RequirementMobileCardView
+ * (TrackerTab handles the responsive switch).
  */
 
 interface Group {
@@ -34,11 +33,35 @@ interface Props extends Omit<RequirementDesktopProps, 'groupedByCategory' | 'fil
   filteredRequirements: any[]
 }
 
-/**
- * Color theme per category. Picked for contrast against the dark
- * tracker backdrop and to visually disambiguate at a glance.
- * Falls back to slate for any category we haven't pre-themed.
- */
+const FREQ_ORDER = [
+  'monthly',
+  'quarterly',
+  'half-yearly',
+  'annual',
+  'one-time',
+  'event-based',
+]
+
+const FREQ_LABEL: Record<string, string> = {
+  monthly: 'Monthly',
+  quarterly: 'Quarterly',
+  'half-yearly': 'Half-Yearly',
+  annual: 'Annual',
+  'one-time': 'One-Time',
+  'event-based': 'Event-Based',
+  unspecified: 'Unspecified',
+}
+
+const FREQ_ACCENT: Record<string, string> = {
+  monthly: 'text-blue-300 bg-blue-500/10 ring-blue-500/25',
+  quarterly: 'text-purple-300 bg-purple-500/10 ring-purple-500/25',
+  'half-yearly': 'text-teal-300 bg-teal-500/10 ring-teal-500/25',
+  annual: 'text-green-300 bg-green-500/10 ring-green-500/25',
+  'one-time': 'text-yellow-300 bg-yellow-500/10 ring-yellow-500/25',
+  'event-based': 'text-fuchsia-300 bg-fuchsia-500/10 ring-fuchsia-500/25',
+  unspecified: 'text-gray-300 bg-white/5 ring-white/15',
+}
+
 const CATEGORY_THEME: Record<string, { ring: string; bg: string; text: string; border: string }> = {
   'Income Tax':        { ring: 'ring-blue-500/30',    bg: 'bg-blue-500/15',    text: 'text-blue-300',    border: 'border-blue-500/30' },
   'GST':               { ring: 'ring-emerald-500/30', bg: 'bg-emerald-500/15', text: 'text-emerald-300', border: 'border-emerald-500/30' },
@@ -54,55 +77,113 @@ const CATEGORY_THEME: Record<string, { ring: string; bg: string; text: string; b
 const FALLBACK_THEME = { ring: 'ring-slate-500/30', bg: 'bg-slate-500/15', text: 'text-slate-300', border: 'border-slate-500/30' }
 const themeFor = (cat: string) => CATEGORY_THEME[cat] ?? FALLBACK_THEME
 
-/**
- * Frequency families summary chips. Derived purely from each item's
- * existing `compliance_type` — no new data.
- */
+function freqKey(item: any): string {
+  const raw = String(item.compliance_type || '').toLowerCase().trim()
+  return raw && FREQ_LABEL[raw] ? raw : 'unspecified'
+}
+
+function groupByFrequency(items: any[]): { freq: string; items: any[] }[] {
+  const map = new Map<string, any[]>()
+  for (const it of items) {
+    const k = freqKey(it)
+    if (!map.has(k)) map.set(k, [])
+    map.get(k)!.push(it)
+  }
+  const order = [...FREQ_ORDER, 'unspecified']
+  return order.filter((k) => map.has(k)).map((k) => ({ freq: k, items: map.get(k)! }))
+}
+
+function groupByForm(items: any[]): { form: string; items: any[] }[] {
+  const map = new Map<string, any[]>()
+  for (const it of items) {
+    const base = stripPeriodSuffix(String(it.requirement || '')) || 'Unnamed'
+    if (!map.has(base)) map.set(base, [])
+    map.get(base)!.push(it)
+  }
+  // Stable alpha sort, with multi-instance forms first (more useful to expand)
+  return [...map.entries()]
+    .map(([form, forms]) => ({ form, items: forms }))
+    .sort((a, b) => {
+      if (a.items.length !== b.items.length) return b.items.length - a.items.length
+      return a.form.localeCompare(b.form)
+    })
+}
+
 function summariseFrequencies(items: any[]): string[] {
-  const order = ['monthly', 'quarterly', 'half-yearly', 'annual', 'one-time', 'event-based']
-  const present = new Set(
-    items.map((i) => (i.compliance_type || '').toLowerCase()).filter(Boolean),
-  )
-  const ordered = order.filter((f) => present.has(f))
-  // Capitalise display
-  const cap = (s: string) => s.replace(/\b\w/g, (c) => c.toUpperCase())
-  return ordered.map(cap)
+  const present = new Set(items.map((i) => freqKey(i)))
+  return [...FREQ_ORDER, 'unspecified']
+    .filter((f) => present.has(f))
+    .map((f) => FREQ_LABEL[f])
 }
 
 export default function TrackerCategoryAccordionView(props: Props) {
   const { groupedByCategory, ...rest } = props
 
-  // Track which categories are open. Default: only the FIRST category
-  // (most relevant) is open on first render, so the user sees something
-  // immediately without an overwhelming wall of expanded sections.
+  // Open-state sets keyed independently per level so toggling one doesn't
+  // collapse the others. Keys:
+  //   category          → "<cat>"
+  //   frequency bucket  → "<cat>::<freq>"
+  //   form bucket       → "<cat>::<freq>::<form>"
   const [openCategories, setOpenCategories] = useState<Set<string>>(() => {
     const first = groupedByCategory[0]?.category
     return new Set(first ? [first] : [])
   })
+  const [openFreqs, setOpenFreqs] = useState<Set<string>>(new Set())
+  const [openForms, setOpenForms] = useState<Set<string>>(new Set())
 
-  // If groupedByCategory shape changes (e.g. filter applied), keep any
-  // previously-open categories that still exist; ensure at least the
-  // first one is open so the surface isn't empty.
+  // When the data shape changes (filter applied), prune open keys that no
+  // longer correspond to anything; ensure at least one category remains open.
   useEffect(() => {
     setOpenCategories((prev) => {
-      const stillExists = new Set(groupedByCategory.map((g) => g.category))
-      const next = new Set([...prev].filter((c) => stillExists.has(c)))
-      if (next.size === 0 && groupedByCategory.length > 0) {
-        next.add(groupedByCategory[0].category)
-      }
+      const cats = new Set(groupedByCategory.map((g) => g.category))
+      const next = new Set([...prev].filter((c) => cats.has(c)))
+      if (next.size === 0 && groupedByCategory.length > 0) next.add(groupedByCategory[0].category)
       return next
     })
+    // Frequency / form keys auto-prune lazily: they just won't render if
+    // their parent cat/freq isn't in the data — no need to clear them here,
+    // and keeping them avoids re-collapsing on every re-render.
   }, [groupedByCategory])
 
-  const expandAll = () => setOpenCategories(new Set(groupedByCategory.map((g) => g.category)))
-  const collapseAll = () => setOpenCategories(new Set())
-  const toggle = (cat: string) =>
+  const toggleCategory = (cat: string) =>
     setOpenCategories((prev) => {
       const next = new Set(prev)
-      if (next.has(cat)) next.delete(cat)
-      else next.add(cat)
+      next.has(cat) ? next.delete(cat) : next.add(cat)
       return next
     })
+
+  const toggleFreq = (key: string) =>
+    setOpenFreqs((prev) => {
+      const next = new Set(prev)
+      next.has(key) ? next.delete(key) : next.add(key)
+      return next
+    })
+
+  const toggleForm = (key: string) =>
+    setOpenForms((prev) => {
+      const next = new Set(prev)
+      next.has(key) ? next.delete(key) : next.add(key)
+      return next
+    })
+
+  const expandAll = () => {
+    const cats = new Set<string>()
+    const freqs = new Set<string>()
+    for (const g of groupedByCategory) {
+      cats.add(g.category)
+      for (const fg of groupByFrequency(g.items)) {
+        freqs.add(`${g.category}::${fg.freq}`)
+      }
+    }
+    setOpenCategories(cats)
+    setOpenFreqs(freqs)
+    // Don't auto-open forms — too noisy. User can drill in per form.
+  }
+  const collapseAll = () => {
+    setOpenCategories(new Set())
+    setOpenFreqs(new Set())
+    setOpenForms(new Set())
+  }
 
   const totalCount = useMemo(
     () => groupedByCategory.reduce((acc, g) => acc + g.items.length, 0),
@@ -111,7 +192,7 @@ export default function TrackerCategoryAccordionView(props: Props) {
 
   return (
     <div className="space-y-3 sm:space-y-4">
-      {/* Toolbar — Expand / Collapse all */}
+      {/* Toolbar */}
       <div className="flex items-center justify-between px-1">
         <div className="text-xs sm:text-sm text-gray-400">
           <span className="text-white font-medium">{totalCount}</span> compliance
@@ -137,32 +218,30 @@ export default function TrackerCategoryAccordionView(props: Props) {
         </div>
       </div>
 
-      {/* Category accordions */}
+      {/* Level 1 — Category */}
       <div className="space-y-3">
         {groupedByCategory.map((group, idx) => {
           const theme = themeFor(group.category)
-          const isOpen = openCategories.has(group.category)
+          const catOpen = openCategories.has(group.category)
           const freqs = summariseFrequencies(group.items)
+          const freqGroups = catOpen ? groupByFrequency(group.items) : []
           return (
             <div
               key={group.category}
-              className={`bg-black/40 border ${isOpen ? theme.border : 'border-white/10'} rounded-xl overflow-hidden transition-colors`}
+              className={`bg-black/40 border ${catOpen ? theme.border : 'border-white/10'} rounded-xl overflow-hidden transition-colors`}
             >
-              {/* Header — clickable, color-themed */}
+              {/* Category header */}
               <button
                 type="button"
-                onClick={() => toggle(group.category)}
+                onClick={() => toggleCategory(group.category)}
                 className="w-full flex items-center gap-3 sm:gap-4 px-4 sm:px-5 py-3 sm:py-4 hover:bg-white/[0.03] transition-colors text-left"
-                aria-expanded={isOpen}
+                aria-expanded={catOpen}
               >
-                {/* Numbered badge */}
                 <div
                   className={`flex-shrink-0 w-8 h-8 sm:w-10 sm:h-10 rounded-lg ${theme.bg} ${theme.text} flex items-center justify-center font-mono text-sm sm:text-base font-semibold ring-1 ${theme.ring}`}
                 >
                   {idx + 1}
                 </div>
-
-                {/* Title + count */}
                 <div className="flex-1 min-w-0 flex items-center gap-3 flex-wrap">
                   <span className="text-white font-semibold text-base sm:text-lg truncate">
                     {group.category}
@@ -171,8 +250,6 @@ export default function TrackerCategoryAccordionView(props: Props) {
                     {group.items.length}
                   </span>
                 </div>
-
-                {/* Frequency chips — hidden on small screens */}
                 {freqs.length > 0 && (
                   <div className="hidden md:flex items-center gap-1.5 flex-shrink-0">
                     {freqs.map((f, i) => (
@@ -183,8 +260,6 @@ export default function TrackerCategoryAccordionView(props: Props) {
                     ))}
                   </div>
                 )}
-
-                {/* Chevron */}
                 <svg
                   width="16"
                   height="16"
@@ -192,23 +267,112 @@ export default function TrackerCategoryAccordionView(props: Props) {
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2"
-                  className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${isOpen ? 'rotate-90' : ''}`}
+                  className={`flex-shrink-0 text-gray-400 transition-transform duration-200 ${catOpen ? 'rotate-90' : ''}`}
                   aria-hidden="true"
                 >
                   <polyline points="9 18 15 12 9 6" />
                 </svg>
               </button>
 
-              {/* Body — render the existing desktop table scoped to this category */}
-              {isOpen && (
-                <div className="border-t border-white/5">
-                  <div className="overflow-x-auto scrollbar-hide">
-                    <RequirementDesktopTableView
-                      {...rest}
-                      groupedByCategory={[group]}
-                      filteredRequirements={group.items}
-                    />
-                  </div>
+              {/* Body — Level 2 (Frequency) sub-accordions */}
+              {catOpen && (
+                <div className="border-t border-white/5 p-3 sm:p-4 space-y-2.5">
+                  {freqGroups.map((fg) => {
+                    const freqKeyId = `${group.category}::${fg.freq}`
+                    const freqOpen = openFreqs.has(freqKeyId)
+                    const accent = FREQ_ACCENT[fg.freq] ?? FREQ_ACCENT.unspecified
+                    const formGroups = freqOpen ? groupByForm(fg.items) : []
+                    return (
+                      <div
+                        key={freqKeyId}
+                        className="bg-white/[0.02] border border-white/10 rounded-lg overflow-hidden"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => toggleFreq(freqKeyId)}
+                          className="w-full flex items-center gap-3 px-3 sm:px-4 py-2.5 hover:bg-white/[0.04] transition-colors text-left"
+                          aria-expanded={freqOpen}
+                        >
+                          <span
+                            className={`text-[11px] uppercase tracking-wide px-2 py-0.5 rounded-md font-mono font-medium ring-1 ${accent}`}
+                          >
+                            {FREQ_LABEL[fg.freq]}
+                          </span>
+                          <span className="text-gray-400 text-xs">
+                            <span className="text-white font-medium">{fg.items.length}</span>{' '}
+                            compliance{fg.items.length === 1 ? '' : 's'}
+                          </span>
+                          <span className="flex-1" />
+                          <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            className={`flex-shrink-0 text-gray-500 transition-transform duration-200 ${freqOpen ? 'rotate-90' : ''}`}
+                            aria-hidden="true"
+                          >
+                            <polyline points="9 18 15 12 9 6" />
+                          </svg>
+                        </button>
+
+                        {/* Body — Level 3 (Form) sub-accordions */}
+                        {freqOpen && (
+                          <div className="border-t border-white/5 p-2 sm:p-3 space-y-2">
+                            {formGroups.map((form) => {
+                              const formKeyId = `${freqKeyId}::${form.form}`
+                              const formOpen = openForms.has(formKeyId)
+                              return (
+                                <div
+                                  key={formKeyId}
+                                  className="bg-black/30 border border-white/10 rounded-md overflow-hidden"
+                                >
+                                  <button
+                                    type="button"
+                                    onClick={() => toggleForm(formKeyId)}
+                                    className="w-full flex items-center gap-3 px-3 py-2 hover:bg-white/[0.04] transition-colors text-left"
+                                    aria-expanded={formOpen}
+                                  >
+                                    <span className="text-gray-200 text-sm font-medium truncate">
+                                      {form.form}
+                                    </span>
+                                    <span className="text-[10px] px-1.5 py-0.5 rounded bg-white/5 text-gray-400 font-mono">
+                                      {form.items.length}
+                                    </span>
+                                    <span className="flex-1" />
+                                    <svg
+                                      width="12"
+                                      height="12"
+                                      viewBox="0 0 24 24"
+                                      fill="none"
+                                      stroke="currentColor"
+                                      strokeWidth="2"
+                                      className={`flex-shrink-0 text-gray-500 transition-transform duration-200 ${formOpen ? 'rotate-90' : ''}`}
+                                      aria-hidden="true"
+                                    >
+                                      <polyline points="9 18 15 12 9 6" />
+                                    </svg>
+                                  </button>
+                                  {formOpen && (
+                                    <div className="border-t border-white/5">
+                                      <div className="overflow-x-auto scrollbar-hide">
+                                        <RequirementDesktopTableView
+                                          {...rest}
+                                          groupedByCategory={[{ category: group.category, items: form.items }]}
+                                          filteredRequirements={form.items}
+                                        />
+                                      </div>
+                                    </div>
+                                  )}
+                                </div>
+                              )
+                            })}
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
                 </div>
               )}
             </div>

--- a/lib/utils/strip-period-suffix.ts
+++ b/lib/utils/strip-period-suffix.ts
@@ -1,0 +1,26 @@
+/**
+ * Iteratively strip the trailing "— Mon Year" / "— Q3 Sep 2025" / "— H1 For Sep 2025"
+ * period suffix from a requirement name. Mirrors the regex used by:
+ *   - app/data-room/actions-intelligence.ts (server-side bulk insert)
+ *   - scripts/fix-historical-names.js     (one-shot cleanup)
+ *   - supabase/migrations-manual/2026-04-28-pollution-watchdog.sql (PL/pgSQL)
+ *
+ * Examples:
+ *   "TDS Payment to Government — Monthly — For Mar 2026"   → "TDS Payment to Government"
+ *   "Advance Tax — Q1 Instalment (15%) — Jun 2025"          → "Advance Tax — Q1 Instalment (15%)"
+ *   "DPT-3 — Jun 2025 — Jun 2024"                           → "DPT-3"
+ */
+const SUFFIX_RE =
+  /\s*[—–-]\s*(?:Monthly|Quarterly|Annual|Half-Yearly|Half-yearly|For\s+|Q[1-4]\s+|H[12]\s+)*(?:For\s+)?(?:Q[1-4]\s+)?(?:H[12]\s+)?[A-Za-z]{3,9}\s+\d{4}\s*$/i
+
+export function stripPeriodSuffix(name: string): string {
+  if (!name) return ''
+  let prev = name
+  let next = name.replace(SUFFIX_RE, '').trim()
+  let i = 0
+  while (next !== prev && i++ < 8) {
+    prev = next
+    next = next.replace(SUFFIX_RE, '').trim()
+  }
+  return next || name
+}


### PR DESCRIPTION
## Summary
- Adds two new nested accordion levels inside each category card.
- **Level 2 — Frequency**: Monthly, Quarterly, Half-Yearly, Annual, One-Time, Event-Based, with color-coded family chip. Derived from \`compliance_type\`.
- **Level 3 — Form**: e.g. \"TDS Payment to Government\" collapses 12 monthly rows; \"Advance Tax — Q1 Instalment (15%)\" stays distinct from \"Advance Tax — Q2 Instalment (45%)\". Derived from \`requirement\` after stripping the trailing period suffix using the same regex as \`actions-intelligence.ts\`, \`scripts/fix-historical-names.js\`, and the pg_cron pollution watchdog. Extracted into \`lib/utils/strip-period-suffix.ts\` for reuse.
- Form-level body still renders the existing \`RequirementDesktopTableView\` scoped to that bucket, so every existing column (status, due date, payable/paid, docs, penalty, …) is preserved.
- No new schema, no new fields.

## Behavior
- Each level's open-state is tracked independently — toggling a form doesn't collapse its frequency parent.
- **Expand all** opens categories + their frequency rows; forms stay closed by default to avoid visual overwhelm. **Collapse all** clears everything.
- When a filter changes the data shape, category open-state is pruned to surviving categories. Frequency / form keys auto-prune lazily (they just don't render).

## Files
- \`lib/utils/strip-period-suffix.ts\` (new — shared client util)
- \`app/data-room/components/tracker/TrackerCategoryAccordionView.tsx\` (refactored: now renders 3 levels)

## Test plan
- [ ] Desktop: open Income Tax → see Monthly + Quarterly sub-cards. Open Monthly → see \"TDS Payment to Government (12)\" form sub-card. Open it → see the existing 12-row table.
- [ ] Open Income Tax → Quarterly → Advance Tax instalments stay separate (Q1, Q2, Q3, Q4 each get their own form sub-card).
- [ ] Expand all → all categories + all frequencies open, forms closed. Collapse all → everything closes.
- [ ] FY filter switch → totals update; previously-open category re-renders with new data; forms not affected.
- [ ] Mobile (<640px): accordion hidden, \`RequirementMobileCardView\` still renders.
- [ ] \`tsc --noEmit\` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)