### PR TITLE
feat(ui): polish CompanySelector + EvaluationPanel + EmptyState (PR-16)

### DIFF
--- a/app/data-room/components/tracker/TrackerEmptyState.tsx
+++ b/app/data-room/components/tracker/TrackerEmptyState.tsx
@@ -54,12 +54,12 @@ export default function TrackerEmptyState({
     const hasNoRequirements = displayRequirements.length === 0 && regulatoryRequirements.length === 0
 
     return (
-      <div className="py-8 sm:py-12 flex flex-col items-center justify-center">
-        <div className="w-12 h-12 sm:w-16 sm:h-16 border-2 border-gray-700 rounded-full flex items-center justify-center mb-4">
+      <div className="py-12 sm:py-16 flex flex-col items-center justify-center">
+        <div className="w-14 h-14 border border-line/15 bg-bg-card rounded-full flex items-center justify-center mb-4">
           <svg
-            width="24"
-            height="24"
-            className="sm:w-8 sm:h-8 text-gray-600"
+            width="22"
+            height="22"
+            className="text-fg-muted"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -72,8 +72,8 @@ export default function TrackerEmptyState({
         </div>
         {hasActiveFilters ? (
           <>
-            <p className="text-gray-400 text-sm sm:text-base font-medium mb-2">No requirements match your filters</p>
-            <p className="text-gray-500 text-xs sm:text-sm mb-4 text-center px-4">
+            <p className="text-fg-primary text-sm font-medium mb-1.5">No requirements match your filters</p>
+            <p className="text-fg-muted text-xs mb-5 text-center px-4">
               Try adjusting your search or filters to see more results
             </p>
             <button
@@ -85,18 +85,18 @@ export default function TrackerEmptyState({
                 setCategoryFilter('all')
                 setSelectedCategory('all')
               }}
-              className="px-4 py-2 bg-white text-black rounded-lg hover:bg-gray-200 transition-colors text-sm font-medium"
+              className="px-4 py-2 bg-bg-card border border-line/15 text-fg-secondary hover:border-line/30 hover:text-fg-primary rounded-token-md transition-colors duration-token ease-token text-xs font-medium"
             >
-              Clear All Filters
+              Clear all filters
             </button>
           </>
         ) : hasNoRequirements ? (
           <>
-            <p className="text-gray-400 text-sm sm:text-base font-medium mb-2">No regulatory requirements yet</p>
-            <p className="text-gray-500 text-xs sm:text-sm mb-4 text-center px-4">
+            <p className="text-fg-primary text-sm font-medium mb-1.5">No regulatory requirements yet</p>
+            <p className="text-fg-muted text-xs mb-5 text-center max-w-md px-4 leading-relaxed">
               {canEdit
-                ? "Get started by adding your first compliance requirement. Requirements are automatically generated based on your company profile, or you can add custom ones."
-                : "No compliance requirements have been set up for this company yet."}
+                ? 'Get started by adding your first compliance requirement. Requirements are automatically generated based on your company profile, or you can add custom ones.'
+                : 'No compliance requirements have been set up for this company yet.'}
             </p>
             {canEdit && (
               <button
@@ -116,18 +116,18 @@ export default function TrackerEmptyState({
                   })
                   setIsCreateModalOpen(true)
                 }}
-                className="px-4 py-2 bg-white text-black rounded-lg hover:bg-gray-200 transition-colors text-sm font-medium flex items-center gap-2"
+                className="px-4 py-2 bg-accent-brand text-white rounded-token-md hover:opacity-90 shadow-sm shadow-accent-brand/20 transition-opacity duration-token ease-token text-xs font-medium flex items-center gap-2"
               >
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                   <line x1="12" y1="5" x2="12" y2="19" />
                   <line x1="5" y1="12" x2="19" y2="12" />
                 </svg>
-                Add First Requirement
+                Add first requirement
               </button>
             )}
           </>
         ) : (
-          <p className="text-gray-500 text-sm sm:text-base">No regulatory requirements found</p>
+          <p className="text-fg-muted text-sm">No regulatory requirements found</p>
         )}
       </div>
     )
@@ -142,15 +142,12 @@ function TrackerLoadingState() {
     messages: COMPLIANCE_TRACKER_LOADING_MESSAGES,
   })
   return (
-    <div className="py-8 sm:py-12 flex flex-col items-center justify-center">
-      <div className="relative mb-6">
-        <div className="w-12 h-12 sm:w-14 sm:h-14 border-4 border-white/30 border-t-transparent rounded-full animate-spin"></div>
-        <div className="absolute inset-0 flex items-center justify-center">
-          <div className="w-6 h-6 bg-gradient-to-br from-blue-500/30 to-purple-500/30 rounded-full animate-pulse"></div>
-        </div>
+    <div className="py-12 sm:py-16 flex flex-col items-center justify-center">
+      <div className="relative mb-5">
+        <div className="w-10 h-10 border-2 border-accent-brand/30 border-t-accent-brand rounded-full animate-spin" />
       </div>
-      <p className="text-gray-300 text-sm sm:text-base font-medium mb-1">Loading Compliance Tracker</p>
-      <p className="text-gray-500 text-xs sm:text-sm" key={message}>{message}</p>
+      <p className="text-fg-primary text-sm font-medium mb-1">Loading compliance tracker</p>
+      <p className="text-fg-muted text-xs" key={message}>{message}</p>
     </div>
   )
 }

