### PR TITLE
fix(vault+tracker): kill loading-flash, fix clipped 3-dots menus, hold Linked chip longer

### DIFF
--- a/app/data-room/actions-ingest-jobs.ts
+++ b/app/data-room/actions-ingest-jobs.ts
@@ -52,7 +52,11 @@ export async function getActiveIngestJobsForCompany(
       if (!membership) return { success: false, error: 'Access denied' }
     }
 
-    const cutoff = new Date(Date.now() - 30 * 1000) // 30s "linked recently" tail
+    // 5-minute "linked recently" tail. Originally 30s, but real-user
+    // feedback showed the chip vanished before they could notice it.
+    // 5 min is long enough to be visible across a typical browse
+    // session, short enough that stale chips don't accumulate.
+    const cutoff = new Date(Date.now() - 5 * 60 * 1000)
 
     const rows = await prisma.documentIngestJob.findMany({
       where: {

--- a/app/data-room/components/vault/VaultTreeView.tsx
+++ b/app/data-room/components/vault/VaultTreeView.tsx
@@ -579,44 +579,15 @@ function FolderNode({
             </button>
           )}
           {canEdit && (
-            <div className="relative">
-              <button
-                onClick={() => setMenuOpen(o => !o)}
-                className="w-6 h-6 flex items-center justify-center text-gray-500 hover:text-white rounded"
-                aria-label="Folder actions"
-              >
-                ⋯
-              </button>
-              {menuOpen && (
-                <>
-                  <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
-                  <div className="absolute right-0 top-full mt-1 z-50 w-44 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl py-1 text-xs">
-                    <button
-                      onClick={() => { setMenuOpen(false); onCreateSubfolder(folder.id) }}
-                      className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
-                    >
-                      + New sub-folder
-                    </button>
-                    {folder.kind === 'user' && (
-                      <>
-                        <button
-                          onClick={() => { setMenuOpen(false); onRenameFolder(folder) }}
-                          className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
-                        >
-                          Rename
-                        </button>
-                        <button
-                          onClick={() => { setMenuOpen(false); onDeleteFolder(folder) }}
-                          className="w-full text-left px-3 py-1.5 text-red-300 hover:bg-red-500/10"
-                        >
-                          Delete folder
-                        </button>
-                      </>
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
+            <FolderActionsMenu
+              folder={folder}
+              isOpen={menuOpen}
+              onToggle={() => setMenuOpen(o => !o)}
+              onClose={() => setMenuOpen(false)}
+              onCreateSubfolder={onCreateSubfolder}
+              onRenameFolder={onRenameFolder}
+              onDeleteFolder={onDeleteFolder}
+            />
           )}
         </div>
       </div>
@@ -764,60 +735,193 @@ function DocumentRow({
       <span className="text-[10px] text-gray-500 flex-shrink-0">{formatted}</span>
 
       {canEdit && (
-        <div className="relative flex-shrink-0">
-          <button
-            onClick={() => setMenuOpen(o => !o)}
-            className="w-6 h-6 flex items-center justify-center text-gray-500 hover:text-white rounded"
-            aria-label="Document actions"
-          >
-            ⋯
-          </button>
-          {menuOpen && (
-            <>
-              <div className="fixed inset-0 z-40" onClick={() => setMenuOpen(false)} />
-              <div className="absolute right-0 top-full mt-1 z-50 w-44 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl py-1 text-xs">
-                {onUploadNewVersion && (
-                  <button
-                    onClick={() => { setMenuOpen(false); onUploadNewVersion(doc) }}
-                    className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
-                  >
-                    Upload new version
-                  </button>
-                )}
-                <button
-                  onClick={() => { setMenuOpen(false); onShowVersions(doc) }}
-                  className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
-                >
-                  Version history
-                </button>
-                <div className="h-px bg-white/5 my-1" />
-                <button
-                  onClick={() => { setMenuOpen(false); onRename(doc) }}
-                  className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
-                >
-                  Rename
-                </button>
-                <button
-                  onClick={() => { setMenuOpen(false); onMove(doc) }}
-                  className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
-                >
-                  Move to…
-                </button>
-                <button
-                  onClick={() => { setMenuOpen(false); onDelete(doc) }}
-                  className="w-full text-left px-3 py-1.5 text-red-300 hover:bg-red-500/10"
-                >
-                  Delete
-                </button>
-              </div>
-            </>
-          )}
-        </div>
+        <DocActionsMenu
+          doc={doc}
+          isOpen={menuOpen}
+          onToggle={() => setMenuOpen(o => !o)}
+          onClose={() => setMenuOpen(false)}
+          onUploadNewVersion={onUploadNewVersion}
+          onShowVersions={onShowVersions}
+          onRename={onRename}
+          onMove={onMove}
+          onDelete={onDelete}
+        />
       )}
     </div>
   )
 }
 
+
+/**
+ * Per-document actions menu (the ⋯ dropdown). Uses position:fixed
+ * with computed coords so the menu escapes any ancestor
+ * `overflow-hidden` — the FolderNode wrapper has it for the rounded
+ * card aesthetic, which previously clipped the menu and made it look
+ * like clicking ⋯ "did nothing" or hid the menu.
+ */
+function DocActionsMenu({
+  doc, isOpen, onToggle, onClose,
+  onUploadNewVersion, onShowVersions, onRename, onMove, onDelete,
+}: {
+  doc: Doc
+  isOpen: boolean
+  onToggle: () => void
+  onClose: () => void
+  onUploadNewVersion?: (d: Doc) => void
+  onShowVersions: (d: Doc) => void
+  onRename: (d: Doc) => void
+  onMove: (d: Doc) => void
+  onDelete: (d: Doc) => void
+}) {
+  const btnRef = useRef<HTMLButtonElement | null>(null)
+  // Coords are computed at toggle time; recompute on open so scroll
+  // doesn't strand the menu.
+  const [coords, setCoords] = useState<{ top: number; right: number } | null>(null)
+
+  function handleToggle(e: React.MouseEvent) {
+    e.stopPropagation()
+    if (!isOpen && btnRef.current) {
+      const r = btnRef.current.getBoundingClientRect()
+      setCoords({ top: Math.round(r.bottom + 4), right: Math.round(window.innerWidth - r.right) })
+    }
+    onToggle()
+  }
+
+  return (
+    <div className="relative flex-shrink-0">
+      <button
+        ref={btnRef}
+        onClick={handleToggle}
+        className="w-6 h-6 flex items-center justify-center text-gray-500 hover:text-white rounded"
+        aria-label="Document actions"
+        aria-expanded={isOpen}
+      >
+        ⋯
+      </button>
+      {isOpen && coords && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={onClose} />
+          <div
+            className="fixed z-50 w-44 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl py-1 text-xs"
+            style={{ top: coords.top, right: coords.right }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {onUploadNewVersion && (
+              <button
+                onClick={() => { onClose(); onUploadNewVersion(doc) }}
+                className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
+              >
+                Upload new version
+              </button>
+            )}
+            <button
+              onClick={() => { onClose(); onShowVersions(doc) }}
+              className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
+            >
+              Version history
+            </button>
+            <div className="h-px bg-white/5 my-1" />
+            <button
+              onClick={() => { onClose(); onRename(doc) }}
+              className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
+            >
+              Rename
+            </button>
+            <button
+              onClick={() => { onClose(); onMove(doc) }}
+              className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
+            >
+              Move to…
+            </button>
+            <button
+              onClick={() => { onClose(); onDelete(doc) }}
+              className="w-full text-left px-3 py-1.5 text-red-300 hover:bg-red-500/10"
+            >
+              Delete
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Per-folder actions menu (the ⋯ dropdown on a folder header).
+ * Same fixed-position pattern as DocActionsMenu so the menu escapes
+ * the FolderNode's `overflow-hidden` card wrapper.
+ */
+function FolderActionsMenu({
+  folder, isOpen, onToggle, onClose,
+  onCreateSubfolder, onRenameFolder, onDeleteFolder,
+}: {
+  folder: Folder
+  isOpen: boolean
+  onToggle: () => void
+  onClose: () => void
+  onCreateSubfolder: (parentId: string | null) => void
+  onRenameFolder: (f: Folder) => void
+  onDeleteFolder: (f: Folder) => void
+}) {
+  const btnRef = useRef<HTMLButtonElement | null>(null)
+  const [coords, setCoords] = useState<{ top: number; right: number } | null>(null)
+
+  function handleToggle(e: React.MouseEvent) {
+    e.stopPropagation()
+    if (!isOpen && btnRef.current) {
+      const r = btnRef.current.getBoundingClientRect()
+      setCoords({ top: Math.round(r.bottom + 4), right: Math.round(window.innerWidth - r.right) })
+    }
+    onToggle()
+  }
+
+  return (
+    <div className="relative">
+      <button
+        ref={btnRef}
+        onClick={handleToggle}
+        className="w-6 h-6 flex items-center justify-center text-gray-500 hover:text-white rounded"
+        aria-label="Folder actions"
+        aria-expanded={isOpen}
+      >
+        ⋯
+      </button>
+      {isOpen && coords && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={onClose} />
+          <div
+            className="fixed z-50 w-44 bg-[#1a1a1a] border border-white/10 rounded-lg shadow-2xl py-1 text-xs"
+            style={{ top: coords.top, right: coords.right }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              onClick={() => { onClose(); onCreateSubfolder(folder.id) }}
+              className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
+            >
+              + New sub-folder
+            </button>
+            {folder.kind === 'user' && (
+              <>
+                <button
+                  onClick={() => { onClose(); onRenameFolder(folder) }}
+                  className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
+                >
+                  Rename
+                </button>
+                <button
+                  onClick={() => { onClose(); onDeleteFolder(folder) }}
+                  className="w-full text-left px-3 py-1.5 text-red-300 hover:bg-red-500/10"
+                >
+                  Delete folder
+                </button>
+              </>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
 
 function VaultLoadingState() {
   const message = useRotatingLoadingMessage({

--- a/hooks/useRequirements.ts
+++ b/hooks/useRequirements.ts
@@ -30,9 +30,14 @@ export function useRequirements(
   // Tracks which companyId we already have fresh data for (skip re-fetch).
   const fetchedForRef = useRef<string | null>(null)
 
-  const fetchForCompany = useCallback(async (id: string) => {
+  const fetchForCompany = useCallback(async (id: string, quiet = false) => {
     activeCompanyRef.current = id
-    setIsLoading(true)
+    // Quiet mode (background refresh from cia:data-changed): keep the
+    // existing data on screen, swap atomically when the response
+    // arrives. Per project rule 5 — never clear state to empty before
+    // replacing. The "Loading compliances…" shell only appears on a
+    // truly cold load.
+    if (!quiet) setIsLoading(true)
 
     try {
       const result = await getRegulatoryRequirements(id)
@@ -44,7 +49,8 @@ export function useRequirements(
         if (result.success && result.requirements) {
           setRequirements(result.requirements)
           fetchedForRef.current = id
-        } else {
+        } else if (!quiet) {
+          // Don't blow away existing data on a quiet background failure.
           setRequirements([])
           if (result.error?.includes('UnrecognizedActionError')) {
             window.location.reload()
@@ -57,18 +63,18 @@ export function useRequirements(
         window.location.reload()
         return
       }
-      startTransition(() => setRequirements([]))
+      if (!quiet) startTransition(() => setRequirements([]))
     } finally {
-      if (activeCompanyRef.current === id) {
+      if (activeCompanyRef.current === id && !quiet) {
         setIsLoading(false)
       }
     }
   }, [])
 
-  const refresh = useCallback(() => {
+  const refresh = useCallback((opts?: { quiet?: boolean }) => {
     if (!companyId || !enabled || !hasAccess) return
     fetchedForRef.current = null
-    fetchForCompany(companyId)
+    fetchForCompany(companyId, opts?.quiet ?? false)
   }, [companyId, enabled, hasAccess, fetchForCompany])
 
   useEffect(() => {
@@ -100,9 +106,12 @@ export function useRequirements(
     activeCompanyRef.current = id
   }, [])
 
-  // Refresh when the CIA agent mutates requirements (tool calls)
+  // Refresh when the CIA agent mutates requirements (tool calls), or
+  // when TrackerEvaluationPanel finishes a (silent) re-evaluation.
+  // Uses quiet=true so the existing accordion stays on screen and the
+  // updated data atomically swaps in — no "Loading compliances…" flash.
   useEffect(() => {
-    const handler = () => refresh()
+    const handler = () => refresh({ quiet: true })
     window.addEventListener('cia:data-changed', handler)
     return () => window.removeEventListener('cia:data-changed', handler)
   }, [refresh])


### PR DESCRIPTION
Three real-user bugs:
1. Tracker shows 'Loading compliances…' mid-session because TrackerEvaluationPanel's silent auto-eval dispatches cia:data-changed and useRequirements flips isLoading. Now quiet=true on listener path — atomic swap, no flash.
2. 3-dots menus clipped by FolderNode card's overflow-hidden. Switched to position:fixed with computed coords. Both folder + doc menus.
3. Linked chip 30s tail too short — bumped to 5min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown menu clipping in folder and document views; menus now display correctly without being hidden by overflow constraints.
  * Enhanced data refresh behavior to prevent unnecessary loading indicators and UI transitions during background updates.

* **Updates**
  * Extended ingest job visibility window for improved tracking and monitoring duration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->