### PR TITLE
feat(vault+tracker): View document — open uploaded files in new tab

### DIFF
--- a/app/data-room/actions-vault.ts
+++ b/app/data-room/actions-vault.ts
@@ -453,3 +453,35 @@ export async function listDocumentVersions(
     return handleActionError(error)
   }
 }
+
+/**
+ * Returns a short-lived signed URL for viewing a vault document. Used
+ * by the "View document" menu item in both the vault tree and the
+ * tracker's doc-checklist popover.
+ *
+ * Auth: any company member (incl. viewers) can preview their own
+ * company's documents — read-only.
+ */
+export async function getDocumentSignedUrl(
+  companyId: string,
+  documentId: string,
+): Promise<{ success: boolean; url?: string; fileName?: string | null; error?: string }> {
+  try {
+    await assertCompanyAccess(companyId)
+
+    const doc = await prisma.companyDocument.findFirst({
+      where: { id: documentId, company_id: companyId, deleted_at: null },
+      select: { id: true, file_path: true, file_name: true },
+    })
+    if (!doc) return { success: false, error: 'Document not found' }
+
+    const { createStorageAdapter } = await import('@/lib/storage/factory')
+    const storage = createStorageAdapter()
+    // 1 hour TTL — long enough for the user to open + glance through;
+    // short enough that leaked URLs become invalid quickly.
+    const url = await storage.createSignedUrl('company-documents', doc.file_path, 3600)
+    return { success: true, url, fileName: doc.file_name }
+  } catch (error) {
+    return handleActionError(error)
+  }
+}

--- a/app/data-room/components/tracker/RequirementDesktopTableView.tsx
+++ b/app/data-room/components/tracker/RequirementDesktopTableView.tsx
@@ -5,6 +5,16 @@ import { IRegulatoryService } from '../../services/RegulatoryService'
 import { showToast } from '@/components/ui/Toast'
 import { updateRequirement } from '@/app/data-room/actions'
 import { stripPeriodSuffix } from '@/lib/utils/strip-period-suffix'
