### PR TITLE
feat(vault): review modal for needs_review docs (PR B.2.2)

### DIFF
--- a/app/data-room/actions-ingest-jobs.ts
+++ b/app/data-room/actions-ingest-jobs.ts
@@ -2,8 +2,10 @@
 
 import { prisma } from '@/lib/prisma'
 import { createServerContainer } from '@/lib/composition/server-container'
-import { validateCompanyId } from '@/lib/utils/input-validation'
+import { validateCompanyId, isValidUUID } from '@/lib/utils/input-validation'
 import { handleActionError } from '@/lib/errors/handle-error'
+import { upsertFiling } from '@/lib/compliance/filings'
+import { stripPeriodSuffix } from '@/lib/utils/strip-period-suffix'
 
 /**
  * Returns the active or recently-finished ingest jobs for a company,
@@ -96,6 +98,287 @@ export async function getActiveIngestJobsForCompany(
     }
 
     return { success: true, jobs }
+  } catch (error) {
+    return handleActionError(error)
+  }
+}
+
+interface RequirementCandidate {
+  id: string
+  requirement: string
+  category: string | null
+  periodKey: string | null
+  periodLabel: string | null
+  dueDate: string | null
+  status: string | null
+  // 0-1 score: how good a match this is for the agent's extracted
+  // (documentType, periodKey). Surfaced in the modal so the user can
+  // pick the highest-confidence option without scanning everything.
+  matchScore: number
+}
+
+interface ReviewCandidatesResult {
+  success: boolean
+  documentId?: string
+  fileName?: string | null
+  agent?: {
+    documentType: string | null
+    periodKey: string | null
+    periodFY: string | null
+    confidence: number | null
+    folderSlug: string | null
+    reasoning: string | null
+  }
+  candidates?: RequirementCandidate[]
+  error?: string
+}
+
+/**
+ * For a single document in needs_review, returns the agent's
+ * extracted metadata + a ranked list of candidate requirements the
+ * user can pick from. Drives the review modal (PR B.2.2).
+ *
+ * Ranking strategy (highest first):
+ *   1. Exact period_key match (with FY-format tolerance) AND
+ *      documentType matches the rule's stripped base name.
+ *   2. Period match alone, doc-type substring match.
+ *   3. Period match alone (any rule for this period).
+ *   4. Doc-type match alone (any period).
+ *   5. Other recurring rules (low score, surfaced last).
+ *
+ * Cap the result at 25 to keep the modal scannable.
+ */
+export async function getReviewCandidatesForDocument(
+  companyId: string,
+  documentId: string,
+): Promise<ReviewCandidatesResult> {
+  try {
+    if (!validateCompanyId(companyId)) return { success: false, error: 'Invalid company ID' }
+    if (!isValidUUID(documentId)) return { success: false, error: 'Invalid document ID' }
+
+    const { authService, companyMembershipRepository, companyRepository } = createServerContainer()
+    const user = await authService.requireCurrentUser()
+    const company = await companyRepository.getDetailsById(companyId)
+    if (!company) return { success: false, error: 'Company not found' }
+    const isOwner = company.ownerUserId === user.id || company.ownerAppUserId === user.id
+    if (!isOwner) {
+      const m = await companyMembershipRepository.findRole(user.id, companyId)
+      if (!m) return { success: false, error: 'Access denied' }
+    }
+
+    // Fetch doc + the most recent ingest job for it (the agent's
+    // suggestion is on the job's `result` JSON or the doc's
+    // `agent_suggestions`; prefer the latest job result).
+    const [doc, latestJob] = await Promise.all([
+      prisma.companyDocument.findFirst({
+        where: { id: documentId, company_id: companyId, deleted_at: null },
+        select: { id: true, file_name: true, agent_suggestions: true },
+      }),
+      prisma.documentIngestJob.findFirst({
+        where: { document_id: documentId, company_id: companyId },
+        orderBy: { enqueued_at: 'desc' },
+        select: { result: true, last_error: true, status: true },
+      }),
+    ])
+    if (!doc) return { success: false, error: 'Document not found' }
+
+    const result = (latestJob?.result || {}) as any
+    const fullAgent = (doc.agent_suggestions || {}) as any
+    const agent = {
+      documentType: result.documentType || fullAgent.documentType || null,
+      periodKey: result.periodKey || fullAgent.periodKey || null,
+      periodFY: result.periodFY || fullAgent.periodFY || null,
+      confidence: typeof result.confidence === 'number'
+        ? result.confidence
+        : (typeof fullAgent.confidence === 'number' ? fullAgent.confidence : null),
+      folderSlug: fullAgent.folderSlug || null,
+      reasoning: fullAgent.reasoning || null,
+    }
+
+    // Build period-key candidates (FY-format tolerant)
+    const pk = (agent.periodKey || agent.periodFY || '').trim()
+    const periodCandidates = new Set<string>()
+    if (pk) {
+      periodCandidates.add(pk)
+      periodCandidates.add(`FY${pk}`)
+      periodCandidates.add(`FY ${pk}`)
+      periodCandidates.add(pk.replace(/^FY\s*/i, ''))
+    }
+
+    // Pull all requirements for this company (cap query for safety).
+    // We rank in JS — total count is bounded (~100s per company).
+    const all = await prisma.regulatoryRequirement.findMany({
+      where: { company_id: companyId },
+      select: {
+        id: true,
+        requirement: true,
+        category: true,
+        period_key: true,
+        period_label: true,
+        due_date: true,
+        status: true,
+      },
+      orderBy: [{ category: 'asc' }, { requirement: 'asc' }],
+    })
+
+    const docTypeLower = (agent.documentType || '').toLowerCase().trim()
+
+    function scoreOf(r: typeof all[number]): number {
+      const baseLower = stripPeriodSuffix(r.requirement).toLowerCase().trim()
+      const periodHit = !!(r.period_key && periodCandidates.has(r.period_key))
+      if (!docTypeLower && !periodHit) return 0
+      // Exact base-name + period match — strongest signal
+      if (periodHit && baseLower === docTypeLower) return 1.0
+      if (periodHit && (baseLower.startsWith(docTypeLower) || baseLower.includes(docTypeLower))) return 0.9
+      if (periodHit) return 0.6
+      if (docTypeLower && baseLower === docTypeLower) return 0.5
+      if (docTypeLower && (baseLower.startsWith(docTypeLower) || baseLower.includes(docTypeLower))) return 0.4
+      return 0.05
+    }
+
+    const ranked: RequirementCandidate[] = all
+      .map(r => ({
+        id: r.id,
+        requirement: r.requirement,
+        category: r.category,
+        periodKey: r.period_key,
+        periodLabel: r.period_label,
+        dueDate: r.due_date ? r.due_date.toISOString().slice(0, 10) : null,
+        status: r.status,
+        matchScore: scoreOf(r),
+      }))
+      .filter(c => c.matchScore > 0.05)
+      .sort((a, b) => b.matchScore - a.matchScore)
+      .slice(0, 25)
+
+    // If filtering produced nothing, fall back to the top 25
+    // category-matching rows so the user has something to scan.
+    const candidates = ranked.length > 0
+      ? ranked
+      : all
+          .slice(0, 25)
+          .map(r => ({
+            id: r.id,
+            requirement: r.requirement,
+            category: r.category,
+            periodKey: r.period_key,
+            periodLabel: r.period_label,
+            dueDate: r.due_date ? r.due_date.toISOString().slice(0, 10) : null,
+            status: r.status,
+            matchScore: 0,
+          }))
+
+    return {
+      success: true,
+      documentId: doc.id,
+      fileName: doc.file_name,
+      agent,
+      candidates,
+    }
+  } catch (error) {
+    return handleActionError(error)
+  }
+}
+
+/**
+ * Manual link from the review modal: write the chosen requirement to
+ * CompanyDocument.requirement_id, mark the latest ingest job linked,
+ * and (when applicable) upsert the matching ComplianceFiling row.
+ *
+ * Auth: editor+ on the company (same gate as document mutations).
+ */
+export async function linkDocumentToRequirement(input: {
+  companyId: string
+  documentId: string
+  requirementId: string
+}): Promise<{ success: boolean; error?: string }> {
+  try {
+    const { companyId, documentId, requirementId } = input
+    if (!validateCompanyId(companyId)) return { success: false, error: 'Invalid company ID' }
+    if (!isValidUUID(documentId)) return { success: false, error: 'Invalid document ID' }
+    if (!isValidUUID(requirementId)) return { success: false, error: 'Invalid requirement ID' }
+
+    const { authService, companyMembershipRepository, companyRepository } = createServerContainer()
+    const user = await authService.requireCurrentUser()
+    const company = await companyRepository.getDetailsById(companyId)
+    if (!company) return { success: false, error: 'Company not found' }
+    const isOwner = company.ownerUserId === user.id || company.ownerAppUserId === user.id
+    let role: string | null = isOwner ? 'owner' : null
+    if (!isOwner) {
+      const m = await companyMembershipRepository.findRole(user.id, companyId)
+      if (!m) return { success: false, error: 'Access denied' }
+      role = m.role
+    }
+    if (role !== 'owner' && role !== 'admin' && role !== 'editor') {
+      return { success: false, error: 'Insufficient permission' }
+    }
+
+    // Confirm the requirement actually belongs to this company.
+    const req = await prisma.regulatoryRequirement.findFirst({
+      where: { id: requirementId, company_id: companyId },
+      select: { id: true, period_key: true, period_label: true, due_date: true },
+    })
+    if (!req) return { success: false, error: 'Requirement not found in this company' }
+
+    await prisma.companyDocument.update({
+      where: { id: documentId },
+      data: {
+        requirement_id: requirementId,
+        period_key: req.period_key ?? null,
+        updated_at: new Date(),
+      },
+    })
+
+    // Find the latest job for this doc and flip it to linked. This
+    // makes the chip disappear in the vault UI immediately.
+    const latest = await prisma.documentIngestJob.findFirst({
+      where: { document_id: documentId, company_id: companyId },
+      orderBy: { enqueued_at: 'desc' },
+      select: { id: true, result: true },
+    })
+    if (latest) {
+      const prevResult = (latest.result || {}) as any
+      await prisma.documentIngestJob.update({
+        where: { id: latest.id },
+        data: {
+          status: 'linked',
+          finished_at: new Date(),
+          last_error: null,
+          result: {
+            ...prevResult,
+            requirementId,
+            linkedManually: true,
+            linkedBy: user.id,
+            linkedAt: new Date().toISOString(),
+          } as any,
+        },
+      })
+    }
+
+    // Best-effort filing upsert; non-fatal if the slug-vs-uuid
+    // mismatch (compliance_filings.rule_id is slug-typed) blocks it.
+    if (req.period_key) {
+      try {
+        await upsertFiling({
+          companyId,
+          ruleId: requirementId,
+          periodKey: req.period_key,
+          financialYear: req.period_label || req.period_key,
+          data: {
+            status: 'filed',
+            documentId,
+            dueDate: req.due_date ? req.due_date.toISOString().slice(0, 10) : null,
+            acknowledgement: null,
+          },
+          updatedBy: user.id,
+        })
+      } catch (filingErr) {
+        console.error('[linkDocumentToRequirement] filing upsert failed (non-fatal):',
+          filingErr instanceof Error ? filingErr.message : filingErr)
+      }
+    }
+
+    return { success: true }
   } catch (error) {
     return handleActionError(error)
   }

--- a/app/data-room/components/vault/ReviewIngestModal.tsx
+++ b/app/data-room/components/vault/ReviewIngestModal.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { showToast } from '@/components/ui/Toast'
+import {
+  getReviewCandidatesForDocument,
+  linkDocumentToRequirement,
+} from '@/app/data-room/actions-ingest-jobs'
+
+/**
+ * Review-and-link modal for documents that the background ingest
+ * worker couldn't auto-link (status = needs_review). Surfaces the
+ * agent's extracted metadata + a ranked list of candidate
+ * requirements; user picks one and the document is linked.
+ *
+ * Triggered from the yellow "Needs review" chip on a vault tile.
+ *
+ * Why a modal (not an inline picker): the candidate list can be 10–25
+ * rows with category headers; an inline expansion would push the
+ * vault tree around. A modal keeps the vault layout stable and gives
+ * room for the agent's reasoning + match scores.
+ */
+interface Props {
+  companyId: string
+  documentId: string
+  onClose: () => void
+  onLinked?: () => void
+}
+
+interface Candidate {
+  id: string
+  requirement: string
+  category: string | null
+  periodKey: string | null
+  periodLabel: string | null
+  dueDate: string | null
+  status: string | null
+  matchScore: number
+}
+
+interface AgentMeta {
+  documentType: string | null
+  periodKey: string | null
+  periodFY: string | null
+  confidence: number | null
+  folderSlug: string | null
+  reasoning: string | null
+}
+
+export default function ReviewIngestModal({ companyId, documentId, onClose, onLinked }: Props) {
+  const [loading, setLoading] = useState(true)
+  const [linking, setLinking] = useState(false)
+  const [fileName, setFileName] = useState<string | null>(null)
+  const [agent, setAgent] = useState<AgentMeta | null>(null)
+  const [candidates, setCandidates] = useState<Candidate[]>([])
+  const [pickedId, setPickedId] = useState<string | null>(null)
+  const [search, setSearch] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true)
+    getReviewCandidatesForDocument(companyId, documentId)
+      .then(res => {
+        if (cancelled) return
+        if (!res.success) {
+          showToast(res.error || 'Failed to load candidates', 'error')
+          return
+        }
+        setFileName(res.fileName ?? null)
+        setAgent(res.agent ?? null)
+        setCandidates(res.candidates ?? [])
+        // Auto-select the highest-scoring candidate so Enter / Save
+        // works without a click in the common case.
+        const top = (res.candidates || []).find(c => c.matchScore >= 0.6)
+        if (top) setPickedId(top.id)
+      })
+      .finally(() => { if (!cancelled) setLoading(false) })
+    return () => { cancelled = true }
+  }, [companyId, documentId])
+
+  async function onSave() {
+    if (!pickedId) return
+    setLinking(true)
+    const res = await linkDocumentToRequirement({
+      companyId,
+      documentId,
+      requirementId: pickedId,
+    }).catch(err => ({ success: false, error: err instanceof Error ? err.message : String(err) }))
+    setLinking(false)
+    if (!res.success) {
+      showToast(res.error || 'Failed to link', 'error')
+      return
+    }
+    showToast('Document linked', 'success')
+    onLinked?.()
+    onClose()
+  }
+
+  const filtered = search.trim()
+    ? candidates.filter(c =>
+        c.requirement.toLowerCase().includes(search.toLowerCase()) ||
+        (c.category || '').toLowerCase().includes(search.toLowerCase()))
+    : candidates
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
+      <div
+        className="bg-[#0e0e0e] border border-white/10 rounded-2xl w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-6 py-4 border-b border-white/10 flex items-start justify-between gap-4">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-[10px] uppercase tracking-wider text-yellow-400">Review pending</span>
+              {agent?.confidence != null && (
+                <span className="text-[10px] text-gray-500">
+                  · agent confidence {Math.round(agent.confidence * 100)}%
+                </span>
+              )}
+            </div>
+            <h2 className="text-base font-medium text-white truncate" title={fileName || ''}>
+              {fileName || 'Document'}
+            </h2>
+            {agent && (agent.documentType || agent.periodFY || agent.periodKey) && (
+              <p className="text-xs text-gray-400 mt-1">
+                Agent suggests:{' '}
+                <span className="text-gray-200">
+                  {agent.documentType || '—'}
+                  {agent.periodFY ? ` · FY ${agent.periodFY}` : agent.periodKey ? ` · ${agent.periodKey}` : ''}
+                </span>
+              </p>
+            )}
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-white transition-colors flex-shrink-0"
+            aria-label="Close"
+          >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Reasoning (collapsible if long) */}
+        {agent?.reasoning && (
+          <div className="px-6 py-3 border-b border-white/5 text-[12px] text-gray-400 bg-white/[0.02]">
+            <span className="text-gray-500">Reasoning: </span>
+            {agent.reasoning}
+          </div>
+        )}
+
+        {/* Search */}
+        <div className="px-6 py-3 border-b border-white/5">
+          <input
+            type="text"
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Filter requirements…"
+            className="w-full px-3 py-2 bg-black border border-white/10 rounded-lg text-sm text-white placeholder-gray-500 focus:outline-none focus:border-white/30"
+          />
+        </div>
+
+        {/* Candidate list */}
+        <div className="flex-1 overflow-y-auto px-2 py-2">
+          {loading ? (
+            <div className="px-4 py-6 text-sm text-gray-500">Loading candidates…</div>
+          ) : filtered.length === 0 ? (
+            <div className="px-4 py-6 text-sm text-gray-500">
+              {search ? 'No matches.' : 'No candidate requirements found for this company.'}
+            </div>
+          ) : (
+            <ul className="space-y-1">
+              {filtered.map(c => {
+                const picked = pickedId === c.id
+                const scoreColor =
+                  c.matchScore >= 0.9 ? 'text-green-400' :
+                  c.matchScore >= 0.6 ? 'text-blue-400' :
+                  c.matchScore >= 0.4 ? 'text-gray-400' :
+                  'text-gray-600'
+                return (
+                  <li key={c.id}>
+                    <button
+                      onClick={() => setPickedId(c.id)}
+                      className={`w-full text-left px-4 py-2.5 rounded-lg border transition-colors ${
+                        picked
+                          ? 'bg-blue-500/10 border-blue-500/40'
+                          : 'border-transparent hover:bg-white/[0.04] hover:border-white/10'
+                      }`}
+                    >
+                      <div className="flex items-start gap-3">
+                        <div className="min-w-0 flex-1">
+                          <div className="text-sm text-white truncate" title={c.requirement}>
+                            {c.requirement}
+                          </div>
+                          <div className="text-[11px] text-gray-500 flex items-center gap-2 mt-0.5">
+                            {c.category && <span>{c.category}</span>}
+                            {c.periodKey && <span>· {c.periodLabel || c.periodKey}</span>}
+                            {c.dueDate && <span>· due {c.dueDate}</span>}
+                            {c.status && <span>· {c.status}</span>}
+                          </div>
+                        </div>
+                        {c.matchScore > 0 && (
+                          <span className={`text-[10px] font-mono ${scoreColor} flex-shrink-0`}>
+                            {Math.round(c.matchScore * 100)}%
+                          </span>
+                        )}
+                      </div>
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-3 border-t border-white/10 flex items-center justify-between gap-3">
+          <span className="text-[11px] text-gray-500">
+            {pickedId ? 'Press Save to link this document.' : 'Pick a requirement to link this document to.'}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-xs rounded-lg border border-white/10 text-gray-300 hover:bg-white/5"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={onSave}
+              disabled={!pickedId || linking}
+              className="px-4 py-1.5 text-xs rounded-lg bg-white text-black hover:bg-gray-200 disabled:opacity-40 disabled:cursor-not-allowed"
+            >
+              {linking ? 'Linking…' : 'Link'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/data-room/components/vault/VaultTreeView.tsx
+++ b/app/data-room/components/vault/VaultTreeView.tsx
@@ -13,6 +13,7 @@ import {
   bulkDeleteDocuments,
 } from '@/app/data-room/actions-vault'
 import VersionHistoryModal from './VersionHistoryModal'
+import ReviewIngestModal from './ReviewIngestModal'
 import { useRotatingLoadingMessage } from '@/hooks/useRotatingLoadingMessage'
 import { DOCUMENTS_VAULT_LOADING_MESSAGES } from '@/lib/ui/loading-messages'
 import { getActiveIngestJobsForCompany } from '@/app/data-room/actions-ingest-jobs'
@@ -85,6 +86,9 @@ export default function VaultTreeView({ companyId, canEdit, onUploadToFolder, on
   // any job is in flight, then backed off to every 30s once everything
   // is at terminal state, then stopped if the queue is fully empty.
   const [ingestByDoc, setIngestByDoc] = useState<Record<string, IngestStatus>>({})
+
+  // Document under review (clicked the yellow "Needs review" chip)
+  const [reviewDocId, setReviewDocId] = useState<string | null>(null)
 
   // Prevent the previous company's response from overwriting the new one
   // when the user switches companies mid-flight. Stamp every load with
@@ -426,9 +430,19 @@ export default function VaultTreeView({ companyId, canEdit, onUploadToFolder, on
             onUploadToFolder={onUploadToFolder}
             onPreviewDocument={onPreviewDocument}
             ingestByDoc={ingestByDoc}
+            onReview={setReviewDocId}
           />
         ))}
       </div>
+
+      {reviewDocId && (
+        <ReviewIngestModal
+          companyId={companyId}
+          documentId={reviewDocId}
+          onClose={() => setReviewDocId(null)}
+          onLinked={() => { setReviewDocId(null); load() }}
+        />
+      )}
 
       {versionHistoryDoc && (
         <VersionHistoryModal
@@ -471,6 +485,7 @@ function FolderNode({
   onUploadToFolder,
   onPreviewDocument,
   ingestByDoc,
+  onReview,
 }: {
   folder: Folder
   depth: number
@@ -492,6 +507,7 @@ function FolderNode({
   onUploadToFolder?: (folderId: string, folderName: string) => void
   onPreviewDocument?: (doc: Doc) => void
   ingestByDoc: Record<string, IngestStatus>
+  onReview: (documentId: string) => void
 }) {
   const kids = childrenOf.get(folder.id) || []
   const docs = docsInFolder.get(folder.id) || []
@@ -625,6 +641,7 @@ function FolderNode({
                   onPreview={onPreviewDocument}
                   onShowVersions={onShowVersions}
                   onUploadNewVersion={onUploadNewVersion}
+                  onReview={onReview}
                 />
               ))}
             </div>
@@ -655,6 +672,7 @@ function FolderNode({
                   onUploadToFolder={onUploadToFolder}
                   onPreviewDocument={onPreviewDocument}
                   ingestByDoc={ingestByDoc}
+                  onReview={onReview}
                 />
               ))}
             </div>
@@ -686,6 +704,7 @@ function DocumentRow({
   onPreview,
   onShowVersions,
   onUploadNewVersion,
+  onReview,
 }: {
   doc: Doc
   depth: number
@@ -699,6 +718,7 @@ function DocumentRow({
   onPreview?: (d: Doc) => void
   onShowVersions: (d: Doc) => void
   onUploadNewVersion?: (d: Doc) => void
+  onReview: (documentId: string) => void
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const formatted = doc.updatedAt ? new Date(doc.updatedAt).toLocaleDateString('en-IN', { day: 'numeric', month: 'short', year: 'numeric' }) : ''
@@ -739,7 +759,7 @@ function DocumentRow({
         )}
       </button>
 
-      <IngestChip ingest={ingestStatus} />
+      <IngestChip ingest={ingestStatus} onReview={() => onReview(doc.id)} />
 
       <span className="text-[10px] text-gray-500 flex-shrink-0">{formatted}</span>
 
@@ -825,7 +845,7 @@ function VaultLoadingState() {
  * Tooltips carry the agent's documentType / confidence / lastError
  * for power-user visibility without crowding the row.
  */
-function IngestChip({ ingest }: { ingest: IngestStatus | null }) {
+function IngestChip({ ingest, onReview }: { ingest: IngestStatus | null; onReview?: () => void }) {
   if (!ingest) return null
   const { status, documentType, confidence, lastError } = ingest
 
@@ -870,12 +890,14 @@ function IngestChip({ ingest }: { ingest: IngestStatus | null }) {
       lastError ? `Reason: ${lastError}` : null,
     ].filter(Boolean).join(' · ') || 'Manual review needed'
     return (
-      <span
-        className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-300 flex-shrink-0 cursor-help"
-        title={tip}
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onReview?.() }}
+        className="text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-300 flex-shrink-0 hover:bg-yellow-500/20 transition-colors"
+        title={`${tip} — click to review`}
       >
         Needs review
-      </span>
+      </button>
     )
   }
   if (status === 'failed') {


### PR DESCRIPTION
## Why
Closes the smart-ingest UX loop. Docs the worker couldn't auto-link sat with a yellow chip that did nothing on click. Now the chip opens a modal with the agent's extracted metadata + a ranked list of candidate requirements; user picks one, doc is linked.

## Changes
- **\`getReviewCandidatesForDocument\`** server action — agent metadata + 25 ranked requirements (exact > period+prefix > period only > docType only > other).
- **\`linkDocumentToRequirement\`** server action — writes \`CompanyDocument.requirement_id\` + \`period_key\`, marks latest ingest job linked, best-effort filing upsert.
- **\`ReviewIngestModal\`** — agent suggestion + reasoning, search box, scrollable candidate list with match-score pills, Cancel / Link footer. Auto-selects top match.
- **Yellow \"Needs review\" chip** is now a clickable button. \`onReview\` callback threaded VaultTreeView → FolderNode → DocumentRow → IngestChip.

## Test plan
- [ ] Doc in \`needs_review\` → click yellow chip → modal opens with agent metadata + ranked candidates → pick one → save → chip disappears, requirement_id written.
- [ ] Search filters the list.
- [ ] Cancel / X / backdrop close the modal without changes.
- [ ] \`tsc --noEmit\` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)