### PR TITLE
feat(auth): seamless account linking for email ↔ Google sign-in (PR-23)

### DIFF
--- a/app/api/auth/passport/login/route.ts
+++ b/app/api/auth/passport/login/route.ts
@@ -37,6 +37,58 @@ export async function POST(req: NextRequest) {
     const user = await loginUser()
 
     if (!user) {
+      // Before returning a generic "Invalid email or password", check if
+      // the address belongs to a Google-only account (no password yet).
+      // Without this, a user who signed up with Google then forgot and
+      // tried email/password login would just get "Invalid" with no
+      // clue. Detecting it lets us route them through the linking flow
+      // — same shape register/route.ts returns.
+      try {
+        const normalizedEmail = email.trim().toLowerCase()
+        const existingUser = await prisma.appUser.findFirst({
+          where: {
+            primary_email: { equals: normalizedEmail, mode: 'insensitive' },
+          },
+          include: { authIdentities: true },
+        })
+
+        const hasGoogleAuth = existingUser?.authIdentities?.some(
+          (identity) =>
+            identity.provider === 'passport' &&
+            identity.legacy_auth_id &&
+            identity.legacy_auth_id !== '',
+        )
+        const hasPassword = existingUser && (existingUser as any).password_hash
+
+        if (existingUser && hasGoogleAuth && !hasPassword) {
+          // Auto-fire the linking verification email so the user sees a
+          // single "check your inbox" message rather than having to
+          // click another button on the login page.
+          const { sendVerificationEmail } = await import('@/lib/email/verification')
+          sendVerificationEmail(
+            existingUser.id,
+            existingUser.primary_email,
+            existingUser.full_name,
+          ).catch((err) => {
+            console.error('[Passport Login] Failed to send linking email:', err)
+          })
+
+          return NextResponse.json(
+            {
+              success: false,
+              requiresLinking: true,
+              userId: existingUser.id,
+              message:
+                "This email is registered with Google. We've sent you a verification email — click the link to set a password.",
+            },
+            { status: 200 },
+          )
+        }
+      } catch (lookupErr) {
+        console.error('[Passport Login] Account-linking lookup failed:', lookupErr)
+        // Fall through to generic error — don't leak existence on lookup failure.
+      }
+
       return NextResponse.json({ error: 'Invalid email or password' }, { status: 401 })
     }
 

--- a/app/api/auth/passport/register/route.ts
+++ b/app/api/auth/passport/register/route.ts
@@ -49,11 +49,26 @@ export async function POST(req: NextRequest) {
       )
 
       if (hasGoogleAuth) {
-        // Account exists with Google - need to verify email ownership before linking password
+        // Account exists with Google. Auto-fire the verification email
+        // immediately so the user sees one clear "check your inbox"
+        // message instead of having to click a separate "Send
+        // Verification Email" button on the login page. The email links
+        // to /api/auth/verify-email?token=… which routes to
+        // /auth/link-password when the user has Google-but-no-password.
+        sendVerificationEmail(
+          existingUser.id,
+          existingUser.primary_email,
+          existingUser.full_name,
+        ).catch((err) => {
+          console.error('[Passport Register] Failed to send linking email:', err)
+        })
+
         return NextResponse.json({
           success: false,
           requiresLinking: true,
-          message: 'This email is already registered with Google. We\'ll send a verification email to confirm you own this account, then you can link a password.',
+          emailSent: true,
+          message:
+            "This email is registered with Google. We've sent you a verification email — click the link to set a password.",
           userId: existingUser.id,
         }, { status: 200 }) // 200 because this is a valid response, not an error
       }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -347,38 +347,41 @@ function LoginPageInner() {
             </>
           ) : requiresLinking ? (
             <>
-              {/* Account Linking UI */}
+              {/* Account Linking UI — verification email auto-sent by the
+                  login/register endpoints, user just needs to check inbox. */}
               <div className="space-y-4">
-                <div className="p-4 bg-blue-500/10 border border-blue-500/50 rounded-lg">
-                  <p className="text-sm text-blue-400 font-light mb-3">
-                    This email is already registered with Google. To add a password to your account, we need to verify you own this email address.
+                <div className="p-4 bg-accent-info/10 border border-accent-info/30 rounded-token-md">
+                  <div className="flex items-start gap-3 mb-3">
+                    <svg className="w-5 h-5 text-accent-info flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                    <p className="text-sm font-medium text-fg-primary">
+                      Check your inbox
+                    </p>
+                  </div>
+                  <p className="text-sm text-fg-secondary mb-1">
+                    {message || `We sent a verification link to`} <strong className="text-fg-primary">{email}</strong>.
                   </p>
-                  <p className="text-sm text-fg-muted font-light">
-                    We'll send a verification email to <strong className="text-white">{email}</strong>. After you verify your email, you can set a password.
+                  <p className="text-xs text-fg-muted mt-2">
+                    Click the link in your email to confirm ownership and set a password. The link expires in 24 hours.
                   </p>
                 </div>
 
                 {error && (
-                  <div className="p-3 bg-red-500/10 border border-red-500/50 rounded-lg">
-                    <p className="text-sm text-red-400 font-light">{error}</p>
-                  </div>
-                )}
-
-                {message && (
-                  <div className="p-3 bg-green-500/10 border border-green-500/50 rounded-lg">
-                    <p className="text-sm text-green-400 font-light">{message}</p>
+                  <div className="p-3 bg-accent-danger/10 border border-accent-danger/30 rounded-token-md">
+                    <p className="text-sm text-accent-danger">{error}</p>
                   </div>
                 )}
 
                 <button
                   onClick={handleSendLinkingVerification}
                   disabled={isSendingVerification}
-                  className="w-full px-6 py-3 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-all disabled:opacity-50 disabled:cursor-not-allowed font-light"
+                  className="w-full px-6 py-3 bg-bg-card border border-line/15 text-fg-secondary rounded-token-md hover:border-line/30 hover:text-fg-primary transition-colors duration-token ease-token disabled:opacity-50 text-sm"
                 >
                   {isSendingVerification ? (
-                    <div className="w-5 h-5 border-2 border-white border-t-transparent rounded-full animate-spin mx-auto"></div>
+                    <div className="w-5 h-5 border-2 border-current border-t-transparent rounded-full animate-spin mx-auto"></div>
                   ) : (
-                    'Send Verification Email'
+                    'Resend email'
                   )}
                 </button>
 
@@ -390,9 +393,9 @@ function LoginPageInner() {
                     setMessage(null)
                     setPassword('')
                   }}
-                  className="w-full px-6 py-3 bg-bg-elevated text-white rounded-lg hover:bg-bg-hover transition-all font-light"
+                  className="w-full px-6 py-3 text-fg-muted hover:text-fg-primary transition-colors duration-token ease-token text-sm"
                 >
-                  Cancel
+                  Use a different email
                 </button>
               </div>
             </>


### PR DESCRIPTION
## Summary

Account linking was already implemented end-to-end:
- `callback/route.ts:105-129` auto-links Google sign-in to existing email accounts (and marks email_verified=true since Google attests it).
- `register/route.ts:42-59` detects email signups that collide with Google accounts.
- `link-password/route.ts` + `/auth/link-password` page exist.
- `verify-email` GET endpoint routes Google-only users to the link-password page after token verification.

**But the email-→-Google direction had two friction points hiding it:**

1. **Login endpoint** returned generic "Invalid email or password" when a Google-only user tried email/password. They had no clue Google was the way in.
2. **Register endpoint** detected the collision but waited for the user to click a separate "Send Verification Email" button after registering — extra friction.

Both fixed in this PR.

## Changes

### `app/api/auth/passport/login/route.ts`
On auth failure, look up the email. If the user exists with Google OAuth identity but no password_hash:
- Auto-fire the linking verification email
- Return `{ requiresLinking: true, userId, message }` — same shape register uses, so the existing login-page UI handles it
- Lookup wrapped in try/catch; any DB hiccup falls through to generic 401 rather than leaking existence

### `app/api/auth/passport/register/route.ts`
When existing-Google-account collision is detected, auto-fire the verification email immediately. Response carries `emailSent: true` so client doesn't double-send.

### `app/login/page.tsx`
`requiresLinking` banner rewritten:
- Was: "We'll send a verification email" + "Send Verification Email" primary button (assumed user has to click).
- Now: "Check your inbox — we sent a link to `<email>`" with envelope icon. Smaller secondary "Resend email" button for edge cases.
- Restyled to design tokens (`accent-info/30`, `bg-bg-card`, `border-line/15`) instead of the legacy `blue-500/50` + `primary-orange` + `bg-gray-700` mix.

## Security model unchanged

- **Google → email-account linking** still trusts Google's email verification. Google never returns unverified emails via OAuth.
- **Email → Google linking** still requires the user to prove ownership by clicking a token link sent to their inbox before any password is attached. Without this gate, anyone could register a password for someone else's gmail address. We just made the gate fire automatically rather than requiring an extra click.
- The verification token flow (24h TTL, single-use, server-side validation) is untouched.

## Functional safety
- 3 files, 91 ins / 21 del.
- No state, hook, or schema changes.
- `tsc --noEmit` clean.
- Wrong-password attempts still get the generic 401 — only legit Google-only-no-password users see the linking flow.

## Branch hygiene
- Branched off `origin/main` after PR #102.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced account linking verification flow with clearer "check your inbox" messaging and inbox-focused guidance
  * Users now receive information about 24-hour verification link expiry timeframes
  * Improved error and success messaging displays in the authentication verification UI
  * Updated action button labels ("Resend email", "Use a different email") for clearer user intent

<!-- end of auto-generated comment: release notes by coderabbit.ai -->