### PR TITLE
fix(auth): email verification crash — column verified_at does not exist (PR-24)

### DIFF
--- a/lib/email/verification.ts
+++ b/lib/email/verification.ts
@@ -56,7 +56,16 @@ export async function sendVerificationEmail(
 }
 
 /**
- * Verify email using token
+ * Verify email using token.
+ *
+ * Single-use semantics: the token row is DELETED on successful
+ * verification rather than marked with a `verified_at` timestamp.
+ * The Prisma schema for EmailVerificationToken doesn't include a
+ * `verified_at` column, and earlier code that referenced it crashed
+ * with `column "verified_at" does not exist` on production. Delete-
+ * after-use achieves the same single-use guarantee — the second
+ * attempt fails with "Invalid verification token" because the row
+ * is gone — without requiring a schema change.
  */
 export async function verifyEmailToken(token: string): Promise<{
   success: boolean
@@ -70,34 +79,34 @@ export async function verifyEmailToken(token: string): Promise<{
       user_id: string
       email: string
       expires_at: Date
-      verified_at: Date | null
     }>>`
-      SELECT user_id, email, expires_at, verified_at
+      SELECT user_id, email, expires_at
       FROM public.email_verification_tokens
       WHERE token = ${token}
       LIMIT 1
     `
 
     if (!result || result.length === 0) {
-      return { success: false, error: 'Invalid verification token' }
+      return { success: false, error: 'Invalid or already-used verification token' }
     }
 
     const tokenRecord = result[0]
 
-    // Check if already verified
-    if (tokenRecord.verified_at) {
-      return { success: false, error: 'This verification link has already been used' }
-    }
-
     // Check if expired
     if (new Date(tokenRecord.expires_at) < new Date()) {
+      // Drop the expired row so the table doesn't accumulate dead tokens.
+      await prisma.$executeRaw`
+        DELETE FROM public.email_verification_tokens
+        WHERE token = ${token}
+      `
       return { success: false, error: 'Verification link has expired. Please request a new one.' }
     }
 
-    // Mark token as verified
+    // Single-use: delete the token now so it can't be replayed. Keep
+    // this BEFORE the user update so a partial success on the first
+    // call still invalidates the token for the second.
     await prisma.$executeRaw`
-      UPDATE public.email_verification_tokens
-      SET verified_at = NOW()
+      DELETE FROM public.email_verification_tokens
       WHERE token = ${token}
     `
 


### PR DESCRIPTION
## Summary

Production crash on the verify-email flow:

```
Invalid `prisma.$queryRaw()` invocation: Raw query failed.
Code: 42703. Message: column "verified_at" does not exist
```

`verifyEmailToken` in `lib/email/verification.ts` was reading and writing a `verified_at` column on `email_verification_tokens` that **doesn't exist** in the production schema. The Prisma model `EmailVerificationToken` has only `{ id, user_id, email, token, expires_at, created_at }` — no `verified_at`. The mismatch was latent — any user clicking a verification email (self-serve verify, password-link flow from PR-23, etc.) was hitting this and seeing "Resend verification email" with no clear cause.

## Fix

Switch to **single-use-DELETE** semantics:
- On successful verification: delete the token row (instead of tagging with `verified_at = NOW()`).
- Second attempt: fails with "Invalid or already-used verification token" because the row is gone — same single-use guarantee, no schema change.
- Bonus: expired tokens are also deleted during lookup so the table doesn't accumulate dead rows.

## Why not add the column instead?

Adding `verified_at` would require a Prisma migration + the prod-deploy-via-CI dance (per CLAUDE.md, prod schema deploys via CI Phase 9, no prod creds locally). The DELETE approach gets us to working in one PR, no migration, same semantics.

If a future feature needs the timestamp (audit trail, etc.), we can add the column properly then.

## Functional safety
- 1 file, 21 ins / 12 del.
- Pure SQL/code change. No schema migration needed.
- Preserves success path: user clicks link → `email_verified=true` on `app_users` → middleware re-caches on next request.
- Preserves single-use guarantee.
- PR-22 (sole-prop name search) + PR-23 (linking) flows that route through `verifyEmailToken` work unchanged.
- `tsc --noEmit` clean.

## Branch hygiene
- Branched off `origin/main` after PR #103.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)