### PR TITLE
feat(ui): add Button primitive — 4 variants × 3 sizes (PR-4)

### DIFF
--- a/app/onboarding/MagicalIntake.tsx
+++ b/app/onboarding/MagicalIntake.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react'
 import { verifyCIN, lookupCompanyByPerplexity, lookupGST, type GSTLookupResult } from '@/lib/api/cin-din'
 import { parseCIN, type ParsedCIN } from '@/utils/cin-parser'
+import Button from '@/components/ui/Button'
 
 const CIN_PATTERN = /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/
 const PAN_PATTERN = /^[A-Z]{5}\d{4}[A-Z]$/
@@ -158,13 +159,9 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
       <div className="w-full max-w-[520px]">
         {/* Skip link top-right */}
         <div className="flex justify-end mb-6">
-          <button
-            type="button"
-            onClick={onSkip}
-            className="text-xs text-fg-muted hover:text-fg-secondary transition-colors duration-token ease-token"
-          >
+          <Button variant="ghost" size="sm" onClick={onSkip}>
             Skip — fill manually
-          </button>
+          </Button>
         </div>
 
         {/* Hero */}
@@ -214,28 +211,25 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
             )}
           </div>
 
-          {/* Verify button — only when valid + still on cin step */}
-          {phase === 'cin' && cinValid && (
+          {/* Verify button — visible from valid CIN through verify-in-flight */}
+          {(phase === 'cin' || phase === 'cin-verifying') && cinValid && (
             <div className="pt-2 animate-fadeIn">
-              <button
-                type="button"
+              <Button
+                size="lg"
                 onClick={handleVerifyCIN}
-                className="inline-flex items-center gap-2 bg-fg-primary text-fg-inverse text-sm font-medium px-5 py-2.5 rounded-token-md hover:opacity-90 transition-opacity duration-token ease-token"
+                loading={phase === 'cin-verifying'}
+                iconRight={
+                  phase === 'cin' ? (
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                      <path d="M5 12h14" />
+                      <path d="M13 5l7 7-7 7" />
+                    </svg>
+                  ) : null
+                }
               >
-                Verify
-                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M5 12h14" />
-                  <path d="M13 5l7 7-7 7" />
-                </svg>
-              </button>
+                {phase === 'cin-verifying' ? 'Verifying with MCA…' : 'Verify'}
+              </Button>
             </div>
-          )}
-
-          {phase === 'cin-verifying' && (
-            <p className="text-sm text-fg-secondary inline-flex items-center gap-2 pt-2">
-              <span className="inline-block w-3 h-3 border-2 border-fg-secondary border-t-transparent rounded-full animate-spin" />
-              Verifying with MCA…
-            </p>
           )}
 
           {phase !== 'cin' && phase !== 'cin-verifying' && companyName && (

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { forwardRef, type ButtonHTMLAttributes, type ReactNode } from 'react'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger'
+export type ButtonSize = 'sm' | 'md' | 'lg'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+  iconLeft?: ReactNode
+  iconRight?: ReactNode
+  fullWidth?: boolean
+}
+
+/**
+ * PR-4: the one Button. Three primary variants + a danger for destructive
+ * actions. Token-driven so it themes cleanly. Designed to replace the four
+ * different button styles currently scattered across the data-room.
+ *
+ * Usage:
+ *   <Button>Save</Button>                          // primary md
+ *   <Button variant="secondary">Cancel</Button>
+ *   <Button variant="ghost" size="sm">More</Button>
+ *   <Button variant="danger" loading>Deleting…</Button>
+ *   <Button iconLeft={<PlusIcon />}>Add</Button>
+ *
+ * Adoption strategy: this PR ships the primitive + converts the magical
+ * onboarding intake (the one "greenfield" surface that already used the
+ * matching tokens). PRs 7/8 sweep tracker and vault as part of their
+ * broader re-skins — converting hundreds of button sites in one PR is
+ * exactly the blast-radius we said we'd avoid.
+ */
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = 'primary',
+    size = 'md',
+    loading = false,
+    iconLeft,
+    iconRight,
+    fullWidth = false,
+    disabled,
+    className = '',
+    children,
+    type = 'button',
+    ...rest
+  },
+  ref,
+) {
+  const base =
+    'inline-flex items-center justify-center gap-2 font-medium rounded-token-md transition-colors duration-token ease-token outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/40 disabled:opacity-50 disabled:cursor-not-allowed'
+
+  const variants: Record<ButtonVariant, string> = {
+    primary:
+      'bg-fg-primary text-fg-inverse hover:opacity-90 active:opacity-80',
+    secondary:
+      'bg-bg-card text-fg-primary border border-line/15 hover:bg-bg-hover hover:border-line/30',
+    ghost:
+      'bg-transparent text-fg-secondary hover:text-fg-primary hover:bg-bg-hover',
+    danger:
+      'bg-accent-danger text-white hover:opacity-90 active:opacity-80',
+  }
+
+  const sizes: Record<ButtonSize, string> = {
+    sm: 'text-xs px-3 py-1.5',
+    md: 'text-sm px-4 py-2',
+    lg: 'text-base px-5 py-2.5',
+  }
+
+  const widthClass = fullWidth ? 'w-full' : ''
+
+  return (
+    <button
+      ref={ref}
+      type={type}
+      disabled={disabled || loading}
+      className={`${base} ${variants[variant]} ${sizes[size]} ${widthClass} ${className}`.trim()}
+      {...rest}
+    >
+      {loading ? (
+        <span
+          aria-hidden="true"
+          className="inline-block w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin"
+        />
+      ) : iconLeft ? (
+        <span aria-hidden="true" className="inline-flex shrink-0">{iconLeft}</span>
+      ) : null}
+      {children}
+      {!loading && iconRight ? (
+        <span aria-hidden="true" className="inline-flex shrink-0">{iconRight}</span>
+      ) : null}
+    </button>
+  )
+})
+
+export default Button


