### PR TITLE
feat(ui): Vercel/Perplexity-style visual transformation (flagship sweep)

### DIFF
--- a/app/data-room/components/DataRoomBootShell.tsx
+++ b/app/data-room/components/DataRoomBootShell.tsx
@@ -2,7 +2,6 @@
 
 import React from 'react'
 import Header from '@/components/layout/Header'
-import SubtleCircuitBackground from '@/components/ui/SubtleCircuitBackground'
 import TrackerCategoryAccordionView from './tracker/TrackerCategoryAccordionView'
 import { getCountryConfig } from '@/lib/config/countries'
 
@@ -50,34 +49,33 @@ export default function DataRoomBootShell({
       : ['Income Tax', 'GST', 'Payroll', 'RoC', 'Renewals', 'Others']
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
-      <SubtleCircuitBackground />
+    <div className="min-h-screen bg-bg-base relative">
       <Header />
 
       <div className="relative z-10 container mx-auto px-3 sm:px-4 py-4 sm:py-8">
         {/* Company Selector slot — matches post-boot dimensions */}
         <div className="mb-4 sm:mb-6">
-          <h2 className="text-gray-400 text-sm font-medium mb-2 sm:mb-3">My companies</h2>
-          <div className="h-[72px] sm:h-[84px] rounded-xl border border-white/10 bg-white/[0.03] animate-pulse" />
+          <h2 className="text-fg-muted text-xs font-medium uppercase tracking-wider mb-2 sm:mb-3">My companies</h2>
+          <div className="h-[72px] sm:h-[84px] rounded-token-md border border-line/10 bg-bg-card animate-pulse" />
         </div>
 
         {/* Page Title — real, no shell */}
-        <h1 className="text-2xl sm:text-4xl font-light text-white mb-4 sm:mb-6">Data Room</h1>
+        <h1 className="text-2xl sm:text-3xl font-medium text-fg-primary tracking-tight mb-4 sm:mb-6">Data Room</h1>
 
-        {/* Tab strip — visually matches the real tabs (rounded buttons,
-            border, padding) so dimensions are identical when the real
-            tabs render. Inert during shell. */}
-        <div className="flex items-center gap-2 mb-4 sm:mb-8 overflow-x-auto pb-2 -mx-3 sm:mx-0 px-3 sm:px-0 scrollbar-hide">
+        {/* Tab strip — Vercel-style hairline border-bottom selected state.
+            Matches the post-boot tabs in page.tsx so dimensions stay
+            stable when the real tabs render. Inert during shell. */}
+        <div className="flex items-center gap-1 mb-6 sm:mb-8 overflow-x-auto -mx-3 sm:mx-0 px-3 sm:px-0 scrollbar-hide border-b border-line/10">
           {['Overview', 'Tracker', 'Documents', 'Reports', 'DSC & DIN', 'Notices'].map((label) => (
             <div
               key={label}
-              className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 whitespace-nowrap flex-shrink-0 ${
+              className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px whitespace-nowrap flex-shrink-0 ${
                 label.toLowerCase() === activeTab
-                  ? 'border-white/40 bg-white/10 text-white'
-                  : 'border-white/20 bg-black text-gray-500'
+                  ? 'text-fg-primary border-fg-primary'
+                  : 'text-fg-muted border-transparent'
               }`}
             >
-              <div className="w-4 h-4 sm:w-[18px] sm:h-[18px] rounded bg-white/10 animate-pulse" />
+              <div className="w-4 h-4 sm:w-[18px] sm:h-[18px] rounded bg-line/15 animate-pulse" />
               <span className="text-sm sm:text-base">{label}</span>
             </div>
           ))}
@@ -115,8 +113,8 @@ function TrackerSectionShell({ shellCategories }: { shellCategories: string[] })
       {/* Title row: "Regulatory Timeline" + view switcher */}
       <div className="flex items-center justify-between mb-4 sm:mb-6 flex-wrap gap-3">
         <div>
-          <h2 className="text-2xl sm:text-3xl font-light text-white">Regulatory Timeline</h2>
-          <p className="text-gray-400 text-sm mt-1">
+          <h2 className="text-xl sm:text-2xl font-medium text-fg-primary tracking-tight">Regulatory Timeline</h2>
+          <p className="text-fg-muted text-sm mt-1">
             Keep track of upcoming tax and compliance deadlines.
           </p>
         </div>

--- a/app/data-room/components/tracker/RequirementDesktopTableView.tsx
+++ b/app/data-room/components/tracker/RequirementDesktopTableView.tsx
@@ -407,7 +407,7 @@ export default function RequirementDesktopTableView({
                               <circle cx="12" cy="12" r="10" />
                               <polyline points="12 6 12 12 16 14" />
                             </svg>
-                            <span className="text-sm whitespace-nowrap">{req.dueDate}</span>
+                            <span className="text-sm font-mono tabular-nums whitespace-nowrap">{req.dueDate}</span>
                           </div>
                           {daysDelayed !== null && daysDelayed > 0 && (
                             <div className="text-red-400 text-xs mt-1 ml-6">

--- a/app/data-room/components/tracker/TrackerHeader.tsx
+++ b/app/data-room/components/tracker/TrackerHeader.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React from 'react'
+import Button from '@/components/ui/Button'
 
 interface TrackerHeaderProps {
   trackerView: 'list' | 'calendar'
@@ -28,21 +29,22 @@ export default function TrackerHeader({
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
-        <h2 className="text-xl sm:text-3xl font-light text-white mb-1 sm:mb-2">Regulatory Timeline</h2>
-        <p className="text-gray-400 text-sm sm:text-base">Keep track of upcoming tax and compliance deadlines.</p>
+        <h2 className="text-xl sm:text-2xl font-medium text-fg-primary tracking-tight mb-1">Regulatory Timeline</h2>
+        <p className="text-fg-muted text-sm">Keep track of upcoming tax and compliance deadlines.</p>
       </div>
-      <div className="flex flex-wrap items-center gap-2 sm:gap-3">
-        {/* View Toggle */}
-        <div className="flex items-center gap-1 sm:gap-2 bg-gray-800 rounded-lg p-0.5 sm:p-1">
+      <div className="flex flex-wrap items-center gap-2">
+        {/* View Toggle — segmented control */}
+        <div className="inline-flex items-center bg-bg-elevated rounded-token-md p-0.5 border border-line/10">
           <button
+            type="button"
             onClick={() => setTrackerView('list')}
-            className={`px-2 sm:px-4 py-1.5 sm:py-2 rounded-md transition-colors flex items-center gap-1 sm:gap-2 text-xs sm:text-sm ${trackerView === 'list'
-                ? 'bg-white text-black'
-                : 'text-gray-400 hover:text-white'
+            className={`px-2.5 sm:px-3 py-1 rounded-token-sm transition-colors duration-token ease-token flex items-center gap-1.5 text-xs ${trackerView === 'list'
+                ? 'bg-bg-card text-fg-primary shadow-sm'
+                : 'text-fg-muted hover:text-fg-primary'
               }`}
             title="List View"
           >
-            <svg width="14" height="14" className="sm:w-4 sm:h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <line x1="8" y1="6" x2="21" y2="6" />
               <line x1="8" y1="12" x2="21" y2="12" />
               <line x1="8" y1="18" x2="21" y2="18" />
@@ -53,44 +55,43 @@ export default function TrackerHeader({
             <span className="hidden sm:inline">List</span>
           </button>
           <button
+            type="button"
             onClick={() => setTrackerView('calendar')}
-            className={`px-2 sm:px-4 py-1.5 sm:py-2 rounded-md transition-colors flex items-center gap-1 sm:gap-2 text-xs sm:text-sm ${trackerView === 'calendar'
-                ? 'bg-white text-black'
-                : 'text-gray-400 hover:text-white'
+            className={`px-2.5 sm:px-3 py-1 rounded-token-sm transition-colors duration-token ease-token flex items-center gap-1.5 text-xs ${trackerView === 'calendar'
+                ? 'bg-bg-card text-fg-primary shadow-sm'
+                : 'text-fg-muted hover:text-fg-primary'
               }`}
             title="Calendar View"
           >
-            <svg width="14" height="14" className="sm:w-4 sm:h-4 hidden sm:inline" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
               <line x1="16" y1="2" x2="16" y2="6" />
               <line x1="8" y1="2" x2="8" y2="6" />
               <line x1="3" y1="10" x2="21" y2="10" />
             </svg>
             <span className="hidden sm:inline">Calendar</span>
-            <span className="sm:hidden">Calendar</span>
           </button>
         </div>
-        <button
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={refreshRequirements}
           disabled={isLoadingRequirements}
-          className="bg-gray-800 text-gray-300 px-2 sm:px-4 py-1.5 sm:py-2 rounded-lg hover:bg-gray-700 transition-colors flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm"
+          loading={isLoadingRequirements}
+          iconLeft={
+            !isLoadingRequirements ? (
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
+              </svg>
+            ) : null
+          }
           title="Refresh requirements"
         >
-          <svg
-            width="14"
-            height="14"
-            className={`sm:w-4 sm:h-4 ${isLoadingRequirements ? 'animate-spin' : ''}`}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2" />
-          </svg>
           <span className="hidden sm:inline">Refresh</span>
-        </button>
+        </Button>
         {canEdit && (
-          <button
+          <Button
+            size="sm"
             onClick={() => {
               setRequirementForm({
                 category: '',
@@ -107,49 +108,33 @@ export default function TrackerHeader({
               })
               setIsCreateModalOpen(true)
             }}
-            className="bg-white text-black px-3 sm:px-6 py-2 sm:py-3 rounded-lg hover:bg-gray-700 transition-colors flex items-center gap-1.5 sm:gap-2 font-medium text-xs sm:text-base"
+            iconLeft={
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="12" y1="5" x2="12" y2="19" />
+                <line x1="5" y1="12" x2="19" y2="12" />
+              </svg>
+            }
           >
-            <svg
-              width="14"
-              height="14"
-              className="sm:w-[18px] sm:h-[18px]"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
             <span className="hidden sm:inline">Add Compliance</span>
             <span className="sm:hidden">Add</span>
-          </button>
+          </Button>
         )}
-        <button
+        <Button
+          variant="secondary"
+          size="sm"
           onClick={handleCalendarSync}
-          className="bg-primary-dark-card border border-gray-700 text-white px-3 sm:px-6 py-2 sm:py-3 rounded-lg hover:border-white/40/50 transition-colors flex items-center gap-1.5 sm:gap-2 font-medium text-xs sm:text-base"
+          iconLeft={
+            <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+              <line x1="16" y1="2" x2="16" y2="6" />
+              <line x1="8" y1="2" x2="8" y2="6" />
+              <line x1="3" y1="10" x2="21" y2="10" />
+            </svg>
+          }
         >
-          <svg
-            width="14"
-            height="14"
-            className="sm:w-[18px] sm:h-[18px]"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
-            <line x1="16" y1="2" x2="16" y2="6" />
-            <line x1="8" y1="2" x2="8" y2="6" />
-            <line x1="3" y1="10" x2="21" y2="10" />
-          </svg>
           <span className="hidden sm:inline">Sync Calendar</span>
           <span className="sm:hidden">Sync</span>
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/app/data-room/components/vault/VaultTreeView.tsx
+++ b/app/data-room/components/vault/VaultTreeView.tsx
@@ -718,7 +718,7 @@ function DocumentRow({
         className="flex-1 text-left min-w-0 flex items-center gap-2 hover:text-white transition-colors"
         title="Click to view document"
       >
-        <span className="text-xs text-gray-200 truncate">{doc.fileName || 'Unnamed document'}</span>
+        <span className="text-xs font-mono text-fg-secondary truncate">{doc.fileName || 'Unnamed document'}</span>
         {hasVersionHistory && (
           <button
             type="button"

--- a/app/data-room/page.tsx
+++ b/app/data-room/page.tsx
@@ -4002,10 +4002,7 @@ function DataRoomPageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
-      {/* Subtle Circuit Board Background */}
-      <SubtleCircuitBackground />
-
+    <div className="min-h-screen bg-bg-base relative">
       {/* Header */}
       <Header />
 
@@ -4013,11 +4010,11 @@ function DataRoomPageInner() {
       {accessType === "trial" &&
         trialDaysRemaining !== null &&
         currentCompany && (
-          <div className="relative z-20 bg-gradient-to-r from-white/10 to-gray-600/20 border-b border-white/20">
-            <div className="container mx-auto px-3 sm:px-4 py-2 sm:py-3 flex items-center justify-between">
+          <div className="relative z-20 bg-accent-warn/10 border-b border-accent-warn/20">
+            <div className="container mx-auto px-3 sm:px-4 py-2 flex items-center justify-between">
               <div className="flex items-center gap-2 text-sm">
                 <svg
-                  className="w-4 h-4 text-white"
+                  className="w-4 h-4 text-accent-warn"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -4029,20 +4026,20 @@ function DataRoomPageInner() {
                     d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
                   />
                 </svg>
-                <span className="text-gray-300">
-                  <span className="text-white font-semibold">
-                    {trialDaysRemaining} days
+                <span className="text-fg-secondary">
+                  <span className="text-fg-primary font-medium font-mono tabular-nums">
+                    {trialDaysRemaining}
                   </span>{" "}
-                  left in your trial
+                  days left in your trial
                 </span>
               </div>
               <button
                 onClick={() =>
                   router.push(`/subscribe?company_id=${currentCompany.id}`)
                 }
-                className="text-xs sm:text-sm bg-white text-black px-3 py-1 rounded-lg hover:bg-gray-700 transition-colors"
+                className="text-xs sm:text-sm font-medium text-accent-warn hover:opacity-80 transition-opacity"
               >
-                Upgrade Now
+                Upgrade →
               </button>
             </div>
           </div>
@@ -4052,7 +4049,7 @@ function DataRoomPageInner() {
       <div className="relative z-10 container mx-auto px-3 sm:px-4 py-4 sm:py-8 animate-fadeIn">
         {/* Company Selector */}
         <div className="mb-4 sm:mb-6">
-          <h2 className="text-gray-400 text-sm font-medium mb-2 sm:mb-3">
+          <h2 className="text-fg-muted text-xs font-medium uppercase tracking-wider mb-2 sm:mb-3">
             My companies
           </h2>
           <CompanySelector
@@ -4064,12 +4061,12 @@ function DataRoomPageInner() {
         </div>
 
         {/* Page Title */}
-        <h1 className="text-2xl sm:text-4xl font-light text-white mb-4 sm:mb-6">
+        <h1 className="text-2xl sm:text-3xl font-medium text-fg-primary tracking-tight mb-4 sm:mb-6">
           Data Room
         </h1>
 
         {/* Horizontal Tabs - Scrollable on Mobile */}
-        <div className="flex items-center gap-2 mb-4 sm:mb-8 overflow-x-auto pb-2 -mx-3 sm:mx-0 px-3 sm:px-0 scrollbar-hide">
+        <div className="flex items-center gap-1 mb-6 sm:mb-8 overflow-x-auto -mx-3 sm:mx-0 px-3 sm:px-0 scrollbar-hide border-b border-line/10">
           <button
             onClick={() => {
               const startTime = performance.now();
@@ -4082,10 +4079,10 @@ function DataRoomPageInner() {
                 });
               });
             }}
-            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 transition-colors whitespace-nowrap flex-shrink-0 ${
+            className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               activeTab === "overview"
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 bg-black text-white hover:text-white hover:border-white/40"
+                ? "text-fg-primary border-fg-primary"
+                : "text-fg-muted border-transparent hover:text-fg-primary"
             }`}
           >
             <svg
@@ -4117,10 +4114,10 @@ function DataRoomPageInner() {
                 import("./components/tracker/TrackerTab");
               }
             }}
-            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 transition-colors whitespace-nowrap flex-shrink-0 ${
+            className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               activeTab === "tracker"
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 bg-black text-white hover:text-white hover:border-white/40"
+                ? "text-fg-primary border-fg-primary"
+                : "text-fg-muted border-transparent hover:text-fg-primary"
             }`}
           >
             <svg
@@ -4140,10 +4137,10 @@ function DataRoomPageInner() {
           </button>
           <button
             onClick={() => startTransition(() => setActiveTab("documents"))}
-            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 transition-colors whitespace-nowrap flex-shrink-0 ${
+            className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               activeTab === "documents"
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 bg-black text-white hover:text-white hover:border-white/40"
+                ? "text-fg-primary border-fg-primary"
+                : "text-fg-muted border-transparent hover:text-fg-primary"
             }`}
           >
             <svg
@@ -4167,10 +4164,10 @@ function DataRoomPageInner() {
           </button>
           <button
             onClick={() => startTransition(() => setActiveTab("reports"))}
-            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 transition-colors whitespace-nowrap flex-shrink-0 ${
+            className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               activeTab === "reports"
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 bg-black text-white hover:text-white hover:border-white/40"
+                ? "text-fg-primary border-fg-primary"
+                : "text-fg-muted border-transparent hover:text-fg-primary"
             }`}
           >
             <svg
@@ -4194,10 +4191,10 @@ function DataRoomPageInner() {
           </button>
           <button
             onClick={() => startTransition(() => setActiveTab("dsc-din"))}
-            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 transition-colors whitespace-nowrap flex-shrink-0 ${
+            className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               activeTab === "dsc-din"
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 bg-black text-white hover:text-white hover:border-white/40"
+                ? "text-fg-primary border-fg-primary"
+                : "text-fg-muted border-transparent hover:text-fg-primary"
             }`}
           >
             <svg
@@ -4220,10 +4217,10 @@ function DataRoomPageInner() {
           </button>
           <button
             onClick={() => startTransition(() => setActiveTab("notices"))}
-            className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 transition-colors whitespace-nowrap flex-shrink-0 ${
+            className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
               activeTab === "notices"
-                ? "border-white/40 bg-white/10 text-white"
-                : "border-white/20 bg-black text-white hover:text-white hover:border-white/40"
+                ? "text-fg-primary border-fg-primary"
+                : "text-fg-muted border-transparent hover:text-fg-primary"
             }`}
           >
             <svg
@@ -4248,10 +4245,10 @@ function DataRoomPageInner() {
           {countryCode === "IN" && (
             <button
               onClick={() => startTransition(() => setActiveTab("gst"))}
-              className={`flex items-center gap-1.5 sm:gap-2 px-3 sm:px-6 py-2 sm:py-3 rounded-lg border-2 transition-colors whitespace-nowrap flex-shrink-0 ${
+              className={`flex items-center gap-2 px-3 sm:px-4 py-2.5 sm:py-3 border-b-2 -mb-px transition-colors whitespace-nowrap flex-shrink-0 ${
                 activeTab === "gst"
-                  ? "border-white/40 bg-white/10 text-white"
-                  : "border-white/20 bg-black text-white hover:text-white hover:border-white/40"
+                  ? "text-fg-primary border-fg-primary"
+                  : "text-fg-muted border-transparent hover:text-fg-primary"
               }`}
             >
               <svg

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -60,7 +60,7 @@ export default function Header() {
   }
 
   return (
-    <header className="bg-primary-dark border-b border-gray-800/50 sticky top-0 z-50" style={{ overflow: 'visible' }}>
+    <header className="bg-bg-base/80 backdrop-blur-md border-b border-line/10 sticky top-0 z-50" style={{ overflow: 'visible' }}>
       <div className="container mx-auto px-3 sm:px-4 py-3 sm:py-4" style={{ overflow: 'visible' }}>
         <div className="flex items-center justify-between" style={{ overflow: 'visible' }}>
           {/* Logo */}
@@ -74,34 +74,34 @@ export default function Header() {
 
           {/* Navigation (Desktop) */}
           <nav className="hidden md:flex items-center gap-6">
-            <a 
-              href="/data-room" 
-              className={`font-light pb-1 transition-colors ${
-                pathname === '/data-room' 
-                  ? 'text-white border-b-2 border-gray-600' 
-                  : 'text-gray-400 hover:text-white'
+            <a
+              href="/data-room"
+              className={`text-sm transition-colors ${
+                pathname === '/data-room'
+                  ? 'text-fg-primary font-medium'
+                  : 'text-fg-muted hover:text-fg-primary'
               }`}
             >
               Data Room
             </a>
             {isSuperadmin && (
-              <a 
-                href="/admin" 
-                className={`font-light transition-colors ${
-                  pathname?.startsWith('/admin') 
-                    ? 'text-white border-b-2 border-gray-600 pb-1' 
-                    : 'text-gray-400 hover:text-white'
+              <a
+                href="/admin"
+                className={`text-sm transition-colors ${
+                  pathname?.startsWith('/admin')
+                    ? 'text-fg-primary font-medium'
+                    : 'text-fg-muted hover:text-fg-primary'
                 }`}
               >
                 Admin
               </a>
             )}
-            <a 
-              href="/team" 
-              className={`font-light transition-colors ${
-                pathname === '/team' 
-                  ? 'text-white border-b-2 border-gray-600 pb-1' 
-                  : 'text-gray-400 hover:text-white'
+            <a
+              href="/team"
+              className={`text-sm transition-colors ${
+                pathname === '/team'
+                  ? 'text-fg-primary font-medium'
+                  : 'text-fg-muted hover:text-fg-primary'
               }`}
             >
               Team


### PR DESCRIPTION
## Summary

The foundation tokens, fonts, and primitives shipped in #88–#91 didn't visibly transform the app because nothing was consuming them. **This is the sweep that does.** Six files, surgical edits — but the whole data-room now reads like Vercel/Linear instead of a 2018-era admin dashboard.

## Before → After

**Body chrome**
- Decorative circuit-pattern radial gradient overlay → flat `bg-bg-base` (token, themable).
- Trial banner gradient + chunky white pill → `accent-warn` tinted bar + text link + **mono tabular-nums** day count.

**Header**
- `bg-primary-dark border-gray-800/50` → `bg-bg-base/80 backdrop-blur-md border-line/10` (translucent sticky chrome — Vercel pattern).
- Nav links: chunky `border-b-2 border-gray-600` active state → `text-fg-primary font-medium` / `text-fg-muted hover:text-fg-primary`.

**Data Room page chrome**
- "Data Room" h1: `text-4xl font-light` (thin) → `text-3xl font-medium tracking-tight` (Vercel-tight).
- "My companies" subhead: gray sentence-case → uppercase tracking-wider eyebrow.
- Tab strip: chunky `rounded-lg border-2 border-white/40 bg-white/10` → hairline `border-b-2 -mb-px` on a strip with `border-b border-line/10`. Selected uses `text-fg-primary border-fg-primary`; unselected `text-fg-muted border-transparent`.

**Tracker**
- `TrackerHeader.tsx`: "Regulatory Timeline" h2 thinned → `font-medium tracking-tight`. View toggle: chunky `bg-gray-800` pills → segmented control with `bg-bg-elevated` + `shadow-sm` on selected. Toolbar buttons → `<Button>` primitive (#89) with `iconLeft` and loading state.
- `RequirementDesktopTableView.tsx`: due-date column gets `font-mono tabular-nums` — dates align across rows like a CA's spreadsheet.

**Vault**
- `VaultTreeView.tsx`: filenames get `font-mono` — Linear/Vercel filesystem pattern.

**Boot shell**
- `DataRoomBootShell.tsx` mirrors all of the above so loading→loaded has zero visual shift.

## What's *not* in this PR (intentionally)

- Re-skin of every modal, the Documents tab, GST tab, DSC/DIN tab, settings pages, and admin pages. Those don't churn enough on a typical user's day to be worth the blast radius now. Can be follow-ups.
- Empty-state and skeleton overhaul (was scoped as PR-9). Defer until the broader sweep stabilizes.
- Motion sweep (PR-10). Defer.
- Per-row chip system in tracker rows. The Chip primitive (#90) is ready; sweep happens when the deep RequirementDesktopTableView interior gets touched.

## Functional safety

- No state, no handlers, no server actions, no hooks touched. Pure className/visual swaps + Button primitive adoption.
- 947-line `Header.tsx` touched in 3 surgical hunks; deep notification panel / mobile drawer / user menu logic untouched.
- Every existing legacy class in unswept files (modals, GST tab, etc.) keeps rendering identically.
- `tsc --noEmit` clean across the project.

## Test plan

- [ ] Sign in → `/data-room` — entire body+header reads like Vercel: hairline borders, generous whitespace, no gradients.
- [ ] Tab strip — clicking each tab still works; selected tab shows hairline underline, not chunky pill.
- [ ] "Regulatory Timeline" header: tighter title, segmented View/Calendar toggle, primary Add button.
- [ ] Tracker rows: due dates render in mono.
- [ ] Vault: filenames render in mono.
- [ ] Trial banner (if applicable): shows day count in mono on a clean amber strip.
- [ ] Theme toggle (top-right): flip to light → body, header, tab strip, all token-driven elements re-skin cleanly.
- [ ] Modal-driven flows (CIA chat, document upload, requirement edit) — unaffected, render in legacy dark.
- [ ] All deep functionality (CIN verify, doc upload, status updates, ingest jobs, notifications) — unchanged.

## Branch hygiene

- Branched off `origin/main` (after PR-6 #91 squash-merged).
- Zero merge commits between work and target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)