### PR TITLE
feat(ingest): extract smart-ingest service — foundation for unified upload (PR A)

### DIFF
--- a/app/data-room/actions-document-agent.ts
+++ b/app/data-room/actions-document-agent.ts
@@ -2,14 +2,12 @@
 
 import { createServerContainer } from '@/lib/composition/server-container'
 import { handleActionError } from '@/lib/errors/handle-error'
-import { validateCompanyId, sanitizeStringInput } from '@/lib/utils/input-validation'
+import { validateCompanyId } from '@/lib/utils/input-validation'
 import { prisma } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
-import { analyzeAndStoreSuggestion, type DocumentAgentSuggestion } from '@/lib/compliance/document-agent'
-import { recordFact, currentIndianFY } from '@/lib/compliance/facts'
-import { ensureSystemFolders, getSystemFolderId } from '@/lib/vault/folders'
-import { generateEmbedding } from '@/lib/utils/embeddings'
-import { upsertFiling } from '@/lib/compliance/filings'
+import { type DocumentAgentSuggestion } from '@/lib/compliance/document-agent'
+import { getSystemFolderId } from '@/lib/vault/folders'
+import { analyzeAndDraft, finalizeIngestion } from '@/lib/compliance/smart-ingest'
 
 async function assertCompanyAccess(companyId: string) {
   if (!validateCompanyId(companyId)) throw new Error('Invalid company ID')
@@ -62,43 +60,22 @@ export async function uploadAndAnalyze(
 }> {
   try {
     const { user } = await assertCompanyAccess(companyId)
-
-    const cleanName = sanitizeStringInput(input.fileName, 500)
-    const cleanPath = sanitizeStringInput(input.filePath, 1000)
-    if (!cleanName || !cleanPath) {
-      return { success: false, error: 'Invalid file name or path' }
-    }
-
-    await ensureSystemFolders(companyId)
-
-    const draft = await prisma.companyDocument.create({
-      data: {
-        company_id: companyId,
-        file_path: cleanPath,
-        file_name: cleanName,
-        is_draft: true,
-        is_latest: true,
-        created_by: user.id,
-      },
-      select: { id: true },
-    })
-
-    const analysis = await analyzeAndStoreSuggestion({
+    const result = await analyzeAndDraft({
       companyId,
-      documentId: draft.id,
+      userId: user.id,
+      filePath: input.filePath,
+      fileName: input.fileName,
     })
-
     console.log('[uploadAndAnalyze] ok', {
-      documentId: draft.id,
-      hasSuggestion: !!analysis.suggestion,
-      errors: analysis.errors,
+      documentId: result.documentId,
+      hasSuggestion: !!result.suggestion,
+      errors: result.errors,
     })
-
     return {
       success: true,
-      documentId: draft.id,
-      suggestion: analysis.suggestion,
-      analysisErrors: analysis.errors,
+      documentId: result.documentId,
+      suggestion: result.suggestion,
+      analysisErrors: result.errors,
     }
   } catch (error) {
     console.error('[uploadAndAnalyze] threw',
@@ -137,191 +114,17 @@ export async function finalizeDocument(
 ): Promise<{ success: boolean; documentId?: string; versionNumber?: number; error?: string }> {
   try {
     const { user } = await assertCompanyAccess(companyId)
-
-    const draft = await prisma.companyDocument.findFirst({
-      where: { id: documentId, company_id: companyId, deleted_at: null },
-      select: { id: true, is_draft: true, agent_suggestions: true, file_path: true, file_name: true },
+    const result = await finalizeIngestion({
+      companyId,
+      userId: user.id,
+      documentId,
+      confirmed,
     })
-    if (!draft) return { success: false, error: 'Draft not found' }
-
-    // Validate folder belongs to this company + get its name for legacy compat
-    const folder = await prisma.vaultFolder.findFirst({
-      where: { id: confirmed.folderId, company_id: companyId },
-      select: { id: true, name: true },
+    console.log('[finalizeDocument] ok', {
+      documentId: result.documentId,
+      versionNumber: result.versionNumber,
     })
-    if (!folder) return { success: false, error: 'Target folder not found' }
-
-    // Validate optional requirement id. Two separate ID spaces converge
-    // here and only the second one is writable:
-    //   - ComplianceRule.id is a stable slug like "dir3-kyc-annual" (plain
-    //     string). The agent returns THIS.
-    //   - CompanyDocument.requirement_id is typed @db.Uuid — it's meant
-    //     to point at a RegulatoryRequirement.id (UUID).
-    // Writing a slug into a UUID column blows up Prisma with
-    // "Error creating UUID, invalid character: found 'p' at 1".
-    //
-    // For now: accept only UUIDs. If the agent returns a rule slug, log
-    // it and null it out — the doc still saves, just without a formal
-    // link. (Proper fix will be a separate rule_id String? column on
-    // CompanyDocument that holds the slug natively.)
-    const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
-    if (confirmed.requirementId) {
-      if (!UUID_RE.test(confirmed.requirementId)) {
-        console.warn('[finalizeDocument] requirementId is not a UUID, clearing before save:', confirmed.requirementId)
-        confirmed.requirementId = undefined
-      } else {
-        // Confirm the UUID actually resolves to a RegulatoryRequirement
-        // row for this company; otherwise null it (stale / cross-company
-        // id shouldn't be saved either).
-        const req = await prisma.regulatoryRequirement.findFirst({
-          where: { id: confirmed.requirementId, company_id: companyId },
-          select: { id: true },
-        }).catch(() => null)
-        if (!req) {
-          console.warn('[finalizeDocument] requirementId UUID does not belong to this company, clearing:', confirmed.requirementId)
-          confirmed.requirementId = undefined
-        }
-      }
-    }
-
-    // Versioning — if supersedesDocumentId is set, mark the old doc
-    // is_latest = false and chain the new one. Do it BEFORE the finalize
-    // update so the version_number is correct.
-    let versionNumber = 1
-    let parentDocumentId: string | null = null
-    if (confirmed.supersedesDocumentId) {
-      const previous = await prisma.companyDocument.findFirst({
-        where: {
-          id: confirmed.supersedesDocumentId,
-          company_id: companyId,
-          deleted_at: null,
-        },
-        select: { id: true, version_number: true },
-      })
-      if (previous) {
-        versionNumber = (previous.version_number || 1) + 1
-        parentDocumentId = previous.id
-        await prisma.companyDocument.update({
-          where: { id: previous.id },
-          data: { is_latest: false, updated_at: new Date() },
-        })
-      }
-    }
-
-    const cleanDocType = sanitizeStringInput(confirmed.documentName, 500)
-    const cleanFileName = sanitizeStringInput(confirmed.fileName, 500)
-    if (!cleanDocType || !cleanFileName) {
-      return { success: false, error: 'Document name and file name are required' }
-    }
-
-    await prisma.companyDocument.update({
-      where: { id: draft.id },
-      data: {
-        is_draft: false,
-        agent_suggestions: Prisma.JsonNull,
-        document_type: cleanDocType,
-        file_name: cleanFileName,
-        folder_id: folder.id,
-        folder_name: folder.name,               // legacy field — vault UI still groups by this
-        period_type: confirmed.periodType ?? null,
-        period_financial_year: confirmed.periodFinancialYear ?? null,
-        period_key: confirmed.periodKey ?? null,
-        period_start: confirmed.periodStart ? new Date(confirmed.periodStart) : null,
-        period_end: confirmed.periodEnd ? new Date(confirmed.periodEnd) : null,
-        frequency: confirmed.frequency ?? null,
-        registration_date: confirmed.registrationDate ? new Date(confirmed.registrationDate) : null,
-        expiry_date: confirmed.expiryDate ? new Date(confirmed.expiryDate) : null,
-        requirement_id: confirmed.requirementId ?? null,
-        is_portal_required: confirmed.isPortalRequired ?? false,
-        portal_email: confirmed.portalEmail ?? null,
-        portal_password: confirmed.portalPassword ?? null,
-        parent_document_id: parentDocumentId,
-        version_number: versionNumber,
-        is_latest: true,
-        updated_at: new Date(),
-      },
-    })
-
-    // Refresh the pgvector embedding to reflect the confirmed name —
-    // Prisma doesn't type the Unsupported("vector") column so this goes
-    // via raw SQL. Wrap in try/catch so an embedding failure (Azure
-    // hiccup, pgvector cast edge case) can't fail the whole save after
-    // the user already clicked confirm.
-    try {
-      const embedding = await generateEmbedding(`${cleanDocType} ${cleanFileName}`)
-      if (embedding.length > 0) {
-        const vectorLiteral = `[${embedding.join(',')}]`
-        await prisma.$executeRaw`
-          UPDATE public.company_documents_internal
-          SET embedding = ${vectorLiteral}::vector
-          WHERE id = ${draft.id}::uuid
-        `
-      }
-    } catch (embedErr) {
-      console.error('[finalizeDocument] embedding refresh failed (non-fatal):',
-        embedErr instanceof Error ? embedErr.message : embedErr)
-    }
-
-    // Persist any facts the agent emitted — only the ones still backed
-    // by confirmed metadata (period must be present for the evaluator
-    // to use them).
-    if (confirmed.persistFacts !== false && draft.agent_suggestions) {
-      const suggestion = draft.agent_suggestions as unknown as DocumentAgentSuggestion
-      if (Array.isArray(suggestion?.facts)) {
-        for (const f of suggestion.facts) {
-          try {
-            await recordFact({
-              companyId,
-              kind: f.kind,
-              periodStart: new Date(f.periodStart),
-              periodEnd: new Date(f.periodEnd),
-              amount: typeof f.amount === 'number' ? f.amount : null,
-              unit: f.unit ?? null,
-              payload: { ...(f.payload as any || {}), evidenceQuote: f.evidenceQuote ?? null },
-              counterparty: f.counterparty ?? null,
-              sourceKind: 'document_extracted',
-              sourceDocId: draft.id,
-              confidence: f.confidence,
-              createdBy: user.id,
-            })
-          } catch (factErr) {
-            console.error('[finalizeDocument] fact persist failed (non-fatal):',
-              factErr instanceof Error ? factErr.message : factErr)
-          }
-        }
-      }
-    }
-
-    // Step 5.1: Vault → Tracker wiring. If the doc is linked to a
-    // compliance rule + has a period, auto-upsert the matching filing
-    // row so the tracker reflects the upload immediately.
-    if (confirmed.requirementId && (confirmed.periodKey || confirmed.periodFinancialYear)) {
-      try {
-        const fy = confirmed.periodFinancialYear || currentIndianFY()
-        const pk = confirmed.periodKey || fy
-        await upsertFiling({
-          companyId,
-          ruleId: confirmed.requirementId,
-          periodKey: pk,
-          financialYear: fy,
-          data: {
-            status: 'filed',
-            dateOfFiling: confirmed.registrationDate || new Date().toISOString().slice(0, 10),
-            documentId: draft.id,
-            acknowledgement: null,
-            dueDate: null,
-          },
-          updatedBy: user.id,
-        })
-        console.log('[finalizeDocument] filing upserted', { ruleId: confirmed.requirementId, periodKey: pk })
-      } catch (filingErr) {
-        console.error('[finalizeDocument] filing upsert failed (non-fatal):',
-          filingErr instanceof Error ? filingErr.message : filingErr)
-      }
-    }
-
-    console.log('[finalizeDocument] ok', { documentId: draft.id, versionNumber })
-    return { success: true, documentId: draft.id, versionNumber }
+    return { success: true, documentId: result.documentId, versionNumber: result.versionNumber }
   } catch (error) {
     console.error('[finalizeDocument] threw',
       error instanceof Error ? error.message : String(error),

--- a/lib/compliance/smart-ingest.ts
+++ b/lib/compliance/smart-ingest.ts
@@ -1,0 +1,295 @@
+/**
+ * Smart-ingest service — the single, reusable pipeline for ingesting an
+ * uploaded document and producing structured metadata + tracker linkage.
+ *
+ * This is the foundation for unifying upload across:
+ *   • tracker upload (calls it synchronously today, surfaces a confirm UI)
+ *   • vault upload   (PR B will call it asynchronously from a queue)
+ *   • onboarding     (PR D will call it asynchronously for cert files)
+ *
+ * The service is auth-agnostic on purpose. Callers are responsible for
+ * verifying the user has access to `companyId` BEFORE invoking. Every
+ * function takes an explicit `userId` so it can record provenance
+ * without reaching for auth context. This makes the service callable
+ * from server actions, cron workers, and tests alike.
+ *
+ * The two entry points mirror the two-step "draft → confirm" UX:
+ *   1. `analyzeAndDraft`   — create the draft row, run AI extraction,
+ *                            stash the suggestion. Idempotent at the
+ *                            row level (only one draft per file path).
+ *   2. `finalizeIngestion` — persist confirmed metadata, embedding,
+ *                            facts, and tracker filing link.
+ *
+ * PR A: behaviour-preserving extraction. Tracker upload still calls
+ * the same code paths via thin server-action wrappers — no functional
+ * change. PR B/C/D will add: requirement auto-resolution, missing-period
+ * auto-generation, and async progress tracking.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { Prisma } from '@prisma/client'
+import { analyzeAndStoreSuggestion, type DocumentAgentSuggestion } from '@/lib/compliance/document-agent'
+import { recordFact, currentIndianFY } from '@/lib/compliance/facts'
+import { ensureSystemFolders } from '@/lib/vault/folders'
+import { generateEmbedding } from '@/lib/utils/embeddings'
+import { upsertFiling } from '@/lib/compliance/filings'
+import { sanitizeStringInput } from '@/lib/utils/input-validation'
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+
+export interface AnalyzeAndDraftInput {
+  companyId: string
+  userId: string
+  filePath: string
+  fileName: string
+}
+
+export interface AnalyzeAndDraftResult {
+  documentId: string
+  suggestion: DocumentAgentSuggestion | null
+  errors: string[]
+}
+
+/**
+ * Stage 1: create draft → run AI extraction → return suggestion.
+ *
+ * Never throws on AI failure. If the agent times out, the draft still
+ * exists and the caller can surface a "manual entry" path. Errors are
+ * accumulated in the returned `errors` array.
+ */
+export async function analyzeAndDraft(input: AnalyzeAndDraftInput): Promise<AnalyzeAndDraftResult> {
+  const cleanName = sanitizeStringInput(input.fileName, 500)
+  const cleanPath = sanitizeStringInput(input.filePath, 1000)
+  if (!cleanName || !cleanPath) {
+    throw new Error('Invalid file name or path')
+  }
+
+  await ensureSystemFolders(input.companyId)
+
+  const draft = await prisma.companyDocument.create({
+    data: {
+      company_id: input.companyId,
+      file_path: cleanPath,
+      file_name: cleanName,
+      is_draft: true,
+      is_latest: true,
+      created_by: input.userId,
+    },
+    select: { id: true },
+  })
+
+  const analysis = await analyzeAndStoreSuggestion({
+    companyId: input.companyId,
+    documentId: draft.id,
+  })
+
+  return {
+    documentId: draft.id,
+    suggestion: analysis.suggestion,
+    errors: analysis.errors,
+  }
+}
+
+export interface FinalizeIngestionInput {
+  companyId: string
+  userId: string
+  documentId: string
+  confirmed: {
+    documentName: string
+    fileName: string
+    folderId: string
+    periodType?: 'one-time' | 'monthly' | 'quarterly' | 'annual'
+    periodFinancialYear?: string
+    periodKey?: string
+    periodStart?: string
+    periodEnd?: string
+    frequency?: string
+    registrationDate?: string
+    expiryDate?: string
+    requirementId?: string
+    isPortalRequired?: boolean
+    portalEmail?: string
+    portalPassword?: string
+    supersedesDocumentId?: string
+    persistFacts?: boolean
+  }
+}
+
+export interface FinalizeIngestionResult {
+  documentId: string
+  versionNumber: number
+}
+
+/**
+ * Stage 2: write confirmed metadata to the draft, refresh embedding,
+ * persist agent-emitted facts, and (if requirement+period are set)
+ * upsert the matching ComplianceFiling row to wire vault → tracker.
+ *
+ * All side-effects after the main update (embedding, facts, filing)
+ * are wrapped in try/catch — they MUST NOT fail the save after the
+ * user already clicked confirm. Errors logged, not thrown.
+ */
+export async function finalizeIngestion(input: FinalizeIngestionInput): Promise<FinalizeIngestionResult> {
+  const { companyId, userId, documentId, confirmed } = input
+
+  const draft = await prisma.companyDocument.findFirst({
+    where: { id: documentId, company_id: companyId, deleted_at: null },
+    select: { id: true, is_draft: true, agent_suggestions: true, file_path: true, file_name: true },
+  })
+  if (!draft) throw new Error('Draft not found')
+
+  const folder = await prisma.vaultFolder.findFirst({
+    where: { id: confirmed.folderId, company_id: companyId },
+    select: { id: true, name: true },
+  })
+  if (!folder) throw new Error('Target folder not found')
+
+  // Two ID spaces converge here. ComplianceRule.id is a slug
+  // ("dir3-kyc-annual"). CompanyDocument.requirement_id is @db.Uuid
+  // pointing at RegulatoryRequirement.id. Writing a slug into the UUID
+  // column blows up Prisma. Accept only UUIDs that resolve to a row
+  // owned by this company; clear otherwise.
+  let requirementId = confirmed.requirementId
+  if (requirementId) {
+    if (!UUID_RE.test(requirementId)) {
+      console.warn('[smart-ingest] requirementId is not a UUID, clearing:', requirementId)
+      requirementId = undefined
+    } else {
+      const req = await prisma.regulatoryRequirement.findFirst({
+        where: { id: requirementId, company_id: companyId },
+        select: { id: true },
+      }).catch(() => null)
+      if (!req) {
+        console.warn('[smart-ingest] requirementId UUID not in this company, clearing:', requirementId)
+        requirementId = undefined
+      }
+    }
+  }
+
+  // Versioning — chain new doc as a new version of supersedes target.
+  let versionNumber = 1
+  let parentDocumentId: string | null = null
+  if (confirmed.supersedesDocumentId) {
+    const previous = await prisma.companyDocument.findFirst({
+      where: {
+        id: confirmed.supersedesDocumentId,
+        company_id: companyId,
+        deleted_at: null,
+      },
+      select: { id: true, version_number: true },
+    })
+    if (previous) {
+      versionNumber = (previous.version_number || 1) + 1
+      parentDocumentId = previous.id
+      await prisma.companyDocument.update({
+        where: { id: previous.id },
+        data: { is_latest: false, updated_at: new Date() },
+      })
+    }
+  }
+
+  const cleanDocType = sanitizeStringInput(confirmed.documentName, 500)
+  const cleanFileName = sanitizeStringInput(confirmed.fileName, 500)
+  if (!cleanDocType || !cleanFileName) {
+    throw new Error('Document name and file name are required')
+  }
+
+  await prisma.companyDocument.update({
+    where: { id: draft.id },
+    data: {
+      is_draft: false,
+      agent_suggestions: Prisma.JsonNull,
+      document_type: cleanDocType,
+      file_name: cleanFileName,
+      folder_id: folder.id,
+      folder_name: folder.name,
+      period_type: confirmed.periodType ?? null,
+      period_financial_year: confirmed.periodFinancialYear ?? null,
+      period_key: confirmed.periodKey ?? null,
+      period_start: confirmed.periodStart ? new Date(confirmed.periodStart) : null,
+      period_end: confirmed.periodEnd ? new Date(confirmed.periodEnd) : null,
+      frequency: confirmed.frequency ?? null,
+      registration_date: confirmed.registrationDate ? new Date(confirmed.registrationDate) : null,
+      expiry_date: confirmed.expiryDate ? new Date(confirmed.expiryDate) : null,
+      requirement_id: requirementId ?? null,
+      is_portal_required: confirmed.isPortalRequired ?? false,
+      portal_email: confirmed.portalEmail ?? null,
+      portal_password: confirmed.portalPassword ?? null,
+      parent_document_id: parentDocumentId,
+      version_number: versionNumber,
+      is_latest: true,
+      updated_at: new Date(),
+    },
+  })
+
+  // Embedding refresh — non-fatal.
+  try {
+    const embedding = await generateEmbedding(`${cleanDocType} ${cleanFileName}`)
+    if (embedding.length > 0) {
+      const vectorLiteral = `[${embedding.join(',')}]`
+      await prisma.$executeRaw`
+        UPDATE public.company_documents_internal
+        SET embedding = ${vectorLiteral}::vector
+        WHERE id = ${draft.id}::uuid
+      `
+    }
+  } catch (embedErr) {
+    console.error('[smart-ingest] embedding refresh failed (non-fatal):',
+      embedErr instanceof Error ? embedErr.message : embedErr)
+  }
+
+  // Persist agent-emitted facts — non-fatal per fact.
+  if (confirmed.persistFacts !== false && draft.agent_suggestions) {
+    const suggestion = draft.agent_suggestions as unknown as DocumentAgentSuggestion
+    if (Array.isArray(suggestion?.facts)) {
+      for (const f of suggestion.facts) {
+        try {
+          await recordFact({
+            companyId,
+            kind: f.kind,
+            periodStart: new Date(f.periodStart),
+            periodEnd: new Date(f.periodEnd),
+            amount: typeof f.amount === 'number' ? f.amount : null,
+            unit: f.unit ?? null,
+            payload: { ...(f.payload as any || {}), evidenceQuote: f.evidenceQuote ?? null },
+            counterparty: f.counterparty ?? null,
+            sourceKind: 'document_extracted',
+            sourceDocId: draft.id,
+            confidence: f.confidence,
+            createdBy: userId,
+          })
+        } catch (factErr) {
+          console.error('[smart-ingest] fact persist failed (non-fatal):',
+            factErr instanceof Error ? factErr.message : factErr)
+        }
+      }
+    }
+  }
+
+  // Vault → Tracker wiring: requirement + period set → upsert filing.
+  if (requirementId && (confirmed.periodKey || confirmed.periodFinancialYear)) {
+    try {
+      const fy = confirmed.periodFinancialYear || currentIndianFY()
+      const pk = confirmed.periodKey || fy
+      await upsertFiling({
+        companyId,
+        ruleId: requirementId,
+        periodKey: pk,
+        financialYear: fy,
+        data: {
+          status: 'filed',
+          dateOfFiling: confirmed.registrationDate || new Date().toISOString().slice(0, 10),
+          documentId: draft.id,
+          acknowledgement: null,
+          dueDate: null,
+        },
+        updatedBy: userId,
+      })
+    } catch (filingErr) {
+      console.error('[smart-ingest] filing upsert failed (non-fatal):',
+        filingErr instanceof Error ? filingErr.message : filingErr)
+    }
+  }
+
+  return { documentId: draft.id, versionNumber }
+}


### PR DESCRIPTION
## Why
First in a chain of 4 PRs unifying smart upload across **tracker / vault / onboarding**, with auto-generation of historical compliances when an uploaded doc covers a period that has no matching tracker requirement (e.g. 2024 GSTR-3B uploaded into a tracker that only has 2026 generated).

The tracker upload is already smart — AI extraction, folder routing, period mapping, fact persistence, requirement linking, ComplianceFiling upsert. Vault upload and onboarding cert upload are dumb passthroughs. The chain unifies them around a single service.

## Scope of PR A
**Foundation only — zero behaviour change at the tracker.**

- New: \`lib/compliance/smart-ingest.ts\` — auth-agnostic service exposing \`analyzeAndDraft\` and \`finalizeIngestion\`.
- Refactored: \`app/data-room/actions-document-agent.ts\` — \`uploadAndAnalyze\` and \`finalizeDocument\` are now ~20 lines each, calling the shared service after auth.
- Same DB writes: CompanyDocument metadata, pgvector embedding refresh, agent-emitted facts, ComplianceFiling upsert.
- Same error handling: non-fatal try/catch around embedding / facts / filing so a confirmation save never half-fails.

## Coming next
- **PR B**: \`document_ingest_jobs\` queue table + Supabase Cron worker. Vault upload completes immediately as dumb storage, enqueues a job. Per-document progress bar (Uploading → Extracting → Matching → Linked / Needs review). Concurrency: 3 per company. \"Review pending\" surface for unmatched.
- **PR C**: Auto-generate historical compliances inside the service when extracted period has no matching requirement. Silent with undo chip.
- **PR D**: Onboarding cert OCR via the same queue. \`companyFact\` rows back-fill (typed form values still win).

## Test plan
- [ ] Tracker upload still works end-to-end: agent suggestion appears, confirm modal opens, save completes, document appears in vault folder, ComplianceFiling row created.
- [ ] \`tsc --noEmit\` clean (verified locally).
- [ ] No new server round-trips, no new latency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized document upload and analysis workflows to improve consistency and reliability.
  * Enhanced validation and metadata handling during document finalization and filing operations.
  * Improved error isolation in document processing to prevent side effects from blocking confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->