--- a/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
+++ b/app/data-room/components/tracker/TrackerEvaluationPanel.tsx
@@ -164,19 +164,22 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
   // ── Compact strip when nothing is pending ──────────────────────────────
   if (!hasAnything) {
     return (
-      <div className="flex items-center justify-between px-4 py-2 bg-gray-900/40 border border-white/5 rounded-lg">
-        <div className="flex items-center gap-2 text-xs text-gray-400">
-          <svg className="w-3.5 h-3.5 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="flex items-center justify-between px-4 py-2 bg-bg-elevated border border-line/10 rounded-token-md">
+        <div className="flex items-center gap-2 text-xs text-fg-muted">
+          <svg className="w-3.5 h-3.5 text-accent-success" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M5 13l4 4L19 7" />
           </svg>
-          <span>Compliance applicability is up to date for {financialYear}.</span>
+          <span>
+            Compliance applicability is up to date for{' '}
+            <span className="font-mono tabular-nums text-fg-secondary">{financialYear}</span>.
+          </span>
         </div>
         <button
           onClick={() => handleEvaluate()}
           disabled={running}
-          className="text-xs text-gray-400 hover:text-white disabled:opacity-50"
+          className="text-xs text-fg-muted hover:text-fg-primary disabled:opacity-50 transition-colors duration-token ease-token"
         >
-          {running ? 'Running...' : 'Re-evaluate'}
+          {running ? 'Running…' : 'Re-evaluate'}
         </button>
       </div>
     )
@@ -184,22 +187,22 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
 
   // ── Active banner with review queue + intake CTA ───────────────────────
   return (
-    <div className="bg-amber-500/[0.03] border border-amber-500/20 rounded-xl overflow-hidden">
+    <div className="bg-accent-warn/[0.05] border border-accent-warn/25 rounded-token-md overflow-hidden">
       <button
         type="button"
         onClick={() => setCollapsed(c => !c)}
-        className="w-full px-4 py-3 flex items-center justify-between hover:bg-amber-500/[0.05] transition-colors"
+        className="w-full px-4 py-3 flex items-center justify-between hover:bg-accent-warn/10 transition-colors duration-token ease-token"
       >
         <div className="flex items-center gap-2.5 text-left">
-          <svg className="w-4 h-4 text-amber-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="w-4 h-4 text-accent-warn flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
           </svg>
           <div>
-            <span className="text-sm font-medium text-amber-200">
-              {pendingCount} item{pendingCount === 1 ? '' : 's'} need your input
+            <span className="text-sm font-medium text-fg-primary">
+              <span className="font-mono tabular-nums">{pendingCount}</span> item{pendingCount === 1 ? '' : 's'} need your input
             </span>
-            <span className="ml-2 text-[11px] text-amber-400/70">
-              to finalise your tracker for FY {financialYear}
+            <span className="ml-2 text-[11px] text-fg-muted">
+              to finalise your tracker for FY <span className="font-mono tabular-nums">{financialYear}</span>
             </span>
           </div>
         </div>
@@ -207,12 +210,12 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
           <span
             role="button"
             onClick={(e) => { e.stopPropagation(); handleEvaluate() }}
-            className={`text-[11px] px-2.5 py-1 rounded border border-white/10 text-gray-300 hover:border-white/20 hover:text-white ${running ? 'opacity-50' : ''}`}
+            className={`text-[11px] px-2.5 py-1 rounded-token-sm border border-line/15 text-fg-secondary hover:border-line/30 hover:text-fg-primary transition-colors duration-token ease-token ${running ? 'opacity-50' : ''}`}
           >
-            {running ? 'Running...' : 'Re-evaluate'}
+            {running ? 'Running…' : 'Re-evaluate'}
           </span>
           <svg
-            className={`w-4 h-4 text-amber-300/60 transition-transform ${collapsed ? '' : 'rotate-180'}`}
+            className={`w-4 h-4 text-fg-muted transition-transform duration-token ease-token ${collapsed ? '' : 'rotate-180'}`}
             fill="none" stroke="currentColor" viewBox="0 0 24 24"
           >
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
@@ -221,7 +224,7 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
       </button>
 
       {!collapsed && (
-        <div className="border-t border-amber-500/15 divide-y divide-amber-500/10">
+        <div className="border-t border-accent-warn/20 divide-y divide-accent-warn/15">
           {/* Intake CTA removed — CIP owns it now. Review queue only. */}
 
           {reviewItems.map(item => (
@@ -235,7 +238,7 @@ export default function TrackerEvaluationPanel({ companyId, financialYear }: Pro
           ))}
 
           {loading && (
-            <div className="px-4 py-2 text-[11px] text-gray-500">Loading…</div>
+            <div className="px-4 py-2 text-[11px] text-fg-muted">Loading…</div>
           )}
         </div>
       )}
@@ -329,35 +332,35 @@ function ReviewRow({
       <div className="flex items-start gap-3">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
-            <span className="text-sm text-white">{item.rule.name}</span>
-            <span className="text-[10px] text-amber-400/70 border border-amber-500/20 px-1.5 py-0.5 rounded">
+            <span className="text-sm text-fg-primary font-medium">{item.rule.name}</span>
+            <span className="text-[10px] font-mono tabular-nums text-accent-warn border border-accent-warn/25 bg-accent-warn/10 px-1.5 py-0.5 rounded-full">
               {confidencePct}%
             </span>
-            <span className="text-[10px] text-gray-500">{item.rule.category}</span>
+            <span className="text-[10px] text-fg-muted uppercase tracking-wider">{item.rule.category}</span>
           </div>
           {question ? (
             <>
-              <p className="text-xs text-gray-400 mt-1">{question.question}</p>
+              <p className="text-xs text-fg-muted mt-1">{question.question}</p>
               <div className="flex items-center gap-2 mt-2">
-                <span className="text-gray-500 text-sm">₹</span>
+                <span className="text-fg-muted text-sm">₹</span>
                 <input
                   type="number"
                   value={value}
                   onChange={e => setValue(e.target.value)}
                   placeholder={question.placeholder}
-                  className="w-40 px-2.5 py-1 bg-black border border-white/10 rounded text-white text-sm focus:outline-none focus:border-amber-400"
+                  className="w-40 px-2.5 py-1 bg-bg-card border border-line/15 rounded-token-sm text-fg-primary text-sm font-mono tabular-nums focus:outline-none focus:border-accent-brand/60 focus:ring-2 focus:ring-accent-brand/25 transition-colors duration-token ease-token"
                   onKeyDown={e => { if (e.key === 'Enter') handleSaveAmount() }}
                 />
                 <button
                   onClick={handleSaveAmount}
                   disabled={!value.trim()}
-                  className="px-3 py-1 bg-amber-500 hover:bg-amber-400 text-black rounded text-[11px] font-medium disabled:opacity-50"
+                  className="px-3 py-1 bg-accent-brand text-white rounded-token-sm text-[11px] font-medium hover:opacity-90 disabled:opacity-50 transition-opacity duration-token ease-token"
                 >
                   Save
                 </button>
                 <button
                   onClick={() => handleOverride(false)}
-                  className="text-[11px] text-gray-400 hover:text-red-300 ml-1"
+                  className="text-[11px] text-fg-muted hover:text-accent-danger ml-1 transition-colors duration-token ease-token"
                 >
                   Not applicable
                 </button>
@@ -365,16 +368,16 @@ function ReviewRow({
             </>
           ) : (
             <div className="flex items-center gap-2 mt-2">
-              <span className="text-xs text-gray-400">Does this apply to your company?</span>
+              <span className="text-xs text-fg-muted">Does this apply to your company?</span>
               <button
                 onClick={() => handleOverride(true)}
-                className="px-2.5 py-1 text-[11px] border border-emerald-500/40 text-emerald-300 rounded hover:bg-emerald-500/10"
+                className="px-2.5 py-1 text-[11px] border border-accent-success/40 text-accent-success rounded-token-sm hover:bg-accent-success/10 transition-colors duration-token ease-token"
               >
                 Yes
               </button>
               <button
                 onClick={() => handleOverride(false)}
-                className="px-2.5 py-1 text-[11px] border border-red-500/40 text-red-300 rounded hover:bg-red-500/10"
+                className="px-2.5 py-1 text-[11px] border border-accent-danger/40 text-accent-danger rounded-token-sm hover:bg-accent-danger/10 transition-colors duration-token ease-token"
               >
                 No
               </button>

--- a/components/features/CompanySelector.tsx
+++ b/components/features/CompanySelector.tsx
@@ -123,7 +123,7 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
   const getStatusBadge = (status: CompanySubscriptionStatus | null) => {
     if (!status) {
       return (
-        <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-800 text-gray-400 border border-gray-700">
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-bg-elevated text-fg-muted border border-line/15">
           No Plan
         </span>
       )
@@ -132,21 +132,21 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
     // Check for trial first, as trials are a form of subscription
     if (status.isTrial && status.trialDaysRemaining !== undefined && status.trialDaysRemaining > 0) {
       return (
-        <span className="px-2 py-0.5 rounded text-xs font-medium bg-yellow-500/20 text-yellow-400 border border-yellow-500/30">
-          Trial ({status.trialDaysRemaining}d)
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-accent-warn/12 text-accent-warn border border-accent-warn/25">
+          Trial · <span className="font-mono tabular-nums">{status.trialDaysRemaining}d</span>
         </span>
       )
     }
 
     if (status.hasSubscription) {
       return (
-        <span className="px-2 py-0.5 rounded text-xs font-medium bg-green-500/20 text-green-400 border border-green-500/30">
-          Valid
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-accent-success/15 text-accent-success border border-accent-success/30">
+          Active
         </span>
       )
     } else {
       return (
-        <span className="px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-400 border border-red-500/30">
+        <span className="px-2 py-0.5 rounded-full text-[10px] font-medium bg-accent-danger/12 text-accent-danger border border-accent-danger/25">
           Expired
         </span>
       )
@@ -158,9 +158,9 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
       {/* Current Company Display */}
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-4 p-5 sm:p-6 bg-[#1a1a1a] border border-gray-800 rounded-xl hover:border-gray-700 transition-all w-full group"
+        className="flex items-center gap-4 p-4 sm:p-5 bg-bg-card border border-line/15 rounded-token-md hover:border-line/30 transition-colors duration-token ease-token w-full group"
       >
-        <div className="w-12 h-12 sm:w-14 sm:h-14 bg-gray-800 border border-gray-700 rounded-lg flex items-center justify-center flex-shrink-0">
+        <div className="w-11 h-11 sm:w-12 sm:h-12 bg-bg-elevated border border-line/10 rounded-token-md flex items-center justify-center flex-shrink-0">
           <svg
             width="20"
             height="20"
@@ -186,9 +186,9 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
           </svg>
         </div>
         <div className="flex-1 text-left min-w-0">
-          <div className="flex items-center justify-between gap-2 mb-1.5">
-            <div className="text-gray-500 text-xs sm:text-sm font-light">
-            {currentCompany ? `${currentCompany.type.toLowerCase()} – ${currentCompany.year}` : 'No company selected'}
+          <div className="flex items-center justify-between gap-2 mb-1">
+            <div className="text-fg-muted text-[11px] uppercase tracking-wider">
+            {currentCompany ? `${currentCompany.type.toLowerCase()} · ${currentCompany.year}` : 'No company selected'}
             </div>
             {currentCompany && (() => {
               const status = getSubscriptionStatus(currentCompany.id)
@@ -199,14 +199,14 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
               ) : null
             })()}
           </div>
-          <div className="text-white text-lg sm:text-xl font-light break-words leading-snug uppercase tracking-tight">
+          <div className="text-fg-primary text-base sm:text-lg font-medium break-words leading-snug tracking-tight">
             {currentCompany ? currentCompany.name : 'Select Company'}
           </div>
         </div>
         <svg
-          width="18"
-          height="18"
-          className={`flex-shrink-0 text-gray-500 transition-transform group-hover:text-gray-400 ${isOpen ? 'rotate-180' : ''}`}
+          width="16"
+          height="16"
+          className={`flex-shrink-0 text-fg-muted transition-transform duration-token ease-token group-hover:text-fg-secondary ${isOpen ? 'rotate-180' : ''}`}
           viewBox="0 0 24 24"
           fill="none"
           stroke="currentColor"
@@ -225,9 +225,9 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
             className="fixed inset-0 z-10"
             onClick={() => setIsOpen(false)}
           />
-          <div className="absolute top-full left-0 mt-3 w-full bg-[#1a1a1a] border border-gray-800 rounded-xl shadow-2xl z-50 sm:min-w-[400px] opacity-100">
-            <div className="p-4 border-b border-gray-800">
-              <div className="text-gray-500 text-xs font-light uppercase tracking-wider">
+          <div className="absolute top-full left-0 mt-2 w-full bg-bg-card border border-line/15 rounded-token-md shadow-popover z-50 sm:min-w-[400px]">
+            <div className="px-4 py-3 border-b border-line/10">
+              <div className="text-fg-muted text-[11px] font-medium uppercase tracking-wider">
                 Select Company
               </div>
             </div>
@@ -239,11 +239,11 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
                     onCompanyChange(company)
                     setIsOpen(false)
                   }}
-                  className={`w-full flex items-center gap-4 p-4 hover:bg-gray-900/50 transition-colors text-left ${
-                    currentCompany && company.id === currentCompany.id ? 'bg-gray-900/30' : ''
+                  className={`w-full flex items-center gap-4 px-4 py-3 hover:bg-bg-hover transition-colors duration-token ease-token text-left ${
+                    currentCompany && company.id === currentCompany.id ? 'bg-bg-hover' : ''
                   }`}
                 >
-                  <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gray-800 border border-gray-700 rounded-lg flex items-center justify-center flex-shrink-0">
+                  <div className="w-10 h-10 bg-bg-elevated border border-line/10 rounded-token-md flex items-center justify-center flex-shrink-0">
                     <svg
                       width="18"
                       height="18"
@@ -269,9 +269,9 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
                     </svg>
                   </div>
                   <div className="flex-1 min-w-0">
-                    <div className="flex items-center justify-between gap-2 mb-1.5">
-                      <div className="text-gray-500 text-xs sm:text-sm font-light">
-                      {company.type.toLowerCase()} – {company.year}
+                    <div className="flex items-center justify-between gap-2 mb-1">
+                      <div className="text-fg-muted text-[11px] uppercase tracking-wider">
+                      {company.type.toLowerCase()} · {company.year}
                       </div>
                       {(() => {
                         const status = getSubscriptionStatus(company.id)
@@ -282,10 +282,10 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
                         ) : null
                       })()}
                     </div>
-                    <div className="text-white font-light text-sm sm:text-base break-words leading-snug uppercase tracking-tight">{company.name}</div>
+                    <div className="text-fg-primary font-medium text-sm break-words leading-snug tracking-tight">{company.name}</div>
                   </div>
                   {currentCompany && company.id === currentCompany.id && (
-                    <div className="w-2 h-2 bg-gray-400 rounded-full flex-shrink-0"></div>
+                    <div className="w-1.5 h-1.5 bg-accent-brand rounded-full flex-shrink-0"></div>
                   )}
                 </button>
               ))}
@@ -294,13 +294,13 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
                   // Navigate to onboarding
                   router.push('/onboarding')
                 }}
-                className="w-full flex items-center gap-4 p-4 hover:bg-gray-900/50 transition-colors text-left border-t border-gray-800"
+                className="w-full flex items-center gap-4 px-4 py-3 hover:bg-bg-hover transition-colors duration-token ease-token text-left border-t border-line/10"
               >
-                <div className="w-10 h-10 sm:w-12 sm:h-12 bg-gray-800 border border-gray-700 rounded-lg flex items-center justify-center flex-shrink-0">
+                <div className="w-10 h-10 bg-bg-elevated border border-line/10 rounded-token-md flex items-center justify-center flex-shrink-0">
                   <svg
-                    width="18"
-                    height="18"
-                    className="sm:w-5 sm:h-5 text-gray-400"
+                    width="16"
+                    height="16"
+                    className="text-fg-muted"
                     viewBox="0 0 24 24"
                     fill="none"
                     stroke="currentColor"
@@ -312,7 +312,7 @@ export default function CompanySelector({ companies, currentCompany, onCompanyCh
                     <line x1="5" y1="12" x2="19" y2="12" />
                   </svg>
                 </div>
-                <div className="text-gray-300 font-light text-sm sm:text-base">Create New Company</div>
+                <div className="text-fg-secondary font-medium text-sm">Create New Company</div>
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

Three more high-visibility surfaces swept to the hairline + token + mono-numerics aesthetic established in PR-15.

## What changed (3 files, 86 insertions / 86 deletions, net zero LOC)

### CompanySelector (visible on every page load)
- **Trigger card**: `bg-[#1a1a1a] border-gray-800 rounded-xl` chunky → `bg-bg-card border-line/15 rounded-token-md` (lighter, hairline).
- **Status badges** (No Plan / Trial / Active / Expired): inline gray-800/yellow/green/red → token-driven Chip-style (`bg-{accent}/12 + text-{accent} + border-{accent}/25`), mono tabular-nums on trial day-count.
- **Type · year subline**: gray sentence-case font-light → `fg-muted` uppercase tracking-wider eyebrow (matches "My companies" subhead from PR-7).
- **Company name**: `text-white font-light text-xl uppercase` → `text-fg-primary font-medium text-lg tracking-tight` (drops aggressive uppercase, reads more brand-like).
- **Dropdown panel**: chunky `shadow-2xl` → `shadow-popover` token. All hover/active states token-driven.
- **Active-row indicator**: 2px gray-400 dot → 1.5px **accent-brand (indigo)** dot — proper "selected" signal.

### TrackerEvaluationPanel (sits above the tracker accordion)
- **Idle "all up to date" bar**: `bg-gray-900/40 border-white/5` → `bg-bg-elevated border-line/10`. Check icon to `accent-success` token. FY in mono tabular-nums.
- **Active warning banner**: amber inline → `accent-warn` tokens (themes cleanly). Pending count in mono tabular-nums.
- **Review row**: rule name now `font-medium fg-primary`, confidence % in mono pill, category in uppercase tracking-wider eyebrow.
- **Amount input**: `bg-black focus:border-amber-400` → `bg-bg-card focus:border-accent-brand/60 focus:ring-accent-brand/25` (indigo focus ring + mono tabular-nums for the rupee figure).
- **Save button**: `bg-amber-500` (visually inconsistent yellow CTA) → `bg-accent-brand` (indigo with subtle shadow) — proper primary style.
- **Yes/No applicability**: emerald/red inline → `accent-success`/`accent-danger` tokens.

### TrackerEmptyState
- **Icon ring**: `border-2 border-gray-700` → hairline `border-line/15` on `bg-bg-card`.
- **"Clear all filters" CTA**: bright `bg-white text-black` pill → secondary token-driven button (consistent with PR-15 dropdown panels).
- **"Add first requirement" CTA**: `bg-white text-black` → `bg-accent-brand text-white shadow-accent-brand/20` (primary indigo).
- **Loading spinner**: 4px white/30 border + gradient blob → 2px `accent-brand/30` with `accent-brand` top-border (single clean indigo spinner, dropped the dual-element gradient pulse).

## Functional safety
- Zero state, handler, server-action, or hook changes.
- `tsc --noEmit` clean.
- Both light and dark themes flip cleanly across these surfaces now.

## Branch hygiene
- Branched off `origin/main` after PR #95 squash-merged.
- Zero merge commits between work and target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)