### PR TITLE
fix(ingest): claim CTE syntax + restore CompliancePollutionAudit model

### DIFF
--- a/lib/compliance/ingest-worker.ts
+++ b/lib/compliance/ingest-worker.ts
@@ -62,7 +62,11 @@ export async function claimNextJobs(workerId: string, totalLimit: number = 30): 
 
   // Claim — at most PER_COMPANY_BATCH_LIMIT per company, totalLimit overall.
   // The ranked CTE numbers pending rows per company by enqueue order;
-  // we pick rank <= cap. SKIP LOCKED prevents double-claim.
+  // `capped` enforces the per-company cap + overall limit. SKIP LOCKED
+  // prevents double-claim across concurrent workers.
+  //
+  // Note: PostgreSQL UPDATE doesn't accept LIMIT directly; the cap must
+  // live inside the CTE that the UPDATE joins against.
   const rows = await prisma.$queryRaw<ClaimedJob[]>`
     WITH ranked AS (
       SELECT
@@ -76,17 +80,21 @@ export async function claimNextJobs(workerId: string, totalLimit: number = 30): 
       WHERE status = 'pending'
         AND attempts < ${MAX_ATTEMPTS}
       FOR UPDATE SKIP LOCKED
+    ),
+    capped AS (
+      SELECT id, document_id, company_id, source, attempts
+      FROM ranked
+      WHERE rn <= ${PER_COMPANY_BATCH_LIMIT}
+      LIMIT ${totalLimit}
     )
     UPDATE public.document_ingest_jobs j
     SET status = 'extracting',
         started_at = NOW(),
         worker_id = ${workerId},
         attempts = j.attempts + 1
-    FROM ranked r
+    FROM capped r
     WHERE j.id = r.id
-      AND r.rn <= ${PER_COMPANY_BATCH_LIMIT}
     RETURNING j.id, j.document_id, j.company_id, j.source, j.attempts
-    LIMIT ${totalLimit}
   `
 
   return rows

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -675,6 +675,26 @@ model CompanyDocument {
   @@map("company_documents_internal")
 }
 
+// ── Pollution Watchdog Audit ────────────────────────────────────────────
+// One row per `check_compliance_pollution()` cron run. Populated by the
+// pg_cron job scheduled in 2026-04-28-pollution-watchdog.sql. Detects
+// rows in `regulatory_requirements` whose `requirement` text drifts from
+// the canonical `<base> — <period_label>` format (PR #58/#60 fixes).
+//
+// MUST stay in this Prisma schema even though the table is created by
+// raw SQL — otherwise `prisma db push` will drop it on the next sync.
+model CompliancePollutionAudit {
+  id            String   @id @default(dbgenerated("extensions.uuid_generate_v4()")) @db.Uuid
+  checked_at    DateTime @default(now()) @db.Timestamptz
+  rows_scanned  Int
+  rows_polluted Int
+  by_company    Json     @default("[]")
+  samples       Json     @default("[]")
+
+  @@index([checked_at(sort: Desc)])
+  @@map("compliance_pollution_audit")
+}
+
 // ── Document Ingest Job Queue ────────────────────────────────────────────
 // Background queue for the smart-ingest pipeline. Vault & onboarding
 // uploads create the CompanyDocument row immediately as dumb storage,


### PR DESCRIPTION
## What
Two fixes hit during PR B.1 ops:

1. **Claim CTE** — \`UPDATE … RETURNING … LIMIT\` isn't valid PostgreSQL. Smoke against prod returned \`syntax error at or near \"LIMIT\"\`. Moved LIMIT + per-company rank filter into a \`capped\` CTE the UPDATE joins against. Same semantics, valid SQL.

2. **Restore \`CompliancePollutionAudit\` Prisma model** — PR #61 created the table via raw SQL only, violating the rule that all tables MUST be in \`prisma/schema.prisma\`. The next \`prisma db push\` (during B.1 ops) silently dropped it. Recreated the table; adding the model so it survives future syncs.

## Test plan
- [ ] After merge: re-trigger the webhook → no SQL error.
- [ ] \`prisma db push\` against prod → no table drops.
- [ ] \`tsc --noEmit\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)