### PR TITLE
fix(onboarding): accept LLPIN in magical intake + preserve CIN through prefill (PR-20)

### DIFF
--- a/app/onboarding/MagicalIntake.tsx
+++ b/app/onboarding/MagicalIntake.tsx
@@ -5,7 +5,13 @@ import { verifyCIN, lookupCompanyByPerplexity, lookupGST, type GSTLookupResult }
 import { parseCIN, type ParsedCIN } from '@/utils/cin-parser'
 import Button from '@/components/ui/Button'
 
+// Accept either a 21-char CIN (regular companies) OR a 7-char LLPIN
+// (limited-liability partnerships). LLPINs come in two MCA formats:
+//   - "AAA-1234" (3 letters + dash + 4 digits)
+//   - "AAA1234"  (some MCA records strip the dash)
+// Both are normalised to upper-case before matching.
 const CIN_PATTERN = /^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$/
+const LLPIN_PATTERN = /^[A-Z]{3}-?\d{4}$/
 const PAN_PATTERN = /^[A-Z]{5}\d{4}[A-Z]$/
 
 export interface MagicalIntakePayload {
@@ -63,7 +69,7 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
 
   const cinFormatted = cinValue.toUpperCase().trim()
   const panFormatted = panValue.toUpperCase().trim()
-  const cinValid = CIN_PATTERN.test(cinFormatted)
+  const cinValid = CIN_PATTERN.test(cinFormatted) || LLPIN_PATTERN.test(cinFormatted)
   const panValid = PAN_PATTERN.test(panFormatted)
 
   // Auto-fire PAN cross-lookup once the user types a valid 10-char PAN.
@@ -78,7 +84,7 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
 
   const handleVerifyCIN = async () => {
     if (!cinValid) {
-      setErrorMsg('Check the CIN format and try again.')
+      setErrorMsg('Check the CIN / LLPIN format and try again.')
       return
     }
     setErrorMsg(null)
@@ -108,14 +114,18 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
 
     // Last-resort: parsed CIN structure only — still let the user proceed
     // because the form has manual fields. Mirrors the existing handler.
-    if (!companyData?.company && !parsed.isValid) {
-      setErrorMsg('We could not find this CIN. Double-check it or skip and fill manually.')
+    // Note: LLPINs don't go through parseCIN successfully (different
+    // structure), so we accept them when companyData has anything useful
+    // OR when the structure parses. If neither, fail gracefully.
+    const isLlpin = LLPIN_PATTERN.test(cinFormatted)
+    if (!companyData?.company && !parsed.isValid && !isLlpin) {
+      setErrorMsg('We could not find this ID. Double-check it or skip and fill manually.')
       setPhase('cin')
       return
     }
 
     cinPayloadRef.current = { parsed, companyData, directorData }
-    setCompanyName(companyData?.company || `CIN ${cinFormatted} (manual review needed)`)
+    setCompanyName(companyData?.company || `${isLlpin ? 'LLPIN' : 'CIN'} ${cinFormatted} (manual review needed)`)
     setPhase('cin-verified')
   }
 
@@ -180,7 +190,7 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
             htmlFor="magical-cin"
             className="text-xs font-medium text-fg-secondary uppercase tracking-wider"
           >
-            Company CIN
+            Company CIN or LLPIN
           </label>
           <div className="relative">
             <input
@@ -191,7 +201,7 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
                 setCinValue(e.target.value)
                 setErrorMsg(null)
               }}
-              placeholder="L17110MH1973PLC019786"
+              placeholder="L17110MH1973PLC019786 or AAA-1234"
               maxLength={21}
               autoFocus
               disabled={phase !== 'cin' && phase !== 'cin-verifying'}
