### PR TITLE
fix(vault): AI Overview retry UI + sort chip chevron

### DIFF
--- a/app/api/cia/overview/route.ts
+++ b/app/api/cia/overview/route.ts
@@ -93,25 +93,49 @@ Rules:
     { role: 'user', content: contextBlock },
   ]
 
+  // Pre-flight: try to OPEN the LLM stream synchronously. If we can
+  // get a stream handle without throwing, we promote to streaming
+  // response. If it throws here (auth, missing deployment, rate limit
+  // at the door), return a real HTTP 500 + JSON so the client can show
+  // a retry UI rather than "Failed to generate overview." being
+  // injected as the AI's content.
+  let tokenStream: AsyncIterable<string> | null = null
+  try {
+    tokenStream = await streamChatCompletion(messages)
+  } catch (error) {
+    console.error('[CIA Overview] stream open threw',
+      error instanceof Error ? error.message : String(error),
+      error instanceof Error ? error.stack : '')
+    return Response.json(
+      { error: 'unavailable', message: 'Overview generator is temporarily unavailable.' },
+      { status: 503 },
+    )
+  }
+  if (!tokenStream) {
+    return Response.json(
+      { error: 'unavailable', message: 'Overview generator returned no stream.' },
+      { status: 503 },
+    )
+  }
+
+  // Mid-stream errors: we've already started writing to the client and
+  // can't change the HTTP status. Use a sentinel marker the client
+  // splits on, then renders "couldn't finish" UI instead of treating
+  // the trailing text as content.
+  const STREAM_ERROR_SENTINEL = '​[STREAM_ERROR]​'
   const encoder = new TextEncoder()
 
   const stream = new ReadableStream({
     async start(controller) {
       try {
-        const tokenStream = await streamChatCompletion(messages)
-        if (!tokenStream) {
-          controller.enqueue(encoder.encode('Unable to generate overview. Please try again.'))
-          controller.close()
-          return
-        }
-        for await (const token of tokenStream) {
+        for await (const token of tokenStream as AsyncIterable<string>) {
           controller.enqueue(encoder.encode(token))
         }
       } catch (error) {
-        console.error('[CIA Overview] stream threw',
+        console.error('[CIA Overview] stream mid-flight threw',
           error instanceof Error ? error.message : String(error),
           error instanceof Error ? error.stack : '')
-        controller.enqueue(encoder.encode('Failed to generate overview.'))
+        controller.enqueue(encoder.encode(STREAM_ERROR_SENTINEL))
       } finally {
         controller.close()
       }

--- a/app/data-room/components/DocumentsTab.tsx
+++ b/app/data-room/components/DocumentsTab.tsx
@@ -1233,6 +1233,12 @@ export default function DocumentsTab({
             value={selectedFY}
             onChange={(e) => setSelectedFY(e.target.value)}
             className="px-3 sm:px-4 py-2 bg-black border border-white/20 rounded-lg text-white text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a0a0a0' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
+              backgroundRepeat: 'no-repeat',
+              backgroundPosition: 'right 10px center',
+              paddingRight: '30px',
+            }}
           >
             <option value="">All Financial Years</option>
             {financialYears.map((fy) => (
@@ -1247,6 +1253,12 @@ export default function DocumentsTab({
             value={sortOption}
             onChange={(e) => setSortOption(e.target.value as typeof sortOption)}
             className="px-3 sm:px-4 py-2 bg-black border border-white/20 rounded-lg text-white text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a0a0a0' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
+              backgroundRepeat: 'no-repeat',
+              backgroundPosition: 'right 10px center',
+              paddingRight: '30px',
+            }}
           >
             <option value="date-newest">Date (Newest)</option>
             <option value="date-oldest">Date (Oldest)</option>
@@ -1261,6 +1273,12 @@ export default function DocumentsTab({
             value={expiringSoonFilter}
             onChange={(e) => setExpiringSoonFilter(e.target.value as typeof expiringSoonFilter)}
             className="px-3 sm:px-4 py-2 bg-black border border-white/20 rounded-lg text-white text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+            style={{
+              backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a0a0a0' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
+              backgroundRepeat: 'no-repeat',
+              backgroundPosition: 'right 10px center',
+              paddingRight: '30px',
+            }}
           >
             <option value="all">All Documents</option>
             <option value="expiring">Expiring Soon (â‰¤30 days)</option>

--- a/app/data-room/components/cia/CIAOverviewSection.tsx
+++ b/app/data-room/components/cia/CIAOverviewSection.tsx
@@ -109,10 +109,16 @@ function SourceCard({ doc }: { doc: SourceDoc }) {
   )
 }
 
+// Mid-stream sentinel emitted by /api/cia/overview when the LLM stream
+// dies after the response started. Lets the client distinguish "AI said
+// this" from "we couldn't finish generating".
+const STREAM_ERROR_SENTINEL = '​[STREAM_ERROR]​'
+
 export default function CIAOverviewSection({ companyId, documentCount, onDeepDive, recentDocuments = [] }: Props) {
   const [overviewText, setOverviewText] = useState('')
   const [loading, setLoading] = useState(true)
   const [streaming, setStreaming] = useState(false)
+  const [errorState, setErrorState] = useState<null | 'unavailable' | 'truncated'>(null)
   const [expanded, setExpanded] = useState(false)
   const accumulatorRef = useRef('')
   const fetchedRef = useRef<string | null>(null)
@@ -128,16 +134,23 @@ export default function CIAOverviewSection({ companyId, documentCount, onDeepDiv
       if (cached) {
         const { text, timestamp } = JSON.parse(cached)
         if (Date.now() - timestamp < 5 * 60 * 1000) {
-          setOverviewText(text); setLoading(false); fetchedRef.current = companyId; return
+          setOverviewText(text); setLoading(false); fetchedRef.current = companyId; setErrorState(null); return
         }
       }
     } catch {}
-    setLoading(true); setStreaming(true); accumulatorRef.current = ''; setOverviewText('')
+    setLoading(true); setStreaming(true); accumulatorRef.current = ''; setOverviewText(''); setErrorState(null)
     try {
       const res = await fetch('/api/cia/overview', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ companyId }) })
-      if (!res.ok) { setOverviewText('Unable to generate overview.'); setLoading(false); setStreaming(false); return }
+      if (!res.ok) {
+        // 503 / 500 = server couldn't even open the LLM stream. Don't
+        // inject the error message as overview content — show a real
+        // retry UI instead.
+        setErrorState('unavailable')
+        setLoading(false); setStreaming(false)
+        return
+      }
       const reader = res.body?.getReader()
-      if (!reader) return
+      if (!reader) { setErrorState('unavailable'); setLoading(false); setStreaming(false); return }
       const decoder = new TextDecoder()
       while (true) {
         const { done, value } = await reader.read()
@@ -145,9 +158,22 @@ export default function CIAOverviewSection({ companyId, documentCount, onDeepDiv
         accumulatorRef.current += decoder.decode(value, { stream: true })
         setOverviewText(accumulatorRef.current)
       }
-      try { localStorage.setItem(cacheKey, JSON.stringify({ text: accumulatorRef.current, timestamp: Date.now() })) } catch {}
-      fetchedRef.current = companyId
-    } catch { setOverviewText('Failed to generate overview. Please try again.') }
+      // Did the stream die mid-flight? Strip the sentinel from the
+      // visible text and surface a "couldn't finish" tail instead of
+      // bleeding error text into the overview body.
+      if (accumulatorRef.current.includes(STREAM_ERROR_SENTINEL)) {
+        const cleaned = accumulatorRef.current.split(STREAM_ERROR_SENTINEL)[0]
+        accumulatorRef.current = cleaned
+        setOverviewText(cleaned)
+        setErrorState('truncated')
+        // Don't cache a partial result.
+      } else {
+        try { localStorage.setItem(cacheKey, JSON.stringify({ text: accumulatorRef.current, timestamp: Date.now() })) } catch {}
+        fetchedRef.current = companyId
+      }
+    } catch {
+      setErrorState('unavailable')
+    }
     finally { setLoading(false); setStreaming(false) }
   }, [companyId])
 
@@ -176,7 +202,7 @@ export default function CIAOverviewSection({ companyId, documentCount, onDeepDiv
       </div>
 
       {/* ── Loading skeleton ── */}
-      {loading && !overviewText && (
+      {loading && !overviewText && !errorState && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px', paddingBottom: '12px' }}>
           {[100, 90, 80, 72].map((w, i) => (
             <div key={i} className="animate-pulse" style={{ height: '14px', width: `${w}%`, borderRadius: '4px', background: 'rgba(255,255,255,0.05)' }} />
@@ -184,8 +210,24 @@ export default function CIAOverviewSection({ companyId, documentCount, onDeepDiv
         </div>
       )}
 
-      {/* ── Two-column content ── */}
-      {isReady && (
+      {/* ── Error state — distinct from "AI said this" ── */}
+      {errorState === 'unavailable' && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px', padding: '10px 0', color: '#9aa0a6', fontSize: '13px' }}>
+          <span>Couldn't generate overview right now.</span>
+          <button
+            onClick={generateOverview}
+            style={{ padding: '4px 12px', borderRadius: '14px', border: '1px solid rgba(255,255,255,0.15)', background: 'transparent', color: '#8ab4f8', fontSize: '12px', cursor: 'pointer' }}
+            onMouseEnter={e => { (e.currentTarget as HTMLElement).style.background = 'rgba(138,180,248,0.08)' }}
+            onMouseLeave={e => { (e.currentTarget as HTMLElement).style.background = 'transparent' }}
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {/* ── Two-column content (also shown when truncated — partial
+            text is still useful; a retry tail appears below it) ── */}
+      {isReady && errorState !== 'unavailable' && (
         <div style={{ display: 'flex', gap: '24px', alignItems: 'flex-start' }}>
           {/* Left: text */}
           <div style={{ flex: 1, minWidth: 0 }}>
@@ -198,6 +240,19 @@ export default function CIAOverviewSection({ companyId, documentCount, onDeepDiv
               <div style={{ animation: 'ovExpand 0.2s ease-out' }}>
                 {renderBody(overviewText)}
                 {streaming && <span className="animate-pulse" style={{ display: 'inline-block', width: '6px', height: '14px', borderRadius: '2px', background: '#4285f4', marginLeft: '3px', verticalAlign: 'middle' }} />}
+              </div>
+            )}
+
+            {/* Truncated — overview was cut off mid-stream; offer retry */}
+            {errorState === 'truncated' && !streaming && (
+              <div style={{ marginTop: '12px', display: 'flex', alignItems: 'center', gap: '10px', color: '#9aa0a6', fontSize: '12px' }}>
+                <span>(generation was interrupted)</span>
+                <button
+                  onClick={generateOverview}
+                  style={{ padding: '3px 10px', borderRadius: '12px', border: '1px solid rgba(255,255,255,0.15)', background: 'transparent', color: '#8ab4f8', fontSize: '11px', cursor: 'pointer' }}
+                >
+                  Retry
+                </button>
               </div>
             )}
 


### PR DESCRIPTION
## Why
Two visible breakages from the user's screenshot.

## Changes
1. **AI Overview** \"Failed to generate overview\" was being rendered as the AI's content. Server enqueued the error string into the plain-text stream. Now:
   - 503 + JSON for failed-to-open errors → client shows real retry UI.
   - Sentinel marker for mid-flight errors → client renders partial output + \"(generation was interrupted) Retry\" tail. Truncated results aren't cached.
2. **Sort / FY / Expiry chips** in DocumentsTab had \`appearance-none\` without a custom chevron. Adding inline-style SVG chevron (same pattern as tracker status pill) so dropdowns are visually distinguishable.

## Test plan
- [ ] Force a 503 from /api/cia/overview → panel shows \"Couldn't generate — Retry\" pill, not error-as-content.
- [ ] Sort chip on documents tab now has a visible down-chevron.
- [ ] \`tsc --noEmit\` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)