### PR TITLE
feat(ui): futuristic skin — indigo brand, aurora text, graph-paper grid (PR-13)

### DIFF
--- a/app/data-room/components/DataRoomBootShell.tsx
+++ b/app/data-room/components/DataRoomBootShell.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import Header from '@/components/layout/Header'
+import HeroGlows from '@/components/ui/HeroGlows'
 import TrackerCategoryAccordionView from './tracker/TrackerCategoryAccordionView'
 import { getCountryConfig } from '@/lib/config/countries'
 
@@ -50,6 +51,12 @@ export default function DataRoomBootShell({
 
   return (
     <div className="min-h-screen bg-bg-base relative">
+      {/* PR-13: futuristic skin — same bg-grid + glows as page.tsx so
+          loading→loaded has zero shift. */}
+      <div className="absolute inset-x-0 top-0 h-[640px] bg-grid pointer-events-none overflow-hidden" />
+      <div className="absolute inset-x-0 top-0 h-[640px] pointer-events-none overflow-hidden">
+        <HeroGlows />
+      </div>
       <Header />
 
       <div className="relative z-10 container mx-auto px-3 sm:px-4 py-4 sm:py-8">
@@ -59,8 +66,17 @@ export default function DataRoomBootShell({
           <div className="h-[72px] sm:h-[84px] rounded-token-md border border-line/10 bg-bg-card animate-pulse" />
         </div>
 
-        {/* Page Title — real, no shell */}
-        <h1 className="text-2xl sm:text-3xl font-medium text-fg-primary tracking-tight mb-4 sm:mb-6">Data Room</h1>
+        {/* Page Title — eyebrow + display headline with aurora accent.
+            Same shape as page.tsx so loading→loaded has zero shift. */}
+        <div className="mb-6 sm:mb-8">
+          <span className="inline-flex items-center gap-1.5 text-[10px] sm:text-[11px] font-semibold tracking-[0.18em] uppercase text-fg-secondary bg-bg-card border border-line/15 rounded-full px-3 py-1 mb-3">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-accent-brand" />
+            <span className="aurora-text">Live · {countryCode === 'SA' ? 'Saudi Arabia' : 'India'}</span>
+          </span>
+          <h1 className="text-3xl sm:text-5xl lg:text-6xl font-semibold text-fg-primary tracking-tight leading-[1.05]">
+            Data <span className="aurora-text">Room</span>
+          </h1>
+        </div>
 
         {/* Tab strip — Vercel-style hairline border-bottom selected state.
             Matches the post-boot tabs in page.tsx so dimensions stay
@@ -113,7 +129,7 @@ function TrackerSectionShell({ shellCategories }: { shellCategories: string[] })
       {/* Title row: "Regulatory Timeline" + view switcher */}
       <div className="flex items-center justify-between mb-4 sm:mb-6 flex-wrap gap-3">
         <div>
-          <h2 className="text-xl sm:text-2xl font-medium text-fg-primary tracking-tight">Regulatory Timeline</h2>
+          <h2 className="text-xl sm:text-2xl font-semibold text-fg-primary tracking-tight">Regulatory <span className="aurora-text">Timeline</span></h2>
           <p className="text-fg-muted text-sm mt-1">
             Keep track of upcoming tax and compliance deadlines.
           </p>

--- a/app/data-room/components/tracker/TrackerHeader.tsx
+++ b/app/data-room/components/tracker/TrackerHeader.tsx
@@ -29,7 +29,7 @@ export default function TrackerHeader({
   return (
     <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
       <div>
-        <h2 className="text-xl sm:text-2xl font-medium text-fg-primary tracking-tight mb-1">Regulatory Timeline</h2>
+        <h2 className="text-xl sm:text-2xl font-semibold text-fg-primary tracking-tight mb-1">Regulatory <span className="aurora-text">Timeline</span></h2>
         <p className="text-fg-muted text-sm">Keep track of upcoming tax and compliance deadlines.</p>
       </div>
       <div className="flex flex-wrap items-center gap-2">

--- a/app/data-room/page.tsx
+++ b/app/data-room/page.tsx
@@ -29,6 +29,7 @@ const DscDinTab = lazy(() => import("./components/DscDinTab"));
 import Header from "@/components/layout/Header";
 import CompanySelector from "@/components/features/CompanySelector";
 import SubtleCircuitBackground from "@/components/ui/SubtleCircuitBackground";
+import HeroGlows from "@/components/ui/HeroGlows";
 import { RequirementTableSkeleton } from "@/components/ui/skeletons/RequirementRowSkeleton";
 import { createClient } from "@/utils/supabase/client";
 import { useAuth } from "@/hooks/useAuth";
@@ -4003,6 +4004,15 @@ function DataRoomPageInner() {
 
   return (
     <div className="min-h-screen bg-bg-base relative">
+      {/* PR-13: futuristic skin — graph-paper grid + violet glow blobs
+          behind the hero area only. Both layers are absolute with no
+          z-index, so they naturally sit below Header (z-50 sticky) and
+          main content (relative z-10). pointer-events-none keeps clicks
+          flowing through to anything below. */}
+      <div className="absolute inset-x-0 top-0 h-[640px] bg-grid pointer-events-none overflow-hidden" />
+      <div className="absolute inset-x-0 top-0 h-[640px] pointer-events-none overflow-hidden">
+        <HeroGlows />
+      </div>
       {/* Header */}
       <Header />
 
@@ -4060,10 +4070,16 @@ function DataRoomPageInner() {
           />
         </div>
 
-        {/* Page Title */}
-        <h1 className="text-2xl sm:text-3xl font-medium text-fg-primary tracking-tight mb-4 sm:mb-6">
-          Data Room
-        </h1>
+        {/* Page Title — eyebrow chip + display headline with aurora accent */}
+        <div className="mb-6 sm:mb-8">
+          <span className="inline-flex items-center gap-1.5 text-[10px] sm:text-[11px] font-semibold tracking-[0.18em] uppercase text-fg-secondary bg-bg-card border border-line/15 rounded-full px-3 py-1 mb-3">
+            <span className="inline-block w-1.5 h-1.5 rounded-full bg-accent-brand" />
+            <span className="aurora-text">Live · {currentCompany?.country_code === 'SA' ? 'Saudi Arabia' : 'India'}</span>
+          </span>
+          <h1 className="text-3xl sm:text-5xl lg:text-6xl font-semibold text-fg-primary tracking-tight leading-[1.05]">
+            Data <span className="aurora-text">Room</span>
+          </h1>
+        </div>
 
         {/* Horizontal Tabs - Scrollable on Mobile */}
         <div className="flex items-center gap-1 mb-6 sm:mb-8 overflow-x-auto -mx-3 sm:mx-0 px-3 sm:px-0 scrollbar-hide border-b border-line/10">

--- a/app/globals.css
+++ b/app/globals.css
@@ -26,7 +26,14 @@
   --border-subtle: 255 255 255;  /* used with /5 alpha */
   --border-strong: 255 255 255;  /* used with /30 alpha */
 
-  --accent-brand: 30 58 95;     /* primary-navy */
+  /* PR-13: brand swapped from #1E3A5F navy to #4F46E5 indigo-600. The
+   * navy read "1995 enterprise"; the indigo reads "2026 SaaS". Cascades
+   * through the entire token system — every accent-brand consumer
+   * (focus rings, primary chip, magical onboarding) flips indigo
+   * automatically. accent-violet added as a sibling for aurora gradients
+   * and floating-glow blobs that pair with brand. */
+  --accent-brand: 79 70 229;    /* indigo-600 */
+  --accent-violet: 139 92 246;  /* violet-500 — companion to brand for gradients/glows */
   --accent-success: 33 115 70;  /* primary-green */
   --accent-warn: 234 179 8;     /* amber-500 */
   --accent-danger: 239 68 68;   /* red-500 */
@@ -117,4 +124,75 @@ select {
 
 .scrollbar-hide::-webkit-scrollbar {
   display: none;  /* Chrome, Safari and Opera */
+}
+
+/*
+ * PR-13: futuristic skin utilities.
+ *
+ * .aurora-text — animated gradient applied to text via background-clip.
+ *   The gradient slides across the text on a 6s loop. Used on key display
+ *   words ("Room", "Timeline", magical-intake hero). Adds the modern-SaaS
+ *   "shimmer" vibe without ANY layout cost — pure background-position
+ *   animation.
+ *
+ * .bg-grid — subtle 56px graph-paper grid. Replaces the circuit-pattern
+ *   we removed in PR-7. Masked with a radial vignette so it never
+ *   competes with content; fades to nothing toward viewport edges.
+ *
+ * .glow-blob — utility for absolutely-positioned violet glow shapes that
+ *   live behind heroes. Soft radial gradient, low opacity, blurred.
+ */
+
+@keyframes aurora-slide {
+  0% { background-position: 0% 50%; }
+  100% { background-position: 200% 50%; }
+}
+
+.aurora-text {
+  background-image: linear-gradient(
+    110deg,
+    rgb(var(--fg-primary)) 0%,
+    rgb(var(--accent-brand)) 35%,
+    rgb(var(--fg-primary)) 70%,
+    rgb(var(--accent-brand)) 100%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  animation: aurora-slide 6s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aurora-text {
+    animation: none;
+    background-position: 0% 50%;
+  }
+}
+
+.bg-grid {
+  background-image:
+    linear-gradient(to right, rgb(var(--border-default) / 0.08) 1px, transparent 1px),
+    linear-gradient(rgb(var(--border-default) / 0.08) 1px, transparent 1px);
+  background-size: 56px 56px;
+  -webkit-mask-image: radial-gradient(ellipse 80% 60% at 50% 35%, black 30%, transparent 80%);
+          mask-image: radial-gradient(ellipse 80% 60% at 50% 35%, black 30%, transparent 80%);
+}
+
+[data-theme='light'] .bg-grid {
+  background-image:
+    linear-gradient(to right, rgb(var(--border-default) / 0.12) 1px, transparent 1px),
+    linear-gradient(rgb(var(--border-default) / 0.12) 1px, transparent 1px);
+}
+
+.glow-blob {
+  position: absolute;
+  border-radius: 9999px;
+  filter: blur(60px);
+  pointer-events: none;
+  opacity: 0.35;
+}
+[data-theme='light'] .glow-blob {
+  opacity: 0.45;
 }

--- a/app/onboarding/MagicalIntake.tsx
+++ b/app/onboarding/MagicalIntake.tsx
@@ -155,8 +155,36 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden flex items-start justify-center pt-20 sm:pt-32 px-4">
-      <div className="w-full max-w-[520px]">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden flex items-start justify-center pt-20 sm:pt-32 px-4">
+      {/* PR-13: bg-grid + glow blobs for parity with the data-room hero. */}
+      <div className="absolute inset-x-0 top-0 h-[720px] bg-grid pointer-events-none" />
+      <div className="absolute inset-x-0 top-0 h-[720px] pointer-events-none overflow-hidden">
+        <div
+          aria-hidden="true"
+          className="glow-blob"
+          style={{
+            top: '40px',
+            left: '20%',
+            width: '320px',
+            height: '320px',
+            background:
+              'radial-gradient(circle, rgb(var(--accent-violet)) 0%, rgb(var(--accent-brand) / 0.6) 50%, transparent 80%)',
+          }}
+        />
+        <div
+          aria-hidden="true"
+          className="glow-blob"
+          style={{
+            top: '120px',
+            right: '15%',
+            width: '240px',
+            height: '240px',
+            background:
+              'radial-gradient(circle, rgb(var(--accent-brand)) 0%, rgb(var(--accent-violet) / 0.5) 60%, transparent 85%)',
+          }}
+        />
+      </div>
+      <div className="relative z-10 w-full max-w-[520px]">
         {/* Skip link top-right */}
         <div className="flex justify-end mb-6">
           <Button variant="ghost" size="sm" onClick={onSkip}>
@@ -166,8 +194,9 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
 
         {/* Hero */}
         <div className="mb-8 text-center">
-          <h1 className="font-sans text-3xl sm:text-4xl font-medium text-fg-primary tracking-tight mb-2">
-            Let's set up your company
+          <h1 className="font-sans text-4xl sm:text-5xl font-semibold text-fg-primary tracking-tight mb-2 leading-[1.05]">
+            Let's set up <br className="sm:hidden" />
+            your <span className="aurora-text">company</span>
           </h1>
           <p className="text-sm text-fg-muted">
             Two IDs and we'll handle the rest.

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -52,8 +52,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
     'inline-flex items-center justify-center gap-2 font-medium rounded-token-md transition-colors duration-token ease-token outline-none focus-visible:ring-2 focus-visible:ring-accent-brand/40 disabled:opacity-50 disabled:cursor-not-allowed'
 
   const variants: Record<ButtonVariant, string> = {
+    // PR-13: primary is now the brand indigo. Was bg-fg-primary (plain
+    // black/white) — that read flat and generic. Indigo gives primary
+    // CTAs the modern-SaaS punch the marketing landing established.
     primary:
-      'bg-fg-primary text-fg-inverse hover:opacity-90 active:opacity-80',
+      'bg-accent-brand text-white hover:opacity-90 active:opacity-80 shadow-sm shadow-accent-brand/20',
     secondary:
       'bg-bg-card text-fg-primary border border-line/15 hover:bg-bg-hover hover:border-line/30',
     ghost:

--- a/components/ui/HeroGlows.tsx
+++ b/components/ui/HeroGlows.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+/**
+ * PR-13: futuristic skin — floating glow blobs that live behind hero
+ * areas. Three softly-blurred violet/indigo gradients positioned
+ * absolutely. Pure decoration, pointer-events: none, prefers-reduced-
+ * motion safe (no animation on the blobs themselves — the page motion
+ * is in .aurora-text which already honors the preference).
+ *
+ * Caller is responsible for setting `position: relative` and
+ * `overflow: hidden` on the wrapping element so the blobs don't bleed.
+ *
+ * Costs ~0 layout perf — three divs with CSS filter:blur and opacity.
+ * GPU-composited.
+ */
+export default function HeroGlows() {
+  return (
+    <div aria-hidden="true" className="absolute inset-0 overflow-hidden pointer-events-none">
+      <div
+        className="glow-blob"
+        style={{
+          top: '-80px',
+          left: '15%',
+          width: '320px',
+          height: '320px',
+          background:
+            'radial-gradient(circle, rgb(var(--accent-violet)) 0%, rgb(var(--accent-brand) / 0.6) 50%, transparent 80%)',
+        }}
+      />
+      <div
+        className="glow-blob"
+        style={{
+          top: '20px',
+          right: '10%',
+          width: '240px',
+          height: '240px',
+          background:
+            'radial-gradient(circle, rgb(var(--accent-brand)) 0%, rgb(var(--accent-violet) / 0.5) 60%, transparent 85%)',
+        }}
+      />
+      <div
+        className="glow-blob"
+        style={{
+          top: '160px',
+          left: '40%',
+          width: '180px',
+          height: '180px',
+          background:
+            'radial-gradient(circle, rgb(var(--accent-violet) / 0.7) 0%, transparent 75%)',
+          opacity: 0.25,
+        }}
+      />
+    </div>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -43,6 +43,7 @@ const config: Config = {
         },
         accent: {
           brand: 'rgb(var(--accent-brand) / <alpha-value>)',
+          violet: 'rgb(var(--accent-violet) / <alpha-value>)',
           success: 'rgb(var(--accent-success) / <alpha-value>)',
           warn: 'rgb(var(--accent-warn) / <alpha-value>)',
           danger: 'rgb(var(--accent-danger) / <alpha-value>)',


### PR DESCRIPTION
## Summary

The previous flagship sweep (#92) made the app look clean, but you noted it still didn't feel "futuristic" like [superaccountant-marketing](https://superaccountant-marketing.vercel.app/). I extracted the actual computed styles from that landing page (Inter at 72px/600/-1.8px tracking, indigo `#4F46E5` brand, animated aurora gradient text, 56px graph-paper grid masked with radial vignette, soft violet glow blobs).

This PR ports that aesthetic to our app surfaces — **8 files, 212 insertions, 14 deletions, no logic touched**.

## The recipe (6 stacked tricks)

### 1. Brand color: navy → indigo
- `--accent-brand`: `30 58 95` (navy, "1995 enterprise") → `79 70 229` (indigo-600, "2026 SaaS").
- New companion `--accent-violet`: `139 92 246`.
- **Cascades automatically** through tokens — every focus ring, primary chip, accent-brand consumer flips at once.

### 2. `.aurora-text` utility
- 110deg gradient (fg → accent-brand → fg → accent-brand), `background-size: 200%`, `background-clip: text`, animated with `aurora-slide 6s linear infinite`.
- Applied to: "Room" in `Data Room`, "Timeline" in `Regulatory Timeline`, "company" in magical onboarding, eyebrow chip text.
- `prefers-reduced-motion` → animation halted, static gradient still renders.

### 3. `.bg-grid` utility
- Two crossed `linear-gradient`s form a 56×56px graph-paper grid (1px lines).
- `mask-image: radial-gradient(ellipse at center, black, transparent)` — fades out toward edges, never competes with content.

### 4. `HeroGlows.tsx` — floating violet/indigo blobs
- 3 absolutely-positioned radial gradients with `filter: blur(60px)` and low opacity.
- GPU-composited, ~0 perf cost.

### 5. Display typography bump
- "Data Room" h1: `text-3xl font-medium` → `text-3xl sm:text-5xl lg:text-6xl font-semibold tracking-tight leading-[1.05]` (~2× at desktop).
- "Regulatory Timeline" h2: `font-medium` → `font-semibold` + aurora on "Timeline".
- Magical intake hero: `text-3xl sm:text-4xl` → `text-4xl sm:text-5xl font-semibold` + aurora on "company".
- New eyebrow chip pattern: indigo dot + uppercase tracking-wider + aurora text. Above Data Room title.

### 6. Button primary → indigo
- Was `bg-fg-primary` (plain black/white) — read flat and generic.
- Now `bg-accent-brand text-white shadow-sm shadow-accent-brand/20` — primary CTAs glow indigo. Verify CIN button on magical onboarding auto-inherits.

## Functional safety

- **No state, handlers, hooks, server actions touched.** Pure CSS + className changes.
- Magical intake's `bg-primary-dark` (legacy hard-coded) → `bg-bg-base` (token). Bonus: light mode now properly skins onboarding.
- DataRoomBootShell mirrors page.tsx 1:1 (grid + glows + new h1 + eyebrow + new h2) so loading → loaded has zero shift.
- `tsc --noEmit` clean across the project.

## Files changed
- `app/globals.css` — accent-brand value swap + aurora-text + bg-grid + glow-blob utilities + reduced-motion guard.
- `tailwind.config.ts` — accent-violet sibling token.
- `components/ui/Button.tsx` — primary variant indigo.
- `components/ui/HeroGlows.tsx` (new) — 3 floating glow blobs.
- `app/data-room/page.tsx` — bg-grid layer + HeroGlows + eyebrow + display h1 with aurora.
- `app/data-room/components/DataRoomBootShell.tsx` — mirrors page.tsx (zero load-shift).
- `app/data-room/components/tracker/TrackerHeader.tsx` — h2 aurora on "Timeline".
- `app/onboarding/MagicalIntake.tsx` — display hero + bg-grid + glows + token-driven body.

## Test plan
- [ ] `/data-room` desktop — body has subtle graph-paper grid in the top 640px, fades toward bottom. Soft violet glow blobs behind hero.
- [ ] "Live · India" eyebrow chip above Data Room title — indigo dot + animated aurora text on the country.
- [ ] "Data Room" — much bigger headline, aurora on the word "Room" (animated indigo sweep).
- [ ] "Regulatory Timeline" — aurora on "Timeline".
- [ ] Magical onboarding — same aurora treatment on "company", same grid + glows.
- [ ] All primary buttons (Verify, Add Compliance, Get started) now indigo with subtle indigo shadow.
- [ ] Theme toggle → light mode: grid lines slightly heavier, glow blobs slightly more opaque, aurora gradients still clearly visible.
- [ ] Reload during loading → boot shell has same grid/glows/h1/h2 — no flash.
- [ ] `prefers-reduced-motion` (OS setting) → aurora text stops animating, gradient still renders statically.
- [ ] Existing functionality (CIN verify, doc upload, status updates, ingest) — completely unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)