+import { getDocumentSignedUrl } from '@/app/data-room/actions-vault'
+
+async function openDocInNewTab(companyId: string, documentId: string) {
+  const res = await getDocumentSignedUrl(companyId, documentId).catch(() => null)
+  if (!res || !res.success || !res.url) {
+    showToast(res?.error || 'Could not open document', 'error')
+    return
+  }
+  window.open(res.url, '_blank', 'noopener,noreferrer')
+}
 
 interface Requirement {
   id: string
@@ -122,11 +132,21 @@ export default function RequirementDesktopTableView({
   }
 
   const isDocUploaded = (reqId: string, requiredName: string): boolean => {
-    return vaultDocuments.some(d => {
+    return !!findDocForSlot(reqId, requiredName)
+  }
+
+  /**
+   * Returns the first vault doc satisfying a (requirement, slot) pair.
+   * Used to wire the "View" link in the doc-checklist popover so the
+   * user can open the actual file behind a checked slot.
+   */
+  function findDocForSlot(reqId: string, requiredName: string): any | null {
+    for (const d of vaultDocuments) {
       const rid = d.requirement_id || d.requirementId
-      if (rid !== reqId) return false
-      return docMatchesSlot(d.document_type || '', requiredName)
-    })
+      if (rid !== reqId) continue
+      if (docMatchesSlot(d.document_type || '', requiredName)) return d
+    }
+    return null
   }
 
   const docsByRequirement = useMemo(() => {
@@ -527,7 +547,8 @@ export default function RequirementDesktopTableView({
                                 <div className="text-[10px] text-gray-500 mb-3">{uploadedCount} of {requiredDocs.length} uploaded</div>
                                 <div className="space-y-2">
                                   {requiredDocs.map((doc: string, idx: number) => {
-                                    const uploaded = isDocUploaded(req.id, doc)
+                                    const matchedDoc = findDocForSlot(req.id, doc)
+                                    const uploaded = !!matchedDoc
                                     return (
                                       <div key={idx} className={`flex items-start gap-2.5 p-2 rounded-lg ${uploaded ? 'bg-green-500/5' : 'bg-gray-800/50'}`}>
                                         {uploaded ? (
@@ -560,8 +581,18 @@ export default function RequirementDesktopTableView({
                                               Upload
                                             </button>
                                           )}
-                                          {uploaded && (
-                                            <span className="text-[10px] text-green-500/60">Uploaded</span>
+                                          {uploaded && matchedDoc && currentCompany && (
+                                            <button
+                                              type="button"
+                                              onClick={(e) => {
+                                                e.stopPropagation()
+                                                openDocInNewTab(currentCompany.id, matchedDoc.id)
+                                              }}
+                                              className="text-[11px] text-blue-400 hover:text-blue-300 mt-0.5 flex items-center gap-1"
+                                            >
+                                              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" /></svg>
+                                              View
+                                            </button>
                                           )}
                                         </div>
                                       </div>

--- a/app/data-room/components/vault/VaultTreeView.tsx
+++ b/app/data-room/components/vault/VaultTreeView.tsx
@@ -11,6 +11,7 @@ import {
   moveDocument,
   deleteDocument,
   bulkDeleteDocuments,
+  getDocumentSignedUrl,
 } from '@/app/data-room/actions-vault'
 import VersionHistoryModal from './VersionHistoryModal'
 import ReviewIngestModal from './ReviewIngestModal'
@@ -428,9 +429,9 @@ export default function VaultTreeView({ companyId, canEdit, onUploadToFolder, on
             onShowVersions={setVersionHistoryDoc}
             onUploadNewVersion={onUploadNewVersion}
             onUploadToFolder={onUploadToFolder}
-            onPreviewDocument={onPreviewDocument}
             ingestByDoc={ingestByDoc}
             onReview={setReviewDocId}
+            companyId={companyId}
           />
         ))}
       </div>
@@ -483,9 +484,9 @@ function FolderNode({
   onShowVersions,
   onUploadNewVersion,
   onUploadToFolder,
-  onPreviewDocument,
   ingestByDoc,
   onReview,
+  companyId,
 }: {
   folder: Folder
   depth: number
@@ -494,6 +495,7 @@ function FolderNode({
   expanded: Set<string>
   selected: Set<string>
   canEdit: boolean
+  companyId: string
   onToggleExpand: (id: string) => void
   onToggleSelect: (id: string) => void
   onCreateSubfolder: (parentId: string | null) => void
@@ -505,7 +507,6 @@ function FolderNode({
   onShowVersions: (d: Doc) => void
   onUploadNewVersion?: (d: Doc) => void
   onUploadToFolder?: (folderId: string, folderName: string) => void
-  onPreviewDocument?: (doc: Doc) => void
   ingestByDoc: Record<string, IngestStatus>
   onReview: (documentId: string) => void
 }) {
@@ -604,12 +605,12 @@ function FolderNode({
                   depth={depth}
                   selected={selected.has(doc.id)}
                   canEdit={canEdit}
+                  companyId={companyId}
                   ingestStatus={ingestByDoc[doc.id] || null}
                   onToggleSelect={onToggleSelect}
                   onRename={onRenameDoc}
                   onDelete={onDeleteDoc}
                   onMove={onMoveDoc}
-                  onPreview={onPreviewDocument}
                   onShowVersions={onShowVersions}
                   onUploadNewVersion={onUploadNewVersion}
                   onReview={onReview}
@@ -641,9 +642,9 @@ function FolderNode({
                   onShowVersions={onShowVersions}
                   onUploadNewVersion={onUploadNewVersion}
                   onUploadToFolder={onUploadToFolder}
-                  onPreviewDocument={onPreviewDocument}
                   ingestByDoc={ingestByDoc}
                   onReview={onReview}
+                  companyId={companyId}
                 />
               ))}
             </div>
@@ -667,12 +668,12 @@ function DocumentRow({
   depth,
   selected,
   canEdit,
+  companyId,
   ingestStatus,
   onToggleSelect,
   onRename,
   onDelete,
   onMove,
-  onPreview,
   onShowVersions,
   onUploadNewVersion,
   onReview,
@@ -681,12 +682,12 @@ function DocumentRow({
   depth: number
   selected: boolean
   canEdit: boolean
+  companyId: string
   ingestStatus: IngestStatus | null
   onToggleSelect: (id: string) => void
   onRename: (d: Doc) => void
   onDelete: (d: Doc) => void
   onMove: (d: Doc) => void
-  onPreview?: (d: Doc) => void
   onShowVersions: (d: Doc) => void
   onUploadNewVersion?: (d: Doc) => void
   onReview: (documentId: string) => void
@@ -713,9 +714,9 @@ function DocumentRow({
       </svg>
 
       <button
-        onClick={() => onPreview?.(doc)}
-        className="flex-1 text-left min-w-0 flex items-center gap-2"
-        disabled={!onPreview}
+        onClick={() => openDocumentInTab(companyId, doc.id)}
+        className="flex-1 text-left min-w-0 flex items-center gap-2 hover:text-white transition-colors"
+        title="Click to view document"
       >
         <span className="text-xs text-gray-200 truncate">{doc.fileName || 'Unnamed document'}</span>
         {hasVersionHistory && (
@@ -737,6 +738,7 @@ function DocumentRow({
       {canEdit && (
         <DocActionsMenu
           doc={doc}
+          companyId={companyId}
           isOpen={menuOpen}
           onToggle={() => setMenuOpen(o => !o)}
           onClose={() => setMenuOpen(false)}
@@ -759,11 +761,26 @@ function DocumentRow({
  * card aesthetic, which previously clipped the menu and made it look
  * like clicking ⋯ "did nothing" or hid the menu.
  */
+/**
+ * Open a document in a new tab via a 1-hour signed URL. Used by the
+ * "View document" menu item (vault) and the per-slot "View" link
+ * (tracker doc-checklist).
+ */
+async function openDocumentInTab(companyId: string, documentId: string) {
+  const res = await getDocumentSignedUrl(companyId, documentId).catch(() => null)
+  if (!res || !res.success || !res.url) {
+    showToast(res?.error || 'Could not open document', 'error')
+    return
+  }
+  window.open(res.url, '_blank', 'noopener,noreferrer')
+}
+
 function DocActionsMenu({
-  doc, isOpen, onToggle, onClose,
+  doc, companyId, isOpen, onToggle, onClose,
   onUploadNewVersion, onShowVersions, onRename, onMove, onDelete,
 }: {
   doc: Doc
+  companyId: string
   isOpen: boolean
   onToggle: () => void
   onClose: () => void
@@ -806,6 +823,13 @@ function DocActionsMenu({
             style={{ top: coords.top, right: coords.right }}
             onClick={(e) => e.stopPropagation()}
           >
+            <button
+              onClick={() => { onClose(); openDocumentInTab(companyId, doc.id) }}
+              className="w-full text-left px-3 py-1.5 text-gray-200 hover:bg-white/5"
+            >
+              View document
+            </button>
+            <div className="h-px bg-white/5 my-1" />
             {onUploadNewVersion && (
               <button
                 onClick={() => { onClose(); onUploadNewVersion(doc) }}


### PR DESCRIPTION
User asked for view/open-document on both vault and tracker. Adds a `getDocumentSignedUrl` server action (1-hour TTL, member-gated read), wires it to: (a) clickable filename + 'View document' menu item in vault, (b) per-slot 'View' link in tracker doc-checklist popover. Threads companyId where needed; dead onPreview prop removed.