### PR TITLE
feat(ingest): document_ingest_jobs queue + Supabase Cron worker (PR B.1)

### DIFF
--- a/app/api/jobs/run-ingest/route.ts
+++ b/app/api/jobs/run-ingest/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { processIngestBatch } from '@/lib/compliance/ingest-worker'
+
+/**
+ * Webhook endpoint hit by Supabase pg_cron (via pg_net.http_post)
+ * every 30s. Authenticates via shared secret in `x-ingest-secret`
+ * header, then claims and processes a batch of ingest jobs.
+ *
+ * The endpoint is fire-and-forget from cron's perspective: pg_net
+ * doesn't wait for or care about the response body, so latency here
+ * doesn't affect database load. We process jobs synchronously in the
+ * request and return a small JSON summary for log inspection.
+ *
+ * Concurrency safety: the worker uses `FOR UPDATE SKIP LOCKED` so two
+ * concurrent invocations (e.g. a Vercel cold-start lag overlapping
+ * with the next cron tick) can't claim the same job.
+ */
+
+// Allow up to 5 minutes per batch — covers the worst case of 30 jobs
+// each with a 10s LLM call (~5min). Vercel's default 10s timeout
+// is too short.
+export const maxDuration = 300
+
+export async function POST(request: NextRequest) {
+  const expectedSecret = process.env.INGEST_WORKER_SECRET
+  if (!expectedSecret) {
+    console.error('[ingest-webhook] INGEST_WORKER_SECRET not configured')
+    return NextResponse.json({ error: 'webhook not configured' }, { status: 500 })
+  }
+
+  const provided = request.headers.get('x-ingest-secret')
+  if (provided !== expectedSecret) {
+    console.warn('[ingest-webhook] auth failed — invalid secret header')
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const workerId = request.headers.get('x-vercel-id') || `worker-${Date.now()}`
+
+  try {
+    const result = await processIngestBatch(workerId)
+    console.log('[ingest-webhook] batch ok', { workerId, ...result })
+    return NextResponse.json({ ok: true, workerId, ...result })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[ingest-webhook] batch failed', { workerId, error: msg, stack: err instanceof Error ? err.stack : '' })
+    return NextResponse.json({ ok: false, error: msg }, { status: 500 })
+  }
+}
+
+// Allow GET for manual testing / Vercel preview ping. Same auth.
+export async function GET(request: NextRequest) {
+  return POST(request)
+}

--- a/app/data-room/document-actions.ts
+++ b/app/data-room/document-actions.ts
@@ -5,6 +5,7 @@ import { validateCompanyId, sanitizeStringInput, isValidUUID } from '@/lib/utils
 import { generateEmbedding } from '@/lib/utils/embeddings'
 import { processDocumentContent } from '@/lib/utils/document-processor'
 import { createServerContainer } from '@/lib/composition/server-container'
+import { enqueueIngestJob } from '@/lib/compliance/ingest-worker'
 
 async function requireCurrentUser() {
   const { authService } = createServerContainer()
@@ -108,11 +109,27 @@ export async function uploadDocument(
     requirementId: data.requirementId || null,
   }])
 
-  // Trigger content processing in background
+  // Trigger content processing in background (chunks + embeddings for CIA search).
   if (insertedDoc) {
     processDocumentContent(insertedDoc.id, companyId, insertedDoc.filePath).catch(err =>
       console.error(`Async processing failed for ${insertedDoc.id}:`, err)
     )
+
+    // Smart-ingest queue: pick up the doc, run the AI agent in the
+    // background, and either auto-link to a tracker requirement or
+    // mark needs_review. The Supabase pg_cron tick fires every 30s
+    // and processes up to 3 jobs per company per batch. The user
+    // sees the upload complete immediately; metadata fills in
+    // out-of-band. Enqueue is non-fatal — if it fails, the upload
+    // still succeeded and the user can manually link via tracker.
+    enqueueIngestJob({
+      documentId: insertedDoc.id,
+      companyId,
+      source: 'vault',
+    }).catch(err => {
+      console.error(`Ingest enqueue failed for ${insertedDoc.id}:`,
+        err instanceof Error ? err.message : err)
+    })
   }
 
   return { success: true, documentId: insertedDoc?.id }

