### PR TITLE
fix(tracker+ingest): doc count, token-match scoring, quarter→deadline-month mapping

### DIFF
--- a/app/data-room/actions-ingest-jobs.ts
+++ b/app/data-room/actions-ingest-jobs.ts
@@ -199,7 +199,13 @@ export async function getReviewCandidatesForDocument(
       reasoning: fullAgent.reasoning || null,
     }
 
-    // Build period-key candidates (FY-format tolerant)
+    // Build period-key candidates. Format tolerance covers:
+    //   • bare year-quarter / month: "2026-Q3", "2026-12"
+    //   • FY-prefixed annual: "FY2024-25", "FY 2024-25"
+    //   • Indian quarter→deadline-month mapping: a TDS Q3 return
+    //     covers Oct-Dec 2026 but the rule's period_key is the
+    //     DEADLINE month "2027-01". Without this mapping the
+    //     auto-resolver and review modal both miss the row.
     const pk = (agent.periodKey || agent.periodFY || '').trim()
     const periodCandidates = new Set<string>()
     if (pk) {
@@ -207,6 +213,25 @@ export async function getReviewCandidatesForDocument(
       periodCandidates.add(`FY${pk}`)
       periodCandidates.add(`FY ${pk}`)
       periodCandidates.add(pk.replace(/^FY\s*/i, ''))
+
+      // Quarter-of-year ("YYYY-Q1..Q4") → likely deadline month for
+      // recurring quarterly compliances. Indian convention: filings
+      // for Q1 (Apr-Jun) are due in July; Q2 (Jul-Sep) → October;
+      // Q3 (Oct-Dec) → January of next year; Q4 (Jan-Mar) → May.
+      // We add the deadline-month variant as an additional candidate;
+      // exact rules vary by compliance, but this covers the common
+      // TDS / GST / advance-tax pattern.
+      const qm = pk.match(/^(\d{4})-Q([1-4])$/)
+      if (qm) {
+        const year = parseInt(qm[1], 10)
+        const q = parseInt(qm[2], 10)
+        // Q1→07, Q2→10, Q3→01(year+1), Q4→05(year+1)
+        const deadlineMonth = q === 1 ? `${year}-07` : q === 2 ? `${year}-10` : q === 3 ? `${year + 1}-01` : `${year + 1}-05`
+        periodCandidates.add(deadlineMonth)
+        // Also add the calendar-month-end variant (last month of the quarter)
+        const endMonth = q === 1 ? `${year}-06` : q === 2 ? `${year}-09` : q === 3 ? `${year}-12` : `${year + 1}-03`
+        periodCandidates.add(endMonth)
+      }
     }
 
     // Pull all requirements for this company (cap query for safety).
@@ -227,16 +252,31 @@ export async function getReviewCandidatesForDocument(
 
     const docTypeLower = (agent.documentType || '').toLowerCase().trim()
 
+    // Token-overlap match: the agent emits short labels ("Form 26Q",
+    // "PAN Card") while rule names are longer ("TDS Return (Form
+    // 24Q/26Q) — Q3 — Jan 2027"). Pure substring fails here because
+    // a slash breaks the substring (Form 26Q is not a substring of
+    // "Form 24Q/26Q"). Tokenizing both and checking that every
+    // distinctive doc-type token appears in the rule's tokens
+    // bridges the gap.
+    const STOP = new Set(['form', 'the', 'of', 'and', 'or', 'a', 'an', 'for', 'in', 'to'])
+    function tokensOf(s: string): string[] {
+      return (s || '').toLowerCase().split(/[^a-z0-9]+/).filter(t => t.length >= 2 && !STOP.has(t))
+    }
+    const docTypeTokens = tokensOf(docTypeLower)
+
     function scoreOf(r: typeof all[number]): number {
       const baseLower = stripPeriodSuffix(r.requirement).toLowerCase().trim()
       const periodHit = !!(r.period_key && periodCandidates.has(r.period_key))
       if (!docTypeLower && !periodHit) return 0
+      const baseTokens = new Set(tokensOf(baseLower))
+      const tokensMatch = docTypeTokens.length > 0 && docTypeTokens.every(t => baseTokens.has(t))
       // Exact base-name + period match — strongest signal
       if (periodHit && baseLower === docTypeLower) return 1.0
-      if (periodHit && (baseLower.startsWith(docTypeLower) || baseLower.includes(docTypeLower))) return 0.9
+      if (periodHit && tokensMatch) return 0.9
       if (periodHit) return 0.6
       if (docTypeLower && baseLower === docTypeLower) return 0.5
-      if (docTypeLower && (baseLower.startsWith(docTypeLower) || baseLower.includes(docTypeLower))) return 0.4
+      if (docTypeLower && tokensMatch) return 0.4
       return 0.05
     }
 

--- a/app/data-room/components/tracker/RequirementDesktopTableView.tsx
+++ b/app/data-room/components/tracker/RequirementDesktopTableView.tsx
@@ -86,13 +86,42 @@ export default function RequirementDesktopTableView({
   const [savingBaseAmount, setSavingBaseAmount] = useState<Record<string, boolean>>({})
   const [openDocChecklist, setOpenDocChecklist] = useState<string | null>(null)
 
-  const uploadedDocSet = new Set(
-    vaultDocuments
-      .filter(d => d.requirement_id || d.requirementId)
-      .map(d => `${d.requirement_id || d.requirementId}::${(d.document_type || '').toLowerCase().trim()}`)
-  )
-  const isDocUploaded = (reqId: string, docName: string) =>
-    uploadedDocSet.has(`${reqId}::${docName.toLowerCase().trim()}`)
+  // Match a vault doc against a required-doc slot. The agent's
+  // `document_type` (e.g. "Form 26Q", "PAN Card") is a SHORT label;
+  // the rule's `required_documents` entries are LONG descriptive
+  // strings (e.g. "Form 140 (salary + non-salary TDS; formerly 24Q/26Q)").
+  // Pure exact-string matching never connects them — even when the
+  // doc is correctly linked to the requirement.
+  //
+  // Token-overlap match: tokenize both, require the SHORTER side's
+  // distinctive tokens (length ≥ 2, alphanumeric) to all appear in
+  // the LONGER side. Stop-words (form, the, of, etc.) are excluded
+  // so "Form 26Q" still demands "26q" present in the required text,
+  // and matches "...formerly 24Q/26Q" because "26q" appears there.
+  const STOP = new Set(['form', 'the', 'of', 'and', 'or', 'a', 'an', 'for', 'in', 'to'])
+  function tokensOf(s: string): string[] {
+    return (s || '')
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(t => t.length >= 2 && !STOP.has(t))
+  }
+  function docMatchesSlot(docType: string, requiredName: string): boolean {
+    const dt = tokensOf(docType)
+    const rn = tokensOf(requiredName)
+    if (dt.length === 0 || rn.length === 0) return false
+    // All distinctive tokens of the shorter side must appear in the longer.
+    const shorter = dt.length <= rn.length ? dt : rn
+    const longerSet = new Set(dt.length <= rn.length ? rn : dt)
+    return shorter.every(t => longerSet.has(t))
+  }
+
+  const isDocUploaded = (reqId: string, requiredName: string): boolean => {
+    return vaultDocuments.some(d => {
+      const rid = d.requirement_id || d.requirementId
+      if (rid !== reqId) return false
+      return docMatchesSlot(d.document_type || '', requiredName)
+    })
+  }
 
   const docsByRequirement = useMemo(() => {
     const map = new Map<string, any[]>()
@@ -409,7 +438,17 @@ export default function RequirementDesktopTableView({
                       if (!Array.isArray(requiredDocs) || requiredDocs.length === 0) {
                         return <div className="text-gray-500 text-sm">-</div>
                       }
-                      const uploadedCount = requiredDocs.filter((doc: string) => isDocUploaded(req.id, doc)).length
+                      const slotMatchCount = requiredDocs.filter((doc: string) => isDocUploaded(req.id, doc)).length
+                      // If the doc is linked to the requirement but doesn't
+                      // match a specific required-doc slot (agent
+                      // document_type vs CA-friendly long names), we still
+                      // want the count to reflect "user uploaded something".
+                      // Cap at requiredDocs.length so the chip never overflows.
+                      const linkedDocsCount = (docsByRequirement.get(req.id) || []).length
+                      const uploadedCount = Math.min(
+                        Math.max(slotMatchCount, linkedDocsCount),
+                        requiredDocs.length
+                      )
                       const allDone = uploadedCount === requiredDocs.length
                       const isOpen = openDocChecklist === req.id
                       return (

--- a/lib/compliance/ingest-worker.ts
+++ b/lib/compliance/ingest-worker.ts
@@ -409,16 +409,29 @@ async function resolveRequirementByNameAndPeriod(input: {
   const { companyId, documentType, periodKey } = input
   if (!documentType) return null
 
-  // Period key format varies across rules. The agent extracts "2024-25"
-  // but the rules-engine annual rules store "FY2024-25" (with prefix,
-  // no space) and other monthly rules store "2024-04" (YYYY-MM). Try
-  // all reasonable variants. Order: exact first, then variants.
+  // Period key format varies. Cover the common ones:
+  //   • Bare ("2026-Q3" / "2024-25" / "2024-04")
+  //   • FY prefix ("FY2024-25", "FY 2024-25") for annual rules
+  //   • Indian quarter→deadline-month mapping: a quarterly compliance
+  //     filed for Q3 of FY 2026-27 (Oct-Dec 2026) has its rule
+  //     period_key set to the DEADLINE MONTH "2027-01", not "2026-Q3".
+  //     Without this mapping, "Form 26Q for Q3 FY 2026-27" never
+  //     matches the rule "TDS Return (Form 24Q/26Q) — Q3 — Jan 2027"
+  //     (period_key=2027-01).
   const trimmedKey = periodKey.trim()
   const candidates = new Set<string>([trimmedKey])
   candidates.add(`FY${trimmedKey}`)
   candidates.add(`FY ${trimmedKey}`)
-  // If the agent gave "FY2024-25" or "FY 2024-25", strip and try bare
   candidates.add(trimmedKey.replace(/^FY\s*/i, ''))
+  const qm = trimmedKey.match(/^(\d{4})-Q([1-4])$/)
+  if (qm) {
+    const year = parseInt(qm[1], 10)
+    const q = parseInt(qm[2], 10)
+    const deadlineMonth = q === 1 ? `${year}-07` : q === 2 ? `${year}-10` : q === 3 ? `${year + 1}-01` : `${year + 1}-05`
+    candidates.add(deadlineMonth)
+    const endMonth = q === 1 ? `${year}-06` : q === 2 ? `${year}-09` : q === 3 ? `${year}-12` : `${year + 1}-03`
+    candidates.add(endMonth)
+  }
 
   const rows = await prisma.regulatoryRequirement.findMany({
     where: {
@@ -429,21 +442,30 @@ async function resolveRequirementByNameAndPeriod(input: {
   })
   if (rows.length === 0) return null
 
+  // Token-overlap match: "Form 26Q" tokens must all appear in the
+  // rule's tokens. Bridges short agent labels ("Form 26Q") against
+  // long rule names ("TDS Return (Form 24Q/26Q)") where pure
+  // substring fails because "/" breaks the substring.
+  const STOP = new Set(['form', 'the', 'of', 'and', 'or', 'a', 'an', 'for', 'in', 'to'])
+  function tokensOf(s: string): string[] {
+    return (s || '').toLowerCase().split(/[^a-z0-9]+/).filter(t => t.length >= 2 && !STOP.has(t))
+  }
+  const docTokens = tokensOf(documentType)
   const docTypeLower = documentType.toLowerCase().trim()
+
   // 1. Exact base-name match (preferred)
   const exact = rows.find(r => stripPeriodSuffix(r.requirement).toLowerCase().trim() === docTypeLower)
   if (exact) return exact.id
 
-  // 2. Prefix / substring match — agent's documentType is often a
-  // prefix of the rule name (e.g. "MGT-7A" vs "MGT-7 / MGT-7A — Annual
-  // Return — FY2026-27"). After stripPeriodSuffix the rule reduces to
-  // its base; we then check the docType is a prefix or appears anywhere
-  // in the base.
-  const prefix = rows.find(r => {
-    const base = stripPeriodSuffix(r.requirement).toLowerCase()
-    return base.startsWith(docTypeLower) || base.includes(docTypeLower)
-  })
-  if (prefix) return prefix.id
+  // 2. Token-overlap match — every distinctive doc-type token must
+  // appear in the rule's tokens.
+  if (docTokens.length > 0) {
+    const tokenMatch = rows.find(r => {
+      const baseTokens = new Set(tokensOf(stripPeriodSuffix(r.requirement)))
+      return docTokens.every(t => baseTokens.has(t))
+    })
+    if (tokenMatch) return tokenMatch.id
+  }
 
   return null
 }


### PR DESCRIPTION
User reported: 'I uploaded Form 26Q but tracker shows 0/3 docs and the doc isn't reflecting in the right tracker row.' Three stacked bugs:

1. **Tracker doc-count** computed by exact match between agent's short `document_type` ("Form 26Q") and rule's long `required_documents` ("Form 140 (...formerly 24Q/26Q)"). Never connects. Fix: token-overlap + cap count at total linked docs.
2. **Scoring fallback** in auto-link + review modal used substring. "Form 26Q" isn't a substring of "TDS Return (Form 24Q/26Q)" because of the slash. Switched both code paths to token-overlap.
3. **Period-key format**: agent's "2026-Q3" never matched rule's "2027-01" (deadline month). Added Indian quarter→deadline-month mapping (Q1→Jul, Q2→Oct, Q3→Jan, Q4→May).