### PR TITLE
fix(onboarding): unblock sole-prop / partnership users from step-1 → step-2 (PR-21)

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -2416,8 +2416,12 @@ export default function OnboardingPage() {
                       if (!formData.companyType) {
                         newErrors.companyType = 'Please select a company type'
                       }
-                      if (!formData.cinNumber.trim()) {
-                        newErrors.cinNumber = 'CIN number is required'
+                      // Sole proprietorships and (general, non-LLP) partnerships
+                      // have no CIN — the field is disabled in the UI for those
+                      // entity types and `requiresCIN` is false. Without this
+                      // guard the "Next" button blocks them indefinitely.
+                      if (requiresCIN && !formData.cinNumber.trim()) {
+                        newErrors.cinNumber = `${countryConfig.labels.registrationId} is required`
                       }
                       if (formData.industries.length === 0) {
                         newErrors.industries = 'Please select at least one industry'


### PR DESCRIPTION
## Summary

Sole-proprietorship and partnership users couldn't complete onboarding. They picked the right entity type, the CIN field correctly auto-disabled, but clicking "Next" blocked them with `"CIN number is required"`.

## Root cause

The onboarding page has **two** validators:

1. **Main validator** at [page.tsx:1003](app/onboarding/page.tsx#L1003) — correctly guards: `if (requiresCIN && !cinNumber.trim())`
2. **Step-1 → step-2 "Next" button validator** at [page.tsx:2419](app/onboarding/page.tsx#L2419) — was missing the guard:

```ts
if (!formData.cinNumber.trim()) {
  newErrors.cinNumber = 'CIN number is required'
}
```

`requiresCIN` is `false` when `companyType` is `sole-proprietorship` or `partnership` (per [page.tsx:137-138](app/onboarding/page.tsx#L137-L138) — these entity types don't have CINs because they're not MCA-registered). The field UI honors this (`disabled={!requiresCIN}`) and the main validator honors this. The "Next" button validator did not.

## Fix

Mirror the main validator's logic:

```ts
if (requiresCIN && !formData.cinNumber.trim()) {
  newErrors.cinNumber = `${countryConfig.labels.registrationId} is required`
}
```

Also switched the hard-coded `'CIN number is required'` to `countryConfig.labels.registrationId` so KSA/other-country labels work correctly.

## Flow now (verified)

1. `/onboarding` → magical intake appears
2. Click "Continue manually" — link literally says "Don't have a CIN or LLPIN (sole-proprietorship / partnership)?"
3. Existing form opens
4. Pick "Sole Proprietorship" or "Partnership" as Company Type → CIN field auto-disables + clears
5. Fill name, PAN, address, industry, etc.
6. Click Next → Documents step → Submit ✓

LLPs still need a CIN (they're MCA-registered with an LLPIN that fits the same field; magical intake's PR-20 also accepts LLPIN format).

## Functional safety
- 1 file, 6 ins / 2 del.
- No state, handler, server-action, or hook signature changes.
- CIN field UI logic, auto-clear useEffect, and main validator unchanged.
- `tsc --noEmit` clean.

## Branch hygiene
- Branched off `origin/main` after PR #100.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed onboarding validation that incorrectly required business registration information for company types where it's not applicable.
  * Updated registration error messages to use location-specific terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->