### PR DESCRIPTION
## Summary

PR-4 of the design-system overhaul. Adds a single `<Button>` primitive that replaces the 4+ different inline button styles scattered across the app.

## What's inside

- **`components/ui/Button.tsx` (new, ~95 lines)**:
  - Variants: `primary` (filled fg/bg), `secondary` (border + ghost bg), `ghost` (text + hover bg), `danger` (filled accent-danger).
  - Sizes: `sm`, `md` (default), `lg`.
  - Props: `loading`, `iconLeft`, `iconRight`, `fullWidth`, all native button props passed through. `forwardRef`-able.
  - Token-driven (`bg-fg-primary`, `text-fg-inverse`, `bg-bg-card`, `border-line/15`, `accent-brand`, `accent-danger`) so it themes cleanly in both modes from foundation PR.
  - Spinner uses `currentColor` so it inherits each variant's text color.

- **`app/onboarding/MagicalIntake.tsx`**: adopts the primitive on the one greenfield surface from foundation.
  - "Skip — fill manually" → `<Button variant="ghost" size="sm">`.
  - "Verify" CIN button → `<Button size="lg" loading={…} iconRight={…}>`. Loading state now lives inside the button itself (no separate "Verifying with MCA…" line) — matches Vercel/Geist UX where the action becomes the status.

## Out of scope

- Tracker, vault, header, modals — converted as part of PR-7 (tracker re-skin) and PR-8 (vault re-skin) where the broader visual language changes too. Doing hundreds of button sites in a standalone PR is exactly the blast radius we agreed to avoid.
- A `link` variant for inline text links — the "Continue manually" inline link in MagicalIntake stays raw because it's intentionally underlined-running-prose, not a button shape.

## Test plan

- [ ] `/onboarding` (IN user) — Skip pill renders identical, hover state correct.
- [ ] Type a valid CIN — Verify button fades in with arrow icon. Click → button shows internal spinner + "Verifying with MCA…" text. No layout shift.
- [ ] After CIN verifies — button disappears, company name renders below as before.
- [ ] No regressions on any other page (Button is new + used in only one place).

## Branch hygiene (per Rule 17)

- Branched off `origin/main` (after foundation PR #88 squash-merged).
- Zero merge commits between work and target — squash will produce a clean diff.
- Will Rule-17c verify after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)