### PR TITLE
fix(auth): break linking-loop — verify-email GET no longer consumes token before link-password POST (PR-25)

### DIFF
--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { verifyEmailToken, resendVerificationEmail } from '@/lib/email/verification'
+import { verifyEmailToken, peekVerificationToken, resendVerificationEmail } from '@/lib/email/verification'
 import { prisma } from '@/lib/prisma'
 import { handleAPIError } from '@/lib/errors/handle-error'
 
@@ -19,32 +19,39 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    const result = await verifyEmailToken(token)
-
-    if (!result.success) {
-      // Return JSON error instead of redirecting - let client handle it
+    // Peek (non-consuming) so we can decide what to do BEFORE deleting
+    // the token. If we consumed here and then redirected to
+    // /auth/link-password, the link-password POST would have nothing
+    // left to validate — it'd reject as "already used", the user would
+    // navigate back to /login, the linking flow would re-detect the
+    // Google-only-no-password state, and they'd be stuck in a loop.
+    const peek = await peekVerificationToken(token)
+    if (!peek.success) {
       return NextResponse.json(
-        { success: false, error: result.error },
+        { success: false, error: peek.error },
         { status: 400 }
       )
     }
 
-    // Check if this is a password linking verification (check if user has Google OAuth but no password)
+    // Check if this is a password linking verification (user has Google OAuth but no password)
     const user = await prisma.appUser.findUnique({
-      where: { id: result.userId },
+      where: { id: peek.userId },
       include: {
         authIdentities: true,
       },
     })
 
     const hasGoogleAuth = user?.authIdentities.some(
-      (identity) => identity.provider === 'passport' && 
-                   identity.legacy_auth_id && 
+      (identity) => identity.provider === 'passport' &&
+                   identity.legacy_auth_id &&
                    identity.legacy_auth_id !== ''
     )
     const hasPassword = user && (user as any).password_hash
 
-    // If user has Google OAuth but no password, redirect to password linking page
+    // If user has Google OAuth but no password, redirect to password
+    // linking page WITHOUT consuming the token — link-password POST
+    // will consume it when the user submits the form. The user's
+    // email_verified flag is also set there (verifyEmailToken sets it).
     const needsPasswordLinking = hasGoogleAuth && !hasPassword
 
     // Check if request wants JSON (from client-side fetch) or redirect (from email link)
@@ -53,28 +60,40 @@ export async function GET(request: NextRequest) {
 
     // Create response
     let response: NextResponse
-    if (wantsJson) {
-      // Client-side fetch - return JSON
-      response = NextResponse.json({
-        success: true,
-        email: result.email,
-        message: 'Email verified successfully',
-        needsPasswordLinking,
-      })
-    } else {
-      // Direct link click from email - redirect appropriately
+    if (needsPasswordLinking) {
+      // Don't consume the token here — link-password endpoint will.
       const origin = new URL(request.url).origin
-      if (needsPasswordLinking) {
-        // Redirect to password linking page with token
-        response = NextResponse.redirect(
-          new URL(`/auth/link-password?token=${encodeURIComponent(token)}`, origin)
-        )
-      } else {
-        // Regular verification - redirect to success page
-        response = NextResponse.redirect(
-          new URL(`/verify-email?success=true&email=${encodeURIComponent(result.email || '')}`, origin)
+      response = wantsJson
+        ? NextResponse.json({
+            success: true,
+            email: peek.email,
+            message: 'Verification confirmed — set your password to finish linking',
+            needsPasswordLinking: true,
+          })
+        : NextResponse.redirect(
+            new URL(`/auth/link-password?token=${encodeURIComponent(token)}`, origin)
+          )
+    } else {
+      // Regular verification — consume the token now (DELETEs row +
+      // marks user.email_verified=true).
+      const consumed = await verifyEmailToken(token)
+      if (!consumed.success) {
+        return NextResponse.json(
+          { success: false, error: consumed.error },
+          { status: 400 }
         )
       }
+      const origin = new URL(request.url).origin
+      response = wantsJson
+        ? NextResponse.json({
+            success: true,
+            email: consumed.email,
+            message: 'Email verified successfully',
+            needsPasswordLinking: false,
+          })
+        : NextResponse.redirect(
+            new URL(`/verify-email?success=true&email=${encodeURIComponent(consumed.email || '')}`, origin)
+          )
     }
 
     // Clear verification cache cookie so next request will check fresh status

--- a/lib/email/verification.ts
+++ b/lib/email/verification.ts
@@ -56,7 +56,52 @@ export async function sendVerificationEmail(
 }
 
 /**
- * Verify email using token.
+ * Look up a verification token WITHOUT consuming it.
+ *
+ * Used by the verify-email GET endpoint to inspect what kind of flow
+ * is needed (regular email-verify vs. Google-only-no-password linking)
+ * before deciding whether to consume the token. The link-password
+ * POST endpoint re-validates the same token to complete linking, so
+ * the GET must not delete it on the way through.
+ */
+export async function peekVerificationToken(token: string): Promise<{
+  success: boolean
+  userId?: string
+  email?: string
+  error?: string
+}> {
+  try {
+    const result = await prisma.$queryRaw<Array<{
+      user_id: string
+      email: string
+      expires_at: Date
+    }>>`
+      SELECT user_id, email, expires_at
+      FROM public.email_verification_tokens
+      WHERE token = ${token}
+      LIMIT 1
+    `
+    if (!result || result.length === 0) {
+      return { success: false, error: 'Invalid or already-used verification token' }
+    }
+    const r = result[0]
+    if (new Date(r.expires_at) < new Date()) {
+      // Drop expired row so the table doesn't accumulate dead tokens.
+      await prisma.$executeRaw`
+        DELETE FROM public.email_verification_tokens
+        WHERE token = ${token}
+      `
+      return { success: false, error: 'Verification link has expired. Please request a new one.' }
+    }
+    return { success: true, userId: r.user_id, email: r.email }
+  } catch (error) {
+    console.error('[Email Verification] peek error:', error)
+    return { success: false, error: error instanceof Error ? error.message : 'Failed to verify token' }
+  }
+}
+
+/**
+ * Verify email using token (consuming).
  *
  * Single-use semantics: the token row is DELETED on successful
  * verification rather than marked with a `verified_at` timestamp.


### PR DESCRIPTION
## Summary

User reported: after clicking the verification link from the inbox, they got bounced back to the login page still showing "Check your inbox". The Google → password linking never completed.

## Root cause

The token was being consumed twice — once in the GET, once in the POST — and the second call was always failing because the row was gone.

**Trace:**
1. User clicks email link → GET `/api/auth/verify-email?token=xxx`
2. `verifyEmailToken(token)` runs → **DELETEs the row** (PR-24 semantics) + sets `email_verified=true`
3. Server detects Google-only-no-password → redirects to `/auth/link-password?token=xxx`
4. User enters password, submits → POST `/api/auth/passport/link-password`
5. `link-password` also calls `verifyEmailToken(token)` to prove ownership before attaching the password
6. **Token row is already gone** → returns "Invalid or already-used verification token"
7. Password never attached. User navigates back to `/login`. Login still detects Google-only-no-password → re-fires the inbox flow. **Loop.**

(This loop existed pre-PR-24 too via the `verified_at` flag — same shape, different mechanism.)

## Fix

Split `verifyEmailToken` into peek + consume:

- **`peekVerificationToken(token)`** — looks up + checks expiry only. Drops expired rows so the table doesn't accumulate dead tokens. **No consumption.**
- **`verifyEmailToken(token)`** — unchanged. Consumes the token (DELETE) + sets `email_verified=true`.

`verify-email` GET now peeks first to decide:
- **Google-only-no-password** → redirect to `/auth/link-password` **without consuming**. The link-password POST will consume when the user submits the password form (and that path also sets `email_verified=true`).
- **Regular flow** → consume now and redirect to the success page.

Single-use guarantee preserved: still consumed exactly once across the GET→POST handoff. Just delayed to the moment the password is actually set.

## Functional safety
- 2 files, ~95 ins / 31 del. Pure logic refactor; no schema changes.
- All other call sites of `verifyEmailToken` are unaffected — only the `verify-email` GET endpoint switched to peek-then-decide.
- `link-password` POST already calls `verifyEmailToken`; behavior unchanged there.
- Edge case (user clicks link, never submits password): token survives to expiry (24h). User can retry by clicking the link again. Clean.
- `tsc --noEmit` clean.

## Branch hygiene
- Branched off `origin/main` after PR #104.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)