### PR TITLE
feat(onboarding): cert OCR via ingest queue + entity fact kinds (PR D)

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -329,6 +329,26 @@ export async function completeOnboarding(
         processDocumentContent(doc.id, company.id, doc.filePath).catch(err =>
           console.error(`Async processing failed for ${doc.id}:`, err)
         )
+
+        // Smart-ingest queue: PAN / GST / COI / MOA-AOA / etc. cert
+        // images get OCR'd and parsed for entity facts (PAN number,
+        // GSTN, CIN, incorporation date, authorized capital). Those
+        // facts back-fill `company_facts` with `confidence=0.7,
+        // sourceKind=document_extracted` while the user-typed values
+        // already in `company_facts` carry `confidence=1.0,
+        // sourceKind=user_declared` — the reader prefers typed on
+        // conflict, so OCR fills gaps without overriding correct
+        // entries. Fire-and-forget; failure logs but doesn't block
+        // onboarding completion.
+        const { enqueueIngestJob } = await import('@/lib/compliance/ingest-worker')
+        enqueueIngestJob({
+          documentId: doc.id,
+          companyId: company.id,
+          source: 'onboarding',
+        }).catch(err => {
+          console.error(`Onboarding ingest enqueue failed for ${doc.id}:`,
+            err instanceof Error ? err.message : err)
+        })
       }
     }
   }

--- a/lib/compliance/document-agent.ts
+++ b/lib/compliance/document-agent.ts
@@ -190,9 +190,24 @@ FIELD COMPLETION RULES — fill EVERY field, think holistically:
   DIR-3 KYC → find the rule with "din-kyc" in its id
 
 For facts: only emit facts grounded in the document; confidence ≥ 0.6; follow
-the same kinds used elsewhere (rent.monthly_payment, contractor.annual_spend,
-salary.annual_bill, headcount.total, turnover.annual, gst.registered_state,
-director.remuneration, imports.annual_value, exports.annual_value).
+the same kinds used elsewhere. Permitted kinds:
+  Operational facts:
+    rent.monthly_payment, contractor.annual_spend, salary.annual_bill,
+    headcount.total, turnover.annual, gst.registered_state,
+    director.remuneration, imports.annual_value, exports.annual_value
+  Entity facts (PAN/GST/COI/MOA cert OCR — populate from the cert
+  itself, not the prompt context):
+    entity.pan                — PAN string (10 chars), payload: { value: "ABCPK1234R" }
+    entity.gstn               — GSTN string (15 chars), payload: { value: "29AABCX1234R1ZM" }
+    entity.cin                — CIN string (21 chars), payload: { value: "U72200KA2019PTC123456" }
+    entity.tan                — TAN string (10 chars), payload: { value: "BLRA12345A" }
+    entity.incorporation_date — periodStart = the date itself, payload: {}
+    entity.authorized_capital — amount in rupees, unit: "rupees", payload: {}
+    entity.paid_up_capital    — amount in rupees, unit: "rupees", payload: {}
+    entity.registered_state   — payload: { value: "Karnataka" }
+For entity.* facts that aren't period-bound, set periodStart and periodEnd
+to the document's registrationDate (or today if absent). Don't fabricate
+entity facts — only emit when the document literally contains them.
 Return { ..., "facts": [] } if nothing extractable.`
 
 function rulesForPrompt(rules: Awaited<ReturnType<typeof getRulesInForce>>): string {


### PR DESCRIPTION
## Why
Closes the smart-upload chain. Onboarding cert uploads (PAN, GST, Incorporation, MOA, AOA images / scans) now flow through the same background queue the vault uses. The agent OCR-extracts entity facts (PAN, GSTN, CIN, incorporation date, authorized capital, etc.) and back-fills \`company_facts\`.

## Changes
- **Onboarding action** enqueues an ingest job for each uploaded doc, \`source='onboarding'\`. Fire-and-forget; failure logs but doesn't block company creation.
- **Agent prompt** extends permitted fact kinds: \`entity.pan / gstn / cin / tan / incorporation_date / authorized_capital / paid_up_capital / registered_state\`. Only emitted when literally present in the document.

## Conflict resolution
Typed onboarding values already land in \`company_facts\` with \`sourceKind='user_declared'\` \`confidence=1.0\`. Agent-extracted lands with \`sourceKind='document_extracted'\` \`confidence=0.7\`. The fact reader prefers typed values — OCR fills gaps but doesn't override.

## Test plan
- [ ] Complete onboarding with a PAN/GST cert image attached → \`document_ingest_jobs\` row appears with \`source='onboarding'\` → cron processes → \`company_facts\` gains a row of kind \`entity.pan\` (or similar) with the OCR'd value.
- [ ] If user typed PAN \`ABCPK1234R\` and cert OCR reads \`ABCPK1234R\` → both rows exist in history; reader returns the typed one.
- [ ] If cert is unreadable (scanned 200x200, illegible) → agent returns \`facts: []\`, no entity rows added, no error to user.
- [ ] \`tsc --noEmit\` clean (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Compliance documents uploaded during onboarding are now automatically processed for information extraction
  * Enhanced recognition of additional compliance data types from documents, including entity-related information and attributes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->