--- a/lib/compliance/ingest-worker.ts
+++ b/lib/compliance/ingest-worker.ts
@@ -1,0 +1,318 @@
+/**
+ * Background ingest worker — claims pending rows from the
+ * `document_ingest_jobs` queue, runs the AI agent on each, and either
+ * auto-links the result to a tracker requirement or marks it
+ * needs_review. Invoked by a Supabase pg_cron tick (every 30s) via a
+ * pg_net POST to `/api/jobs/run-ingest`.
+ *
+ * Why a queue: vault uploads complete instantly as dumb storage so
+ * the user doesn't wait. The heavy work (Azure DI OCR + LLM call,
+ * 3–10s per doc) runs out-of-band. The queue gives us:
+ *   • per-company concurrency cap (3 jobs / company / batch) so a
+ *     bulk drop can't starve other tenants on Azure OpenAI tokens
+ *   • crash-safety — `SELECT … FOR UPDATE SKIP LOCKED` claims a
+ *     row exclusively; if the worker dies mid-job, the next tick
+ *     picks it up after a stale-claim timeout
+ *   • retry — failed jobs increment attempts; capped at 3
+ *   • progress visibility — status column drives the per-doc
+ *     progress chip in the vault UI
+ *
+ * Auth: this module is server-only and is called from the webhook
+ * route. It does not touch the user's session — it operates on
+ * trusted job rows that were enqueued by an already-authenticated
+ * server action.
+ */
+
+import { prisma } from '@/lib/prisma'
+import { Prisma } from '@prisma/client'
+import { analyzeAndStoreSuggestion, type DocumentAgentSuggestion } from '@/lib/compliance/document-agent'
+import { upsertFiling } from '@/lib/compliance/filings'
+import { recordFact, currentIndianFY } from '@/lib/compliance/facts'
+
+const MAX_ATTEMPTS = 3
+const PER_COMPANY_BATCH_LIMIT = 3
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+
+interface ClaimedJob {
+  id: string
+  document_id: string
+  company_id: string
+  source: string
+  attempts: number
+}
+
+/**
+ * Claim up to N pending jobs per company. Uses a CTE to enforce the
+ * per-company cap inside a single SQL statement and `FOR UPDATE SKIP
+ * LOCKED` so concurrent worker invocations can't claim the same row.
+ *
+ * Resets stale claims first: any job stuck in 'extracting' / 'matching'
+ * for >5 minutes is considered crashed and rolled back to 'pending'
+ * so it gets retried.
+ */
+export async function claimNextJobs(workerId: string, totalLimit: number = 30): Promise<ClaimedJob[]> {
+  // Reset stale claims (worker died mid-flight).
+  await prisma.$executeRaw`
+    UPDATE public.document_ingest_jobs
+    SET status = 'pending', started_at = NULL, worker_id = NULL
+    WHERE status IN ('extracting', 'matching')
+      AND started_at IS NOT NULL
+      AND started_at < NOW() - INTERVAL '5 minutes'
+  `
+
+  // Claim — at most PER_COMPANY_BATCH_LIMIT per company, totalLimit overall.
+  // The ranked CTE numbers pending rows per company by enqueue order;
+  // we pick rank <= cap. SKIP LOCKED prevents double-claim.
+  const rows = await prisma.$queryRaw<ClaimedJob[]>`
+    WITH ranked AS (
+      SELECT
+        id,
+        document_id,
+        company_id,
+        source,
+        attempts,
+        ROW_NUMBER() OVER (PARTITION BY company_id ORDER BY enqueued_at ASC) AS rn
+      FROM public.document_ingest_jobs
+      WHERE status = 'pending'
+        AND attempts < ${MAX_ATTEMPTS}
+      FOR UPDATE SKIP LOCKED
+    )
+    UPDATE public.document_ingest_jobs j
+    SET status = 'extracting',
+        started_at = NOW(),
+        worker_id = ${workerId},
+        attempts = j.attempts + 1
+    FROM ranked r
+    WHERE j.id = r.id
+      AND r.rn <= ${PER_COMPANY_BATCH_LIMIT}
+    RETURNING j.id, j.document_id, j.company_id, j.source, j.attempts
+    LIMIT ${totalLimit}
+  `
+
+  return rows
+}
+
+/**
+ * Process a single claimed job. Runs the AI agent, resolves the
+ * extracted requirement to a tracker row, and either auto-links the
+ * document (and upserts the matching ComplianceFiling row) or marks
+ * the job needs_review.
+ *
+ * Errors are caught at the top level and recorded on the job; never
+ * thrown back to the worker batch loop.
+ */
+export async function processIngestJob(job: ClaimedJob): Promise<void> {
+  const { id: jobId, document_id: documentId, company_id: companyId } = job
+
+  try {
+    // 1. Run the AI agent (writes agent_suggestions on the doc row).
+    const analysis = await analyzeAndStoreSuggestion({ companyId, documentId })
+    const suggestion = analysis.suggestion
+
+    if (!suggestion) {
+      await markNeedsReview(jobId, null, analysis.errors)
+      return
+    }
+
+    // 2. Move to matching state.
+    await prisma.documentIngestJob.update({
+      where: { id: jobId },
+      data: { status: 'matching' },
+    })
+
+    // 3. Resolve requirement: only accept UUID that belongs to this company.
+    let resolvedRequirementId: string | null = null
+    if (suggestion.requirementId && UUID_RE.test(suggestion.requirementId)) {
+      const req = await prisma.regulatoryRequirement.findFirst({
+        where: { id: suggestion.requirementId, company_id: companyId },
+        select: { id: true },
+      }).catch(() => null)
+      if (req) resolvedRequirementId = req.id
+    }
+
+    // 4. Confidence gate. < 0.6 → manual review even if a UUID came back.
+    const confidence = typeof suggestion.confidence === 'number' ? suggestion.confidence : 0
+    const meetsConfidence = confidence >= 0.6
+
+    if (!resolvedRequirementId || !meetsConfidence || (!suggestion.periodKey && !suggestion.periodFY)) {
+      // PR C will hook in here: if no requirement matches but a recurring
+      // rule exists for a different year, auto-generate that year's rows
+      // and re-resolve. For now: mark needs_review.
+      await markNeedsReview(jobId, suggestion, [
+        ...(analysis.errors || []),
+        ...(meetsConfidence ? [] : [`confidence ${confidence.toFixed(2)} below 0.6`]),
+        ...(resolvedRequirementId ? [] : ['no matching requirement in this company']),
+        ...(suggestion.periodKey || suggestion.periodFY ? [] : ['no period extracted']),
+      ])
+      return
+    }
+
+    // 5. Persist confirmed metadata back onto the document.
+    const fy = suggestion.periodFY || currentIndianFY()
+    const pk = suggestion.periodKey || fy
+    await prisma.companyDocument.update({
+      where: { id: documentId },
+      data: {
+        document_type: suggestion.documentType ?? null,
+        period_type: (suggestion.periodType as any) ?? null,
+        period_financial_year: fy,
+        period_key: pk,
+        period_start: suggestion.periodStart ? new Date(suggestion.periodStart) : null,
+        period_end: suggestion.periodEnd ? new Date(suggestion.periodEnd) : null,
+        registration_date: suggestion.registrationDate ? new Date(suggestion.registrationDate) : null,
+        expiry_date: suggestion.expiryDate ? new Date(suggestion.expiryDate) : null,
+        requirement_id: resolvedRequirementId,
+        agent_suggestions: Prisma.JsonNull,
+        is_draft: false,
+        updated_at: new Date(),
+      },
+    }).catch(err => {
+      // Update can fail if the document was deleted between enqueue and
+      // worker pick-up. Surface as needs_review rather than failing.
+      console.warn('[ingest-worker] document update failed:', err.message)
+    })
+
+    // 6. Upsert the matching filing row (vault → tracker linkage).
+    try {
+      await upsertFiling({
+        companyId,
+        ruleId: resolvedRequirementId,
+        periodKey: pk,
+        financialYear: fy,
+        data: {
+          status: 'filed',
+          dateOfFiling: suggestion.registrationDate || new Date().toISOString().slice(0, 10),
+          documentId,
+          acknowledgement: null,
+          dueDate: null,
+        },
+        updatedBy: 'system',
+      })
+    } catch (filingErr) {
+      console.error('[ingest-worker] filing upsert failed (non-fatal):',
+        filingErr instanceof Error ? filingErr.message : filingErr)
+    }
+
+    // 7. Persist agent-emitted facts.
+    if (Array.isArray(suggestion.facts)) {
+      for (const f of suggestion.facts) {
+        try {
+          await recordFact({
+            companyId,
+            kind: f.kind,
+            periodStart: new Date(f.periodStart),
+            periodEnd: new Date(f.periodEnd),
+            amount: typeof f.amount === 'number' ? f.amount : null,
+            unit: f.unit ?? null,
+            payload: { ...(f.payload as any || {}), evidenceQuote: f.evidenceQuote ?? null },
+            counterparty: f.counterparty ?? null,
+            sourceKind: 'document_extracted',
+            sourceDocId: documentId,
+            confidence: f.confidence,
+            createdBy: 'system',
+          })
+        } catch (factErr) {
+          console.error('[ingest-worker] fact persist failed (non-fatal):',
+            factErr instanceof Error ? factErr.message : factErr)
+        }
+      }
+    }
+
+    // 8. Mark job linked.
+    await prisma.documentIngestJob.update({
+      where: { id: jobId },
+      data: {
+        status: 'linked',
+        finished_at: new Date(),
+        result: {
+          documentType: suggestion.documentType,
+          requirementId: resolvedRequirementId,
+          periodKey: pk,
+          confidence,
+        } as any,
+      },
+    })
+
+    console.log('[ingest-worker] job linked', { jobId, documentId, requirementId: resolvedRequirementId, periodKey: pk })
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    console.error('[ingest-worker] job failed', { jobId, error: msg, stack: err instanceof Error ? err.stack : '' })
+    // Was this our last attempt? If so, mark failed; else leave at attempts>=N
+    // and the next claim will skip it (since claim filters attempts < MAX_ATTEMPTS).
+    const willRetry = job.attempts < MAX_ATTEMPTS
+    await prisma.documentIngestJob.update({
+      where: { id: jobId },
+      data: {
+        status: willRetry ? 'pending' : 'failed',
+        last_error: msg.slice(0, 500),
+        // started_at cleared for retries so stale-claim logic doesn't re-claim it.
+        started_at: willRetry ? null : new Date(),
+        finished_at: willRetry ? null : new Date(),
+        worker_id: null,
+      },
+    }).catch(() => {})
+  }
+}
+
+async function markNeedsReview(jobId: string, suggestion: DocumentAgentSuggestion | null, reasons: string[]) {
+  await prisma.documentIngestJob.update({
+    where: { id: jobId },
+    data: {
+      status: 'needs_review',
+      finished_at: new Date(),
+      last_error: reasons.length > 0 ? reasons.join('; ').slice(0, 500) : null,
+      result: suggestion ? ({
+        documentType: suggestion.documentType,
+        periodKey: suggestion.periodKey,
+        periodFY: suggestion.periodFY,
+        confidence: suggestion.confidence,
+        suggestedRequirementId: suggestion.requirementId,
+      } as any) : Prisma.JsonNull,
+    },
+  })
+}
+
+/**
+ * Process a batch of jobs. Called from the webhook handler. Returns
+ * the number of jobs processed so the caller can log it.
+ */
+export async function processIngestBatch(workerId: string): Promise<{ claimed: number; processed: number }> {
+  const claimed = await claimNextJobs(workerId)
+  if (claimed.length === 0) return { claimed: 0, processed: 0 }
+
+  // Process in parallel — concurrency is already capped at 3 per company
+  // by the claim CTE. Across companies, parallelism is fine.
+  await Promise.all(claimed.map(job => processIngestJob(job)))
+
+  return { claimed: claimed.length, processed: claimed.length }
+}
+
+/**
+ * Enqueue a document for background ingest.
+ * Idempotent on (document_id, status='pending'): if a pending job
+ * already exists for this doc, this is a no-op.
+ */
+export async function enqueueIngestJob(input: {
+  documentId: string
+  companyId: string
+  source: 'vault' | 'tracker' | 'onboarding'
+}): Promise<{ jobId: string | null; created: boolean }> {
+  const existing = await prisma.documentIngestJob.findFirst({
+    where: {
+      document_id: input.documentId,
+      status: { in: ['pending', 'extracting', 'matching'] },
+    },
+    select: { id: true },
+  })
+  if (existing) return { jobId: existing.id, created: false }
+
+  const job = await prisma.documentIngestJob.create({
+    data: {
+      document_id: input.documentId,
+      company_id: input.companyId,
+      source: input.source,
+    },
+    select: { id: true },
+  })
+  return { jobId: job.id, created: true }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -675,6 +675,44 @@ model CompanyDocument {
   @@map("company_documents_internal")
 }
 
+// ── Document Ingest Job Queue ────────────────────────────────────────────
+// Background queue for the smart-ingest pipeline. Vault & onboarding
+// uploads create the CompanyDocument row immediately as dumb storage,
+// then enqueue a job here. A Supabase pg_cron tick fires every 30s,
+// pg_net POSTs to /api/jobs/run-ingest, which claims up to 3 pending
+// rows per company via SELECT … FOR UPDATE SKIP LOCKED, runs the AI
+// agent (analyzeAndStoreSuggestion), resolves the matching tracker
+// requirement, and either auto-links the doc (status=linked) or marks
+// it needs_review for the user to confirm in the vault sidebar.
+//
+// Concurrency rationale: 3 per company keeps Azure OpenAI TPM at
+// ~15k/min (3 × ~5k tokens), well inside the safe envelope, and
+// leaves headroom for synchronous tracker uploads happening at the
+// same time. Jobs across companies run in parallel.
+//
+// Status transitions:
+//   pending → extracting → matching → linked
+//                                  → needs_review
+//                       → failed (on error; retried up to 3 times)
+model DocumentIngestJob {
+  id           String    @id @default(dbgenerated("extensions.uuid_generate_v4()")) @db.Uuid
+  document_id  String    @db.Uuid
+  company_id   String    @db.Uuid
+  source       String                                      // 'vault' | 'tracker' | 'onboarding'
+  status       String    @default("pending")               // 'pending' | 'extracting' | 'matching' | 'linked' | 'needs_review' | 'failed'
+  attempts     Int       @default(0)
+  last_error   String?
+  result       Json?                                        // { suggestion, resolvedRequirementId, confidence }
+  enqueued_at  DateTime  @default(now()) @db.Timestamptz
+  started_at   DateTime? @db.Timestamptz
+  finished_at  DateTime? @db.Timestamptz
+  worker_id    String?                                     // for liveness debugging
+
+  @@index([company_id, status])
+  @@index([status, enqueued_at])
+  @@map("document_ingest_jobs")
+}
+
 // ── Vault Folder Tree ─────────────────────────────────────────────────────
 // A per-company folder hierarchy. Seeded system folders (kind = "system")
 // implement the PRD v1.1 §2.2 / §3.1 taxonomy:

--- a/supabase/migrations-manual/2026-04-28-ingest-cron.sql
+++ b/supabase/migrations-manual/2026-04-28-ingest-cron.sql
@@ -1,0 +1,94 @@
+-- ============================================================================
+-- Document ingest worker — pg_cron schedule
+--
+-- WHY: Vault (and onboarding) uploads complete instantly as dumb
+-- storage so the user doesn't wait. The heavy AI extraction work runs
+-- out-of-band via the `document_ingest_jobs` queue. This cron tick
+-- POSTs to the Vercel /api/jobs/run-ingest endpoint every 30 seconds;
+-- the endpoint claims and processes a batch of pending jobs.
+--
+-- Auth: a shared secret is set in Postgres GUC (`app.ingest_worker_secret`)
+-- and forwarded as the `x-ingest-secret` header. The endpoint
+-- authenticates against `INGEST_WORKER_SECRET` env var on Vercel.
+--
+-- WORKER SECRET SETUP (one-time, set via Supabase SQL editor):
+--   ALTER DATABASE postgres SET app.ingest_worker_url = 'https://www.finacra.com/api/jobs/run-ingest';
+--   ALTER DATABASE postgres SET app.ingest_worker_secret = '<generate-32-byte-hex>';
+-- The same secret must be set in Vercel as INGEST_WORKER_SECRET.
+--
+-- Schedule: every 30 seconds. Uses '30 seconds' interval syntax which
+-- pg_cron supports as a sub-minute job. If the host pg_cron version
+-- does not support sub-minute (older Supabase pools), fall back to a
+-- '* * * * *' once-per-minute schedule.
+--
+-- Idempotent: every CREATE uses IF NOT EXISTS / OR REPLACE; cron job
+-- is unscheduled and rescheduled atomically so re-running this
+-- migration is safe.
+-- ============================================================================
+
+-- 1. Helper function — POSTs to the worker endpoint with the shared
+--    secret. Returns the http request id (pg_net is async; the response
+--    is captured in net._http_response by Supabase, no need to handle
+--    here).
+CREATE OR REPLACE FUNCTION public.fire_ingest_worker()
+RETURNS BIGINT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, net
+AS $$
+DECLARE
+  url    TEXT;
+  secret TEXT;
+  rid    BIGINT;
+BEGIN
+  url    := current_setting('app.ingest_worker_url', true);
+  secret := current_setting('app.ingest_worker_secret', true);
+  IF url IS NULL OR url = '' THEN
+    RAISE NOTICE '[fire_ingest_worker] app.ingest_worker_url not set; skipping';
+    RETURN NULL;
+  END IF;
+  IF secret IS NULL OR secret = '' THEN
+    RAISE NOTICE '[fire_ingest_worker] app.ingest_worker_secret not set; skipping';
+    RETURN NULL;
+  END IF;
+
+  SELECT net.http_post(
+    url     := url,
+    headers := jsonb_build_object('x-ingest-secret', secret, 'content-type', 'application/json'),
+    body    := jsonb_build_object('source', 'pg_cron', 'fired_at', NOW())
+  ) INTO rid;
+
+  RETURN rid;
+END
+$$;
+
+-- 2. Schedule it. Try sub-minute first, fall back to once-per-minute.
+DO $$
+BEGIN
+  PERFORM cron.unschedule('document-ingest-worker');
+EXCEPTION
+  WHEN OTHERS THEN NULL;
+END
+$$;
+
+-- pg_cron 1.5+ supports '30 seconds'. Older versions need '* * * * *'.
+DO $$
+BEGIN
+  BEGIN
+    PERFORM cron.schedule(
+      'document-ingest-worker',
+      '30 seconds',
+      'SELECT public.fire_ingest_worker();'
+    );
+    RAISE NOTICE '[ingest-cron] scheduled at 30s interval';
+  EXCEPTION WHEN OTHERS THEN
+    -- Fallback to per-minute schedule.
+    PERFORM cron.schedule(
+      'document-ingest-worker',
+      '* * * * *',
+      'SELECT public.fire_ingest_worker();'
+    );
+    RAISE NOTICE '[ingest-cron] scheduled at 1-min interval (sub-minute not supported)';
+  END;
+END
+$$;


### PR DESCRIPTION
## Why
Foundation for unifying smart upload (chain after #70). Vault uploads complete instantly as dumb storage while the AI agent runs out-of-band via a background queue, so the user doesn't wait 5–10s on every drop.

## Stack
- **Prisma model** \`DocumentIngestJob\` (table \`document_ingest_jobs\`) with status / attempts / result, indexes on \`(company_id, status)\` and \`(status, enqueued_at)\`.
- **Worker** \`lib/compliance/ingest-worker.ts\` — claim, process, finalize. Uses \`WITH ranked AS … FOR UPDATE SKIP LOCKED\` to enforce a **3-jobs-per-company** concurrency cap inside a single SQL statement. Stale claims (worker died mid-flight) auto-reset after 5 minutes. Failed jobs retry up to 3 times.
- **Webhook** \`app/api/jobs/run-ingest/route.ts\` — Vercel endpoint invoked by Supabase pg_cron. Authenticates via shared secret in \`x-ingest-secret\` header. \`maxDuration = 300s\`.
- **Cron** \`supabase/migrations-manual/2026-04-28-ingest-cron.sql\` — schedules \`document-ingest-worker\` every 30s (falls back to 1-min if sub-minute pg_cron isn't supported). Uses \`pg_net.http_post\` with secret + URL from DB GUCs.
- **Vault upload** now enqueues a job after creating the doc row. Fire-and-forget; failure logs but doesn't block the upload.

## Behaviour
- Vault upload: user sees \"uploaded ✓\" immediately. Within 30s the worker picks it up; within ~10s of pickup the AI agent has extracted metadata and either (a) resolved a tracker requirement and upserted a \`ComplianceFiling\` row, or (b) marked the job \`needs_review\`.
- Tracker upload (PR A) unchanged — synchronous \`analyzeAndDraft → confirm modal → finalizeIngestion\` because the user already saw the result inline.

## Status transitions
\`\`\`
pending → extracting → matching → linked
                              → needs_review  (low confidence / no req
                                                / no period found)
                   → failed (after 3 retries)
\`\`\`

## Coming next
- **PR B.2**: per-doc progress chip in vault UI (Uploading → Extracting → Matching → Linked / Needs review) + \"Review pending\" surface for needs_review jobs.
- **PR C**: when extraction is confident but no requirement matches (2024 GSTR-3B in 2026-only tracker), auto-call \`generateHistoricalCompliances\` and re-resolve. Silent with undo chip.
- **PR D**: onboarding cert OCR via the same queue.

## Ops setup (one-time, after merge)
\`\`\`sql
-- Supabase SQL editor:
ALTER DATABASE postgres SET app.ingest_worker_url = 'https://www.finacra.com/api/jobs/run-ingest';
ALTER DATABASE postgres SET app.ingest_worker_secret = '<generate 32-byte hex>';
\`\`\`
+ Vercel env: \`INGEST_WORKER_SECRET = <same hex>\`.

The migration SQL must be run manually in Supabase (it uses \`cron.schedule\` and \`pg_net\` which aren't part of the Prisma schema).

## Test plan
- [ ] \`tsc --noEmit\` clean (verified locally).
- [ ] After merge: run migration in Supabase, set GUCs + Vercel secret.
- [ ] Vault upload of a test PDF → \`document_ingest_jobs\` row appears with \`status=pending\`, transitions to \`extracting\`, \`linked\` (or \`needs_review\`) within 1–2 minutes.
- [ ] Bulk drop of 6 files for one company → first 3 process in parallel, next 3 wait their turn.
- [ ] Kill a worker mid-extract → next tick picks the job up after 5min stale-claim window.
- [ ] Tracker upload (existing flow) unaffected — no enqueue, same synchronous UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)