### PR TITLE
feat(data-room): replace cinematic boot screen with layout-aligned shell

### DIFF
--- a/app/data-room/components/DataRoomBootShell.tsx
+++ b/app/data-room/components/DataRoomBootShell.tsx
@@ -1,0 +1,213 @@
+'use client'
+
+import React from 'react'
+import Header from '@/components/layout/Header'
+import SubtleCircuitBackground from '@/components/ui/SubtleCircuitBackground'
+import TrackerCategoryAccordionView from './tracker/TrackerCategoryAccordionView'
+import { getCountryConfig } from '@/lib/config/countries'
+
+/**
+ * Pre-data layout shell for the entire data-room page.
+ *
+ * Renders the SAME outer DOM structure as the post-boot data-room tree
+ * (Header → main container → company card slot → "Data Room" title →
+ * tab strip → active-tab content), but with skeletons / shells in each
+ * data-dependent slot. When the page-level boot guard flips, the
+ * populated tree lands in the exact same DOM positions, so there's no
+ * pop-in and no visible layout shift.
+ *
+ * Why a separate component (not inline in page.tsx): this is rendered
+ * during the early-return at the top of page.tsx where most of the page
+ * state isn't initialized yet. Keeping it self-contained means it can
+ * derive everything it needs (country categories) from a synchronous
+ * config without depending on any of the page's hooks.
+ *
+ * The cinematic "Booting Data Room" banner from the previous boot
+ * screen is intentionally removed. It theatrically announced the load
+ * but caused the perceived abruptness — by replacing the real layout
+ * with a stylized message and then snapping back to the real layout,
+ * every section moved when the gate flipped.
+ */
+export default function DataRoomBootShell({
+  activeTab = 'tracker',
+  countryCode = 'IN',
+}: {
+  activeTab?: string
+  countryCode?: string
+}) {
+  // Static category list for the tracker shell. Sourced synchronously
+  // from the country config — no async wait.
+  const config = (() => {
+    try {
+      return getCountryConfig(countryCode)
+    } catch {
+      return null
+    }
+  })()
+  const shellCategories =
+    config?.compliance?.defaultCategories && config.compliance.defaultCategories.length > 0
+      ? config.compliance.defaultCategories
+      : ['Income Tax', 'GST', 'Payroll', 'RoC', 'Renewals', 'Others']
+
+  return (
+    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+      <SubtleCircuitBackground />
+      <Header />
+
+      <div className="relative z-10 container mx-auto px-3 sm:px-4 py-4 sm:py-8">
+        {/* Company Selector slot — matches post-boot dimensions */}
+        <div className="mb-4 sm:mb-6">
+          <h2 className="text-gray-400 text-sm font-medium mb-2 sm:mb-3">My companies</h2>
+          <div className="h-[72px] sm:h-[84px] rounded-xl border border-white/10 bg-white/[0.03] animate-pulse" />
+        </div>
+
+        {/* Page Title — real, no shell */}
+        <h1 className="text-2xl sm:text-4xl font-light text-white mb-4 sm:mb-6">Data Room</h1>
+
+        {/* Tab strip — visually matches the real tabs (rounded buttons,
+            border, padding) so dimensions are identical when the real
+            tabs render. Inert during shell. */}
+        <div className="flex items-center gap-2 mb-4 sm:mb-8 overflow-x-auto pb-2 -mx-3 sm:mx-0 px-3 sm:px-0 scrollbar-hide">
+          {['Overview', 'Tracker', 'Documents', 'Reports', 'DSC & DIN', 'Notices'].map((label) => (
+            <div
+              key={label}
+              className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 whitespace-nowrap flex-shrink-0 ${
+                label.toLowerCase() === activeTab
+                  ? 'border-white/40 bg-white/10 text-white'
+                  : 'border-white/20 bg-black text-gray-500'
+              }`}
+            >
+              <div className="w-4 h-4 sm:w-[18px] sm:h-[18px] rounded bg-white/10 animate-pulse" />
+              <span className="text-sm sm:text-base">{label}</span>
+            </div>
+          ))}
+        </div>
+
+        {/* Active-tab content shell. We only invest in the tracker
+            tab's shell (the user-reported pain). Other tabs get a
+            generic block. */}
+        {activeTab === 'tracker' ? (
+          <TrackerSectionShell shellCategories={shellCategories} />
+        ) : (
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 sm:gap-6">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-32 rounded-2xl border border-white/10 bg-white/[0.03] animate-pulse"
+              />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Tracker tab content shell — mirrors what TrackerTab renders post-boot:
+ *   Regulatory Timeline title row → Compliance Intelligence panel →
+ *   Filter strip → Search bar → Status pills → accordion shell.
+ * Each slot is sized to the post-boot height so positions are stable.
+ */
+function TrackerSectionShell({ shellCategories }: { shellCategories: string[] }) {
+  return (
+    <>
+      {/* Title row: "Regulatory Timeline" + view switcher */}
+      <div className="flex items-center justify-between mb-4 sm:mb-6 flex-wrap gap-3">
+        <div>
+          <h2 className="text-2xl sm:text-3xl font-light text-white">Regulatory Timeline</h2>
+          <p className="text-gray-400 text-sm mt-1">
+            Keep track of upcoming tax and compliance deadlines.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {['List', 'Calendar', 'Refresh', 'Add Compliance', 'Sync Calendar'].map((label) => (
+            <div
+              key={label}
+              className="h-9 px-3 sm:px-4 rounded-lg border border-white/10 bg-white/[0.03] flex items-center gap-2"
+            >
+              <div className="w-3 h-3 rounded bg-white/10 animate-pulse" />
+              <span className="text-xs sm:text-sm text-gray-500">{label}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Country line */}
+      <div className="text-sm text-gray-500 mb-4">
+        <span className="text-gray-600">Country:</span> India
+      </div>
+
+      {/* Compliance Intelligence panel slot — matches the real panel's
+          ~120px footprint */}
+      <div className="mb-4 h-[120px] sm:h-[140px] rounded-2xl border border-white/10 bg-white/[0.02] animate-pulse" />
+
+      {/* Filter strip slot — 4 dropdown placeholders */}
+      <div className="flex items-center gap-2 mb-4 flex-wrap">
+        {['FY', 'All Months', 'All Quarters', 'All Categories'].map((label) => (
+          <div
+            key={label}
+            className="h-10 px-3 rounded-lg border border-white/10 bg-white/[0.03] flex items-center gap-2"
+          >
+            <span className="text-sm text-gray-500">{label}</span>
+            <div className="w-3 h-3 rounded bg-white/10 animate-pulse" />
+          </div>
+        ))}
+      </div>
+
+      {/* Search bar */}
+      <div className="h-12 mb-4 rounded-lg border border-white/10 bg-white/[0.03] flex items-center px-4">
+        <span className="text-sm text-gray-600">Search requirements, categories, descriptions…</span>
+      </div>
+
+      {/* Status pills strip */}
+      <div className="flex items-center gap-2 mb-4 overflow-x-auto pb-1">
+        {['All', 'Overdue', 'Critical', 'Pending', 'Upcoming', 'Completed'].map((label) => (
+          <div
+            key={label}
+            className="h-8 px-3 rounded-lg border border-white/10 bg-white/[0.03] flex items-center gap-2 flex-shrink-0"
+          >
+            <span className="text-xs text-gray-500">{label}</span>
+            <div className="w-5 h-3 rounded-full bg-white/5 animate-pulse" />
+          </div>
+        ))}
+      </div>
+
+      {/* Tracker accordion — same component as post-boot, status="loading" */}
+      <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl shadow-2xl overflow-hidden">
+        {/* The shell uses a hidden mobile path so the categories appear
+            on every breakpoint — mirrors the post-boot wrapper. */}
+        <div className="p-3 sm:p-4">
+          <TrackerCategoryAccordionView
+            status="loading"
+            shellCategories={shellCategories}
+            // The remaining props are required by the type but unused
+            // when status === 'loading'. Pass safe no-op defaults.
+            groupedByCategory={[]}
+            filteredRequirements={[]}
+            canEdit={false}
+            vaultDocuments={[]}
+            selectedRequirements={new Set()}
+            setSelectedRequirements={() => {}}
+            handleStatusChange={async () => {}}
+            regulatoryService={null as any}
+            currentCompany={null}
+            setHiddenCompliances={() => {}}
+            setRegulatoryRequirements={() => {}}
+            regulatoryRequirements={[]}
+            setEditingRequirement={() => {}}
+            setRequirementForm={() => {}}
+            setIsEditModalOpen={() => {}}
+            setComplianceDetailsModal={() => {}}
+            setDocumentUploadModal={() => {}}
+            calculateDelay={() => null}
+            calculatePenalty={() => '-'}
+            getFormFrequency={() => null}
+            getRelevantLegalSections={() => []}
+            getAuthorityForCategory={() => null}
+          />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/data-room/page.tsx
+++ b/app/data-room/page.tsx
@@ -19,6 +19,7 @@ import React from "react";
 const TrackerTab = lazy(() => import("./components/tracker/TrackerTab"));
 const DocumentsTab = lazy(() => import("./components/DocumentsTab"));
 const CIAWidget = lazy(() => import("./components/cia/CIAWidget"));
+import DataRoomBootShell from "./components/DataRoomBootShell";
 const AgentAssistedUploadModalLazy = lazy(() => import("./components/AgentAssistedUploadModal"));
 const ReportsTab = lazy(() => import("./components/ReportsTab"));
 const OverviewTab = lazy(() => import("./components/OverviewTab"));
@@ -28,9 +29,6 @@ const DscDinTab = lazy(() => import("./components/DscDinTab"));
 import Header from "@/components/layout/Header";
 import CompanySelector from "@/components/features/CompanySelector";
 import SubtleCircuitBackground from "@/components/ui/SubtleCircuitBackground";
-import { OverviewStatsSkeleton } from "@/components/ui/skeletons/OverviewStatsSkeleton";
-import { useRotatingLoadingMessage } from "@/hooks/useRotatingLoadingMessage";
-import { DATA_ROOM_LOADING_MESSAGES } from "@/lib/ui/loading-messages";
 import { RequirementTableSkeleton } from "@/components/ui/skeletons/RequirementRowSkeleton";
 import { createClient } from "@/utils/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
@@ -231,14 +229,7 @@ function DataRoomPageInner() {
   const [isDataRoomInitLoading, setIsDataRoomInitLoading] = useState(true);
   const [isCompanySwitching, setIsCompanySwitching] = useState(false);
   const [initError, setInitError] = useState<string | null>(null);
-  // Loading message during /data-room boot. Sourced from the shared
-  // catalog so messaging is consistent with the other major skeleton
-  // states (Create Company, Documents tab, Compliance tracker).
-  const loadingMessage = useRotatingLoadingMessage({
-    active: isDataRoomInitLoading,
-    messages: DATA_ROOM_LOADING_MESSAGES,
-  })
-  
+
   const [entityDetails, setEntityDetails] = useState<EntityDetails | null>(
     null,
   );
@@ -3940,68 +3931,14 @@ function DataRoomPageInner() {
   ];
 
   // --- Consolidated Rendering Logic ---
-  
-  // 1. Initial boot: Show dynamic loading messages
+
+  // 1. Initial boot: render the page-layout shell.
+  //    The shell mirrors the post-boot DOM (Header → main container →
+  //    company-card slot → "Data Room" → tab strip → tracker accordion
+  //    shell). When the gate flips, the populated tree drops into the
+  //    same DOM positions — no pop-in, no layout shift.
   if (isDataRoomInitLoading || (authLoading && !user)) {
-    return (
-      <div className="min-h-screen bg-primary-dark">
-        <Header />
-        <div className="container mx-auto px-4 py-8 space-y-6 max-w-7xl">
-          {/* Cinematic loading banner — pulsing radar dot + rotating
-              futuristic message above the skeletons. The key on the
-              text element forces a fade-in transition each time the
-              message rotates so the eye is drawn to the new line. */}
-          <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-white/[0.03] via-transparent to-blue-500/[0.04] px-5 py-6 sm:px-7 sm:py-7">
-            {/* Animated scanline accent */}
-            <div className="pointer-events-none absolute inset-0 opacity-[0.07]">
-              <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white to-transparent animate-[boot-scan_3s_linear_infinite]" />
-            </div>
-            <div className="flex items-center gap-4">
-              {/* Radar dot */}
-              <div className="relative flex h-3 w-3 flex-shrink-0">
-                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-emerald-400 opacity-60" />
-                <span className="relative inline-flex h-3 w-3 rounded-full bg-emerald-500" />
-              </div>
-              <div className="flex-1 min-w-0">
-                <div className="text-[10px] uppercase tracking-[0.2em] text-emerald-400/80 font-medium mb-1">
-                  System • Booting Data Room
-                </div>
-                <div
-                  key={loadingMessage}
-                  className="text-sm sm:text-base font-light text-white/90 truncate animate-[boot-fade_0.5s_ease-out]"
-                >
-                  {loadingMessage}
-                </div>
-              </div>
-            </div>
-            <style jsx>{`
-              @keyframes boot-fade {
-                from { opacity: 0; transform: translateX(-6px); }
-                to { opacity: 1; transform: translateX(0); }
-              }
-              @keyframes boot-scan {
-                0% { transform: translateY(0); }
-                100% { transform: translateY(120px); }
-              }
-            `}</style>
-          </div>
-          {/* Skeleton company selector strip */}
-          <div className="flex gap-3 overflow-hidden">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <div key={i} className="h-10 w-36 animate-pulse rounded-xl bg-white/5 flex-shrink-0" />
-            ))}
-          </div>
-          {/* Skeleton tab strip */}
-          <div className="flex gap-2">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <div key={i} className="h-9 w-24 animate-pulse rounded-lg bg-white/5" />
-            ))}
-          </div>
-          {/* Skeleton main content */}
-          <OverviewStatsSkeleton />
-        </div>
-      </div>
-    );
+    return <DataRoomBootShell activeTab={activeTab} countryCode={countryCode || 'IN'} />;
   }
 
   // 2. Initialization Error


### PR DESCRIPTION
## Why
PR #68 fixed the tracker accordion's pop-in but had no measurable cold-load impact — verified by instrumented trace, the actual gate is the page-level early-return at \`page.tsx:3945\`. The cinematic \"Booting Data Room\" screen rendered a structurally-different DOM (radar banner + skeleton company strip + skeleton tab buttons + \`OverviewStatsSkeleton\`); when it flipped to the populated tree, every section moved.

## What
- New \`DataRoomBootShell\` component renders the SAME outer DOM as the post-boot data-room (Header → main container → company-card slot → \"Data Room\" title → tab strip → active-tab content). Each data-dependent slot is replaced by a real-dimensioned skeleton.
- The active-tab content shell mirrors the tracker view: \"Regulatory Timeline\" title row + view-switch buttons + Compliance Intelligence panel slot + filter strip + search bar + status pills + the tracker accordion shell from PR #68.
- The page-level early-return now renders \`<DataRoomBootShell activeTab={activeTab} countryCode={countryCode || 'IN'} />\`. When the gate flips, the populated tree lands in the same DOM positions — no pop-in.
- Drops dead imports: \`useRotatingLoadingMessage\`, \`DATA_ROOM_LOADING_MESSAGES\`, \`OverviewStatsSkeleton\`.

## What this is NOT
- Not a CSS animation. The boot tree previously snapped to the populated tree because they had different DOM. Now they have aligned DOM.
- No new schema, no new server work. Uses static \`COUNTRY_CONFIGS[countryCode].compliance.defaultCategories\` (already in repo via PR #68).

## Result (expected)
- Cold-load: from t≈0 ms the user sees the actual page layout — Header, company picker slot, \"Data Room\", tab strip with the active tab visually selected, \"Regulatory Timeline\", and the 6–7 tracker category cards as a shell.
- When data lands, the same DOM positions populate — count chips swap shimmer→number, intelligence panel populates, etc. CLS ≈ 0.
- Cinematic \"Booting Data Room\" radar banner is gone.

## Test plan
- [ ] Cold sign-in → first paint shows the layout-aligned shell (no \"Booting Data Room\" banner). Tracker tab shows 6–7 category cards with shimmer count chips.
- [ ] When data arrives, no card-position shift; only counts and inner content populate.
- [ ] Active-tab preservation: if URL is \`?tab=overview\`, the shell highlights the Overview tab.
- [ ] Mobile (<640 px) renders without overflow.
- [ ] \`tsc --noEmit\` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)