@@ -303,7 +313,7 @@ export default function MagicalIntake({ onComplete, onSkip }: MagicalIntakeProps
 
         {/* Help */}
         <div className="mt-12 text-center text-xs text-fg-muted">
-          Don't have a CIN (sole-proprietorship / partnership)?{' '}
+          Don't have a CIN or LLPIN (sole-proprietorship / partnership)?{' '}
           <button
             type="button"
             onClick={onSkip}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -537,13 +537,6 @@ export default function OnboardingPage() {
    * until the user fills them — exactly the "below the fold" plan.
    */
   const handleMagicalIntakeComplete = (payload: MagicalIntakePayload) => {
-    // Seed the IDs first so applyParsedCINData / downstream code see them.
-    setFormData((prev) => ({
-      ...prev,
-      cinNumber: payload.cin,
-      panNumber: payload.pan,
-    }))
-
     // Mark CIN as verified so the existing CIN-verify button doesn't ask
     // the user to verify again.
     setIsCINVerified(true)
@@ -559,6 +552,19 @@ export default function OnboardingPage() {
 
     // Apply company prefill via the SAME helper the legacy flow uses.
     applyParsedCINData(payload.parsed, payload.companyData, payload.directorData)
+
+    // Seed cin/pan AFTER applyParsedCINData so this write lands LAST in
+    // the React batch and wins. Putting it first caused the CIN field to
+    // end up empty: applyParsedCINData reads `formData.cinNumber` from a
+    // stale closure, and when companyData.cin was missing (Perplexity
+    // fallback path), it overrode our just-set value with an empty
+    // string. Putting our setter last guarantees the user's typed CIN
+    // is preserved on the form.
+    setFormData((prev) => ({
+      ...prev,
+      cinNumber: payload.cin,
+      panNumber: payload.pan,
+    }))
 
     // Directors — mirror handleCINVerification's mapping so verification
     // status, IDs, and source labels stay consistent with the legacy flow.


### PR DESCRIPTION
## Summary

Two production bugs in the magical onboarding flow, both reported via screenshots.

## Bug 1 — Magical intake rejected LLPINs

The CIN regex only matched 21-char company CINs (`^[LU]\d{5}[A-Z]{2}\d{4}[A-Z]{3}\d{6}$`). LLPs use a 7-char LLPIN like `AAA-1234` or `AAA1234`. **Users with an LLP couldn't get past step 1.**

**Fix:**
- Added `LLPIN_PATTERN` (`^[A-Z]{3}-?\d{4}$`)
- `cinValid` now passes if EITHER CIN or LLPIN matches
- Label updated: "Company CIN or LLPIN"
- Placeholder: `L17110MH1973PLC019786 or AAA-1234`
- Error message + bottom helper text mention LLPIN
- Cin-verified phase shows `LLPIN AAA-1234 (manual review needed)` when MCA didn't return a hit but format is valid

## Bug 2 — CIN field empty on existing form after magical intake

Per screenshot: user typed CIN + PAN in magical intake → existing form opened with Company Name "LEEZA CARE RESEARCH..." filled but **CIN field empty**.

**Root cause:** `handleMagicalIntakeComplete` was setting `cinNumber` FIRST, then calling `applyParsedCINData(...)`. The legacy helper does:

```ts
cinNumber: companyData?.cin || formData.cinNumber
```

`formData` is captured in closure at the original render. When MCA returned no `.cin` (Perplexity fallback path), the helper read the closure's empty `cinNumber` and wiped our just-set value.

**Fix:** moved the `cin/pan` `setFormData` to AFTER `applyParsedCINData`. React batches both setters and applies them in order — putting our setter LAST guarantees the user's typed CIN survives. Added a comment explaining the ordering trap.

## Functional safety
- Two property writes reordered + two regex patterns added. No state, handler, server-action, or hook signature changes.
- The Perplexity fallback path that triggers Bug 2 still works the same way; we just preserve the user's CIN through it.
- LLPIN format detection is scoped to MagicalIntake only. The legacy form's `parseCIN` logic is unchanged — LLPs that flow through go to manual review as before.
- `tsc --noEmit` clean.

## Test plan
- [ ] Type a valid CIN (`L17110MH1973PLC019786`) → Verify button fades in → click → form opens with CIN field populated.
- [ ] Type a valid LLPIN (`AAA-1234`) → Verify button fades in (regex now passes) → form opens with the LLPIN preserved in the CIN field.
- [ ] Type a malformed string → Verify stays hidden → no false-positive flow.
- [ ] Skip flow still works (form opens empty as before).

## Branch hygiene
- Branched off `origin/main` after PR #99 squash-merged.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)