### PR TITLE
fix(auth): /verify-email page redirects to /auth/link-password for Google-only users (PR-27)

### DIFF
--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -34,10 +34,24 @@ function VerifyEmailContent() {
           'Accept': 'application/json',
         },
       })
-      
+
       if (response.ok) {
         const data = await response.json()
-        // Update URL to show success
+
+        // If the user authenticated only via Google and has no password,
+        // route them to /auth/link-password where they set one. The API
+        // returns needsPasswordLinking=true and deliberately did NOT
+        // consume the token (per /api/auth/verify-email's peek-first
+        // logic), so the same token can be re-used by the link-password
+        // POST. Without this branch, the user lands on "Email Verified"
+        // → "Continue to Subscription" but never gets to set a password,
+        // and the next login attempt re-fires the linking flow forever.
+        if (data.needsPasswordLinking) {
+          router.replace(`/auth/link-password?token=${encodeURIComponent(verificationToken)}`)
+          return
+        }
+
+        // Regular flow — token was consumed server-side, mark success.
         const url = new URL(window.location.href)
         url.searchParams.set('success', 'true')
         if (data.email) {


### PR DESCRIPTION
## Summary

**Final piece of the email→Google linking-loop fix.** The user smoke-tested via Playwright and we caught the actual bug:

- Click verification email link → land on `/verify-email?token=...`
- Page fetches `/api/auth/verify-email?token=...` with `Accept: application/json`
- API returns `{ success: true, needsPasswordLinking: true, email: ... }` (per PR-25 — and deliberately does NOT consume the token in this branch)
- **Page ignores `needsPasswordLinking`** and redirects to `?success=true`
- User sees "Email Verified! Continue to Subscription"
- User never reaches `/auth/link-password`, no password set
- User logs in again → Google-only-no-password detection re-fires → loop

## Fix

In `app/verify-email/page.tsx` `verifyToken`, add one conditional branch: if `data.needsPasswordLinking`, `router.replace` to `/auth/link-password?token=<token>` (preserving the same token; the API deliberately doesn't consume it in this path so link-password POST can still validate).

## End-to-end now

1. `POST /api/auth/passport/login { email, wrongpw }` returns `requiresLinking` + auto-sends email ✓ (PR-23)
2. Email lands at `/verify-email?token=xxx` ✓
3. Page fetches API → JSON `{ needsPasswordLinking: true }` ✓ (PR-25)
4. **Page redirects to `/auth/link-password?token=xxx`** ✓ (this PR)
5. User sets password → `link-password` POST consumes token + attaches password
6. Session created → redirect to `/data-room`

## Functional safety
- 1 file, 16 ins / 2 del. Single conditional branch.
- Regular email-verification flow (non-Google-linking) unchanged — `needsPasswordLinking` is false, original `?success=true` path runs.
- Token preservation across the GET→POST handoff was already designed for in PR-25's API.
- `tsc --noEmit` clean.

## Branch hygiene
- Branched off `origin/main` after PR #106.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)