### PR TITLE
fix(ui): light-mode regressions + boot shell loading messages (PR-29)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -544,7 +544,7 @@ function AdminPageInner() {
       return (
         <div key={folder.path}>
           <div
-            className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer hover:bg-bg-elevated transition-colors ${isSelected ? 'bg-primary-orange/20 border border-primary-orange/50' : ''
+            className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer hover:bg-bg-elevated transition-colors ${isSelected ? 'bg-accent-brand/20 border border-accent-brand/50' : ''
               }`}
             style={{ paddingLeft: `${level * 20 + 8}px` }}
             onClick={() => setSelectedFolderPath(folder.path)}
@@ -568,7 +568,7 @@ function AdminPageInner() {
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
-              className="text-primary-orange"
+              className="text-accent-brand"
             >
               <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
             </svg>
@@ -581,7 +581,7 @@ function AdminPageInner() {
                   setEditingVaultFolder(folder)
                   setVaultFolderForm({ name: folder.name, description: '' })
                 }}
-                className="p-1 text-fg-muted hover:text-primary-orange transition-colors"
+                className="p-1 text-fg-muted hover:text-accent-brand transition-colors"
                 title="Edit folder"
               >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -667,11 +667,11 @@ function AdminPageInner() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+      <div className="min-h-screen bg-bg-base relative overflow-hidden">
         <SubtleCircuitBackground />
         <div className="relative z-10 container mx-auto px-4 py-8 flex items-center justify-center min-h-screen">
           <div className="text-center">
-            <div className="w-10 h-10 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mb-4 mx-auto"></div>
+            <div className="w-10 h-10 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mb-4 mx-auto"></div>
             <p className="text-fg-muted">Loading...</p>
           </div>
         </div>
@@ -695,7 +695,7 @@ function AdminPageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       {confirmDialog}
       <SubtleCircuitBackground />
       <Header />
@@ -732,7 +732,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('overview')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'overview'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -747,7 +747,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('companies')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'companies'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -760,7 +760,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('compliances')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'compliances'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -772,7 +772,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('templates')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'templates'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -788,7 +788,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('subscriptions')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'subscriptions'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -801,7 +801,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('allusers')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'allusers'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -816,7 +816,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('financials')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'financials'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -829,7 +829,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('transactions')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'transactions'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -845,7 +845,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('vault')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'vault'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -859,7 +859,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('kpis')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'kpis'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -873,7 +873,7 @@ function AdminPageInner() {
           <button
             onClick={() => setActiveTab('tracking')}
             className={`flex items-center gap-2 px-6 py-3 rounded-lg border-2 transition-colors ${activeTab === 'tracking'
-              ? 'border-primary-orange bg-primary-orange/20 text-white'
+              ? 'border-accent-brand bg-accent-brand/20 text-white'
               : 'border-line/15 bg-bg-card text-fg-muted hover:text-fg-primary hover:border-line/30'
               }`}
           >
@@ -890,8 +890,8 @@ function AdminPageInner() {
             <div className="bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-6">
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-fg-muted text-sm font-medium">Total Companies</h3>
-                <div className="w-10 h-10 bg-primary-orange/20 rounded-lg flex items-center justify-center">
-                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-primary-orange">
+                <div className="w-10 h-10 bg-accent-brand/20 rounded-lg flex items-center justify-center">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent-brand">
                     <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
                     <polyline points="14 2 14 8 20 8" />
                   </svg>
@@ -970,7 +970,7 @@ function AdminPageInner() {
                       <td className="px-6 py-4">
                         <button
                           onClick={() => router.push(`/data-room?company=${company.id}`)}
-                          className="px-4 py-2 bg-primary-orange/20 border border-primary-orange text-primary-orange rounded-lg hover:bg-primary-orange/30 transition-colors text-sm"
+                          className="px-4 py-2 bg-accent-brand/20 border border-accent-brand text-accent-brand rounded-lg hover:bg-accent-brand/30 transition-colors text-sm"
                         >
                           View Details
                         </button>
@@ -991,7 +991,7 @@ function AdminPageInner() {
               <select
                 value={selectedCompany}
                 onChange={(e) => setSelectedCompany(e.target.value)}
-                className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
               >
                 <option value="all">All Companies</option>
                 {companies.map((company) => (
@@ -1124,7 +1124,7 @@ function AdminPageInner() {
                     setEditingTemplate(null)
                     setIsTemplateModalOpen(true)
                   }}
-                  className="bg-primary-orange text-white px-6 py-3 rounded-lg hover:bg-primary-orange/90 transition-colors flex items-center gap-2 font-medium"
+                  className="bg-accent-brand text-white px-6 py-3 rounded-lg hover:bg-accent-brand/90 transition-colors flex items-center gap-2 font-medium"
                 >
                   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                     <line x1="12" y1="5" x2="12" y2="19" />
@@ -1196,7 +1196,7 @@ function AdminPageInner() {
             {/* Templates List */}
             {isLoadingTemplates ? (
               <div className="bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-12 flex flex-col items-center justify-center">
-                <div className="w-10 h-10 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mb-4"></div>
+                <div className="w-10 h-10 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mb-4"></div>
                 <p className="text-fg-muted">Loading templates...</p>
               </div>
             ) : (
@@ -1219,7 +1219,7 @@ function AdminPageInner() {
                                 setSelectedTemplates([])
                               }
                             }}
-                            className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                            className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                           />
                         </th>
                         <th className="px-6 py-4 text-left text-xs font-medium text-fg-muted uppercase">Requirement</th>
@@ -1241,7 +1241,7 @@ function AdminPageInner() {
                         </tr>
                       ) : (
                         templates.map((template) => (
-                          <tr key={template.id} className={`hover:bg-bg-card/50 transition-colors border-t border-line/10 ${selectedTemplates.includes(template.id) ? 'bg-primary-orange/10' : ''}`}>
+                          <tr key={template.id} className={`hover:bg-bg-card/50 transition-colors border-t border-line/10 ${selectedTemplates.includes(template.id) ? 'bg-accent-brand/10' : ''}`}>
                             <td className="px-4 py-4">
                               <input
                                 type="checkbox"
@@ -1253,7 +1253,7 @@ function AdminPageInner() {
                                     setSelectedTemplates(prev => prev.filter(id => id !== template.id))
                                   }
                                 }}
-                                className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                                className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                               />
                             </td>
                             <td className="px-6 py-4 text-fg-primary font-medium">{template.requirement}</td>
@@ -1503,7 +1503,7 @@ function AdminPageInner() {
                   <div className="space-y-3">
                     <div className="flex justify-between items-center pt-2 border-t border-line/15">
                       <span className="text-fg-primary font-medium">Total Annual Fixed Costs</span>
-                      <span className="text-xl font-bold text-primary-orange">{formatCurrency(FIXED_COSTS.total)}</span>
+                      <span className="text-xl font-bold text-accent-brand">{formatCurrency(FIXED_COSTS.total)}</span>
                     </div>
                     <div className="flex justify-between items-center">
                       <span className="text-fg-muted">CapEx (Year 1 Only)</span>
@@ -1542,7 +1542,7 @@ function AdminPageInner() {
                         </div>
                         <div className="flex justify-between text-fg-muted">
                           <span>Break-Even Customers</span>
-                          <span className="text-primary-orange font-medium">{year1Analysis.breakEvenCustomers}</span>
+                          <span className="text-accent-brand font-medium">{year1Analysis.breakEvenCustomers}</span>
                         </div>
                         <div className="flex justify-between text-fg-muted">
                           <span>Contribution Margin</span>
@@ -1568,7 +1568,7 @@ function AdminPageInner() {
                         </div>
                         <div className="flex justify-between text-fg-muted">
                           <span>Break-Even Customers</span>
-                          <span className="text-primary-orange font-medium">{year2Analysis.breakEvenCustomers}</span>
+                          <span className="text-accent-brand font-medium">{year2Analysis.breakEvenCustomers}</span>
                         </div>
                         <div className="flex justify-between text-fg-muted">
                           <span>Contribution Margin</span>
@@ -1614,7 +1614,7 @@ function AdminPageInner() {
                       </div>
                       <div className="bg-bg-card/50 rounded-lg p-4 border border-line/15">
                         <div className="text-xs text-fg-muted mb-1">CAC</div>
-                        <div className="text-2xl font-bold text-primary-orange">{formatCurrency(metrics.cac)}</div>
+                        <div className="text-2xl font-bold text-accent-brand">{formatCurrency(metrics.cac)}</div>
                       </div>
                       <div className="bg-bg-card/50 rounded-lg p-4 border border-line/15">
                         <div className="text-xs text-fg-muted mb-1">LTV</div>
@@ -1732,7 +1732,7 @@ function AdminPageInner() {
                   <select
                     value={templateForm.category}
                     onChange={(e) => setTemplateForm(prev => ({ ...prev, category: e.target.value }))}
-                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     disabled={categoriesLoading}
                   >
                     <option value="">Select Category</option>
@@ -1751,7 +1751,7 @@ function AdminPageInner() {
                     type="text"
                     value={templateForm.requirement}
                     onChange={(e) => setTemplateForm(prev => ({ ...prev, requirement: e.target.value }))}
-                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     placeholder="e.g., TDS Payment - Monthly"
                   />
                 </div>
@@ -1764,7 +1764,7 @@ function AdminPageInner() {
                   <textarea
                     value={templateForm.description}
                     onChange={(e) => setTemplateForm(prev => ({ ...prev, description: e.target.value }))}
-                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     rows={3}
                     placeholder="Brief description of the requirement"
                   />
@@ -1778,7 +1778,7 @@ function AdminPageInner() {
                   <select
                     value={templateForm.compliance_type}
                     onChange={(e) => setTemplateForm(prev => ({ ...prev, compliance_type: e.target.value as any }))}
-                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                   >
                     <option value="one-time">One-time</option>
                     <option value="monthly">Monthly</option>
@@ -1811,7 +1811,7 @@ function AdminPageInner() {
                     <select
                       value={templateForm.year_type}
                       onChange={(e) => setTemplateForm(prev => ({ ...prev, year_type: e.target.value as 'FY' | 'CY' }))}
-                      className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                      className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     >
                       <option value="FY">Financial Year (India) - FY starts from April</option>
                       <option value="CY">Calendar Year (Gulf/USA) - CY starts from January</option>
@@ -1831,7 +1831,7 @@ function AdminPageInner() {
                   </label>
                   <div className="grid grid-cols-2 gap-2">
                     {['Private Limited', 'Public Limited', 'LLP', 'NGO / Section 8', 'Other'].map((type) => (
-                      <label key={type} className="flex items-center gap-2 p-3 bg-bg-card border border-line/15 rounded-lg hover:border-primary-orange/50 transition-colors cursor-pointer">
+                      <label key={type} className="flex items-center gap-2 p-3 bg-bg-card border border-line/15 rounded-lg hover:border-accent-brand/50 transition-colors cursor-pointer">
                         <input
                           type="checkbox"
                           checked={templateForm.entity_types.includes(type)}
@@ -1842,7 +1842,7 @@ function AdminPageInner() {
                               setTemplateForm(prev => ({ ...prev, entity_types: prev.entity_types.filter(t => t !== type) }))
                             }
                           }}
-                          className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                          className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                         />
                         <span className="text-fg-primary text-sm">{type}</span>
                       </label>
@@ -1856,7 +1856,7 @@ function AdminPageInner() {
                     <label className="block text-sm font-medium text-fg-secondary">
                       Industries * (Select at least one)
                     </label>
-                    <label className="flex items-center gap-2 px-3 py-1.5 bg-bg-card border border-line/15 rounded-lg hover:border-primary-orange/50 transition-colors cursor-pointer">
+                    <label className="flex items-center gap-2 px-3 py-1.5 bg-bg-card border border-line/15 rounded-lg hover:border-accent-brand/50 transition-colors cursor-pointer">
                       <input
                         type="checkbox"
                         checked={['IT & Technology Services', 'Healthcare', 'Education', 'Finance', 'Food Manufacturing', 'Food & Hospitality', 'Construction', 'Real Estate', 'Manufacturing', 'Retail & Trading', 'Professional Services', 'Ecommerce', 'Other'].every(industry => templateForm.industries.includes(industry))}
@@ -1868,14 +1868,14 @@ function AdminPageInner() {
                             setTemplateForm(prev => ({ ...prev, industries: [] }))
                           }
                         }}
-                        className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                        className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                       />
                       <span className="text-fg-primary text-sm font-medium">Select All</span>
                     </label>
                   </div>
                   <div className="grid grid-cols-2 gap-2 max-h-48 overflow-y-auto">
                     {['IT & Technology Services', 'Healthcare', 'Education', 'Finance', 'Food Manufacturing', 'Food & Hospitality', 'Construction', 'Real Estate', 'Manufacturing', 'Retail & Trading', 'Professional Services', 'Ecommerce', 'Other'].map((industry) => (
-                      <label key={industry} className="flex items-center gap-2 p-3 bg-bg-card border border-line/15 rounded-lg hover:border-primary-orange/50 transition-colors cursor-pointer">
+                      <label key={industry} className="flex items-center gap-2 p-3 bg-bg-card border border-line/15 rounded-lg hover:border-accent-brand/50 transition-colors cursor-pointer">
                         <input
                           type="checkbox"
                           checked={templateForm.industries.includes(industry)}
@@ -1886,7 +1886,7 @@ function AdminPageInner() {
                               setTemplateForm(prev => ({ ...prev, industries: prev.industries.filter(i => i !== industry) }))
                             }
                           }}
-                          className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                          className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                         />
                         <span className="text-fg-primary text-sm">{industry}</span>
                       </label>
@@ -1900,7 +1900,7 @@ function AdminPageInner() {
                     <label className="block text-sm font-medium text-fg-secondary">
                       Industry Categories * (Select at least one)
                     </label>
-                    <label className="flex items-center gap-2 px-3 py-1.5 bg-bg-card border border-line/15 rounded-lg hover:border-primary-orange/50 transition-colors cursor-pointer">
+                    <label className="flex items-center gap-2 px-3 py-1.5 bg-bg-card border border-line/15 rounded-lg hover:border-accent-brand/50 transition-colors cursor-pointer">
                       <input
                         type="checkbox"
                         checked={['Startups & MSMEs', 'Large Enterprises', 'NGOs & Section 8 Companies', 'Healthcare & Education', 'Real Estate & Construction', 'IT & Technology Services', 'Retail & Manufacturing', 'Food & Hospitality', 'Ecommerce & D2C', 'Other'].every(category => templateForm.industry_categories.includes(category))}
@@ -1912,14 +1912,14 @@ function AdminPageInner() {
                             setTemplateForm(prev => ({ ...prev, industry_categories: [] }))
                           }
                         }}
-                        className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                        className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                       />
                       <span className="text-fg-primary text-sm font-medium">Select All</span>
                     </label>
                   </div>
                   <div className="grid grid-cols-2 gap-2">
                     {['Startups & MSMEs', 'Large Enterprises', 'NGOs & Section 8 Companies', 'Healthcare & Education', 'Real Estate & Construction', 'IT & Technology Services', 'Retail & Manufacturing', 'Food & Hospitality', 'Ecommerce & D2C', 'Other'].map((category) => (
-                      <label key={category} className="flex items-center gap-2 p-3 bg-bg-card border border-line/15 rounded-lg hover:border-primary-orange/50 transition-colors cursor-pointer">
+                      <label key={category} className="flex items-center gap-2 p-3 bg-bg-card border border-line/15 rounded-lg hover:border-accent-brand/50 transition-colors cursor-pointer">
                         <input
                           type="checkbox"
                           checked={templateForm.industry_categories.includes(category)}
@@ -1930,7 +1930,7 @@ function AdminPageInner() {
                               setTemplateForm(prev => ({ ...prev, industry_categories: prev.industry_categories.filter(c => c !== category) }))
                             }
                           }}
-                          className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                          className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                         />
                         <span className="text-fg-primary text-sm">{category}</span>
                       </label>
@@ -1949,7 +1949,7 @@ function AdminPageInner() {
                         type="date"
                         value={templateForm.due_date}
                         onChange={(e) => setTemplateForm(prev => ({ ...prev, due_date: e.target.value }))}
-                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                       />
                     </div>
                     <div>
@@ -1960,7 +1960,7 @@ function AdminPageInner() {
                         type="text"
                         value={templateForm.financial_year}
                         onChange={(e) => setTemplateForm(prev => ({ ...prev, financial_year: e.target.value }))}
-                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                         placeholder="e.g., FY 2025-26"
                       />
                     </div>
@@ -1978,7 +1978,7 @@ function AdminPageInner() {
                       max="31"
                       value={templateForm.due_date_offset || ''}
                       onChange={(e) => setTemplateForm(prev => ({ ...prev, due_date_offset: e.target.value ? parseInt(e.target.value) : undefined }))}
-                      className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                      className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                       placeholder="15"
                     />
                   </div>
@@ -2024,7 +2024,7 @@ function AdminPageInner() {
                             const monthInQuarter = e.target.value ? parseInt(e.target.value) : undefined
                             setTemplateForm(prev => ({ ...prev, due_month: monthInQuarter }))
                           }}
-                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                         >
                           <option value="">Select Month</option>
                           <option value="1">1st Month of Quarter</option>
@@ -2045,7 +2045,7 @@ function AdminPageInner() {
                           max="31"
                           value={templateForm.due_day || ''}
                           onChange={(e) => setTemplateForm(prev => ({ ...prev, due_day: e.target.value ? parseInt(e.target.value) : undefined }))}
-                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                           placeholder="15"
                         />
                         <p className="text-xs text-fg-muted mt-1">
@@ -2068,7 +2068,7 @@ function AdminPageInner() {
                         max="12"
                         value={templateForm.due_month || ''}
                         onChange={(e) => setTemplateForm(prev => ({ ...prev, due_month: e.target.value ? parseInt(e.target.value) : undefined }))}
-                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                         placeholder="3"
                       />
                     </div>
@@ -2082,7 +2082,7 @@ function AdminPageInner() {
                         max="31"
                         value={templateForm.due_day || ''}
                         onChange={(e) => setTemplateForm(prev => ({ ...prev, due_day: e.target.value ? parseInt(e.target.value) : undefined }))}
-                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                         placeholder="31"
                       />
                     </div>
@@ -2098,7 +2098,7 @@ function AdminPageInner() {
                     type="text"
                     value={templateForm.penalty}
                     onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty: e.target.value }))}
-                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     placeholder="e.g., Late fee ₹200/day"
                   />
                 </div>
@@ -2118,7 +2118,7 @@ function AdminPageInner() {
                     <select
                       value={templateForm.penalty_config_type}
                       onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_type: e.target.value as any }))}
-                      className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                      className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     >
                       <option value="none">None / Text only</option>
                       <option value="flat">Flat amount (fixed penalty)</option>
@@ -2133,7 +2133,7 @@ function AdminPageInner() {
                       <label className="block text-sm font-medium text-fg-secondary mb-2">Fixed Penalty Amount (₹)</label>
                       <input type="number" value={templateForm.penalty_config_amount}
                         onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_amount: e.target.value }))}
-                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                        className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                         placeholder="e.g., 5000" min="0" />
                     </div>
                   )}
@@ -2144,14 +2144,14 @@ function AdminPageInner() {
                         <label className="block text-sm font-medium text-fg-secondary mb-2">Rate per Day (₹)</label>
                         <input type="number" value={templateForm.penalty_config_rate}
                           onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_rate: e.target.value }))}
-                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                           placeholder="e.g., 200" min="0" />
                       </div>
                       <div>
                         <label className="block text-sm font-medium text-fg-secondary mb-2">Maximum Cap (₹, optional)</label>
                         <input type="number" value={templateForm.penalty_config_cap}
                           onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_cap: e.target.value }))}
-                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                           placeholder="e.g., 10000" min="0" />
                       </div>
                     </div>
@@ -2163,7 +2163,7 @@ function AdminPageInner() {
                         <label className="block text-sm font-medium text-fg-secondary mb-2">Rate (%)</label>
                         <input type="number" value={templateForm.penalty_config_rate}
                           onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_rate: e.target.value }))}
-                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                           placeholder="e.g., 1.5" min="0" step="0.01" />
                       </div>
                       {templateForm.penalty_config_type === 'interest' && (
@@ -2171,7 +2171,7 @@ function AdminPageInner() {
                           <label className="block text-sm font-medium text-fg-secondary mb-2">Per</label>
                           <select value={templateForm.penalty_config_period}
                             onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_period: e.target.value as any }))}
-                            className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors">
+                            className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors">
                             <option value="month">Month</option>
                             <option value="day">Day</option>
                             <option value="year">Year</option>
@@ -2182,7 +2182,7 @@ function AdminPageInner() {
                         <label className="block text-sm font-medium text-fg-secondary mb-2">Base Amount Type</label>
                         <select value={templateForm.penalty_config_base}
                           onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_base: e.target.value }))}
-                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors">
+                          className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors">
                           <option value="tax_due">Tax Due</option>
                           <option value="turnover">Turnover</option>
                           <option value="income">Income</option>
@@ -2194,7 +2194,7 @@ function AdminPageInner() {
                           <label className="block text-sm font-medium text-fg-secondary mb-2">Cap (₹, optional)</label>
                           <input type="number" value={templateForm.penalty_config_cap}
                             onChange={(e) => setTemplateForm(prev => ({ ...prev, penalty_config_cap: e.target.value }))}
-                            className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                            className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                             placeholder="Maximum penalty cap" min="0" />
                         </div>
                       )}
@@ -2219,7 +2219,7 @@ function AdminPageInner() {
                     type="text"
                     value={templateForm.possible_legal_action}
                     onChange={(e) => setTemplateForm(prev => ({ ...prev, possible_legal_action: e.target.value }))}
-                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     placeholder="e.g., Prosecution under Section 276B"
                   />
                 </div>
@@ -2244,7 +2244,7 @@ function AdminPageInner() {
                           }))
                         }
                       }}
-                      className="flex-1 px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                      className="flex-1 px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                       placeholder="Type document name and press Enter"
                     />
                     <button
@@ -2258,7 +2258,7 @@ function AdminPageInner() {
                           }))
                         }
                       }}
-                      className="px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-orange-600 transition-colors"
+                      className="px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-orange-600 transition-colors"
                     >
                       Add
                     </button>
@@ -2297,7 +2297,7 @@ function AdminPageInner() {
                     id="is_critical_template"
                     checked={templateForm.is_critical}
                     onChange={(e) => setTemplateForm(prev => ({ ...prev, is_critical: e.target.checked }))}
-                    className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                    className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                   />
                   <label htmlFor="is_critical_template" className="text-sm font-medium text-fg-secondary">
                     Mark as Critical
@@ -2312,7 +2312,7 @@ function AdminPageInner() {
                       id="is_active_template"
                       checked={templateForm.is_active}
                       onChange={(e) => setTemplateForm(prev => ({ ...prev, is_active: e.target.checked }))}
-                      className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                      className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                     />
                     <label htmlFor="is_active_template" className="text-sm font-medium text-fg-secondary">
                       Template is Active
@@ -2401,7 +2401,7 @@ function AdminPageInner() {
                         showToast(`Error: ${error instanceof Error ? error.message : 'Something went wrong'}`, 'error')
                       }
                     }}
-                    className="flex-1 bg-primary-orange text-white px-6 py-3 rounded-lg hover:bg-primary-orange/90 transition-colors font-medium"
+                    className="flex-1 bg-accent-brand text-white px-6 py-3 rounded-lg hover:bg-accent-brand/90 transition-colors font-medium"
                   >
                     {editingTemplate ? 'Update Template' : 'Create Template'}
                   </button>
@@ -2430,7 +2430,7 @@ function AdminPageInner() {
 
             {isLoadingVaultFolders ? (
               <div className="flex items-center justify-center py-12">
-                <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+                <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
               </div>
             ) : (
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -2445,7 +2445,7 @@ function AdminPageInner() {
                           setVaultFolderForm({ name: '', description: '' })
                           setShowCreateVaultFolderModal(true)
                         }}
-                        className="px-3 py-1.5 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors text-sm font-medium"
+                        className="px-3 py-1.5 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors text-sm font-medium"
                       >
                         + New Folder
                       </button>
@@ -2454,7 +2454,7 @@ function AdminPageInner() {
                     {/* Root level button */}
                     <button
                       onClick={() => setSelectedFolderPath(null)}
-                      className={`w-full flex items-center gap-2 p-2 rounded-lg hover:bg-bg-elevated transition-colors mb-2 ${selectedFolderPath === null ? 'bg-primary-orange/20 border border-primary-orange/50' : ''
+                      className={`w-full flex items-center gap-2 p-2 rounded-lg hover:bg-bg-elevated transition-colors mb-2 ${selectedFolderPath === null ? 'bg-accent-brand/20 border border-accent-brand/50' : ''
                         }`}
                     >
                       <svg
@@ -2464,7 +2464,7 @@ function AdminPageInner() {
                         fill="none"
                         stroke="currentColor"
                         strokeWidth="2"
-                        className="text-primary-orange"
+                        className="text-accent-brand"
                       >
                         <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
                         <polyline points="9 22 9 12 15 12 15 22" />
@@ -2493,7 +2493,7 @@ function AdminPageInner() {
                                 {idx > 0 && <span className="mx-1">/</span>}
                                 <button
                                   onClick={() => setSelectedFolderPath(crumb.path)}
-                                  className="hover:text-primary-orange transition-colors"
+                                  className="hover:text-accent-brand transition-colors"
                                 >
                                   {crumb.name}
                                 </button>
@@ -2514,7 +2514,7 @@ function AdminPageInner() {
                           })
                           setShowCreateVaultTemplateModal(true)
                         }}
-                        className="px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors text-sm font-medium"
+                        className="px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors text-sm font-medium"
                       >
                         + New Document
                       </button>
@@ -2523,7 +2523,7 @@ function AdminPageInner() {
                     {isLoadingVaultTemplates ? (
                       <div className="flex items-center justify-center py-8">
                         <div className="flex items-center gap-3 text-fg-muted">
-                          <div className="w-5 h-5 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+                          <div className="w-5 h-5 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
                           <span className="text-sm">Loading templates...</span>
                         </div>
                       </div>
@@ -2569,7 +2569,7 @@ function AdminPageInner() {
                               )}
                               <div className="flex items-center gap-4 text-xs text-fg-muted">
                                 {template.category && (
-                                  <span className="px-2 py-0.5 bg-primary-orange/20 text-primary-orange rounded">
+                                  <span className="px-2 py-0.5 bg-accent-brand/20 text-accent-brand rounded">
                                     {template.category}
                                   </span>
                                 )}
@@ -2587,7 +2587,7 @@ function AdminPageInner() {
                                     isMandatory: template.is_mandatory,
                                   })
                                 }}
-                                className="p-2 text-fg-muted hover:text-primary-orange transition-colors"
+                                className="p-2 text-fg-muted hover:text-accent-brand transition-colors"
                                 title="Edit"
                               >
                                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -2629,7 +2629,7 @@ function AdminPageInner() {
                         type="text"
                         value={vaultFolderForm.name}
                         onChange={(e) => setVaultFolderForm({ ...vaultFolderForm, name: e.target.value })}
-                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                         placeholder="Enter folder name"
                       />
                     </div>
@@ -2638,21 +2638,21 @@ function AdminPageInner() {
                       <textarea
                         value={vaultFolderForm.description}
                         onChange={(e) => setVaultFolderForm({ ...vaultFolderForm, description: e.target.value })}
-                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                         placeholder="Enter folder description"
                         rows={3}
                       />
                     </div>
                     {selectedFolderPath && !editingVaultFolder && (
                       <div className="text-sm text-fg-muted">
-                        Creating in: <span className="text-primary-orange">{selectedFolderPath}</span>
+                        Creating in: <span className="text-accent-brand">{selectedFolderPath}</span>
                       </div>
                     )}
                     <div className="flex items-center gap-3">
                       <button
                         onClick={editingVaultFolder ? handleUpdateVaultFolder : handleCreateVaultFolder}
                         disabled={isCreatingVaultFolder || !vaultFolderForm.name.trim()}
-                        className="flex-1 px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="flex-1 px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         {isCreatingVaultFolder ? 'Saving...' : editingVaultFolder ? 'Update' : 'Create'}
                       </button>
@@ -2686,7 +2686,7 @@ function AdminPageInner() {
                         type="text"
                         value={vaultTemplateForm.name}
                         onChange={(e) => setVaultTemplateForm({ ...vaultTemplateForm, name: e.target.value })}
-                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                         placeholder="e.g., GSTR-3B Filed Copy"
                       />
                     </div>
@@ -2698,7 +2698,7 @@ function AdminPageInner() {
                           const value = e.target.value as 'one-time' | 'monthly' | 'quarterly' | 'yearly'
                           setVaultTemplateForm({ ...vaultTemplateForm, frequency: value })
                         }}
-                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                       >
                         <option value="one-time">One-Time</option>
                         <option value="monthly">Monthly</option>
@@ -2712,7 +2712,7 @@ function AdminPageInner() {
                         type="text"
                         value={vaultTemplateForm.category}
                         onChange={(e) => setVaultTemplateForm({ ...vaultTemplateForm, category: e.target.value })}
-                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                         placeholder="e.g., GST, Income Tax"
                       />
                     </div>
@@ -2721,7 +2721,7 @@ function AdminPageInner() {
                       <textarea
                         value={vaultTemplateForm.description}
                         onChange={(e) => setVaultTemplateForm({ ...vaultTemplateForm, description: e.target.value })}
-                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                        className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                         placeholder="Enter document description"
                         rows={3}
                       />
@@ -2732,7 +2732,7 @@ function AdminPageInner() {
                         id="isMandatoryVault"
                         checked={vaultTemplateForm.isMandatory}
                         onChange={(e) => setVaultTemplateForm({ ...vaultTemplateForm, isMandatory: e.target.checked })}
-                        className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                        className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                       />
                       <label htmlFor="isMandatoryVault" className="text-sm text-fg-secondary">
                         Mandatory Document
@@ -2740,14 +2740,14 @@ function AdminPageInner() {
                     </div>
                     {selectedFolderPath && (
                       <div className="text-sm text-fg-muted">
-                        Creating in: <span className="text-primary-orange">{selectedFolderPath}</span>
+                        Creating in: <span className="text-accent-brand">{selectedFolderPath}</span>
                       </div>
                     )}
                     <div className="flex items-center gap-3">
                       <button
                         onClick={editingVaultTemplate ? handleUpdateVaultTemplate : handleCreateVaultTemplate}
                         disabled={isCreatingVaultTemplate || !vaultTemplateForm.name.trim()}
-                        className="flex-1 px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        className="flex-1 px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         {isCreatingVaultTemplate ? 'Saving...' : editingVaultTemplate ? 'Update' : 'Create'}
                       </button>
@@ -2863,7 +2863,7 @@ function KPIsTab() {
             <select
               value={selectedCategory}
               onChange={(e) => setSelectedCategory(e.target.value)}
-              className="w-full px-4 py-2 bg-primary-dark border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+              className="w-full px-4 py-2 bg-bg-base border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
             >
               {categories.map(cat => (
                 <option key={cat} value={cat}>{cat}</option>
@@ -2878,7 +2878,7 @@ function KPIsTab() {
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               placeholder="Search KPIs, formulas, descriptions..."
-              className="w-full px-4 py-2 bg-primary-dark border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-primary-orange"
+              className="w-full px-4 py-2 bg-bg-base border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-accent-brand"
             />
           </div>
         </div>
@@ -3176,7 +3176,7 @@ function TrackingSystemTab() {
             <select
               value={selectedCategory}
               onChange={(e) => setSelectedCategory(e.target.value)}
-              className="w-full px-4 py-2 bg-primary-dark border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+              className="w-full px-4 py-2 bg-bg-base border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
             >
               {categories.map(cat => (
                 <option key={cat} value={cat}>{cat}</option>
@@ -3189,7 +3189,7 @@ function TrackingSystemTab() {
             <select
               value={selectedKPI}
               onChange={(e) => setSelectedKPI(e.target.value)}
-              className="w-full px-4 py-2 bg-primary-dark border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+              className="w-full px-4 py-2 bg-bg-base border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
             >
               {kpis.map(kpi => (
                 <option key={kpi} value={kpi}>{kpi}</option>
@@ -3202,7 +3202,7 @@ function TrackingSystemTab() {
             <select
               value={selectedCompany}
               onChange={(e) => setSelectedCompany(e.target.value)}
-              className="w-full px-4 py-2 bg-primary-dark border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+              className="w-full px-4 py-2 bg-bg-base border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
             >
               <option value="All">All Companies</option>
               {companies.map(company => (
@@ -3216,7 +3216,7 @@ function TrackingSystemTab() {
             <select
               value={dateRange}
               onChange={(e) => setDateRange(e.target.value as '7d' | '30d' | '90d' | 'all')}
-              className="w-full px-4 py-2 bg-primary-dark border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+              className="w-full px-4 py-2 bg-bg-base border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
             >
               <option value="7d">Last 7 days</option>
               <option value="30d">Last 30 days</option>
@@ -3228,7 +3228,7 @@ function TrackingSystemTab() {
           <div className="flex items-end gap-2">
             <button
               onClick={() => window.location.reload()}
-              className="flex-1 px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors"
+              className="flex-1 px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors"
             >
               Refresh
             </button>
@@ -3333,7 +3333,7 @@ function TrackingSystemTab() {
         </div>
         {isLoading ? (
           <div className="p-8 text-center">
-            <div className="w-8 h-8 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+            <div className="w-8 h-8 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
             <p className="text-fg-muted">Loading tracking data...</p>
           </div>
         ) : aggregations.length === 0 ? (
@@ -3379,7 +3379,7 @@ function TrackingSystemTab() {
                       <td className="px-6 py-4 text-center">
                         <button
                           onClick={() => loadKPIDetails(agg.kpi_name, agg.category)}
-                          className="px-3 py-1 text-xs bg-primary-orange/20 text-primary-orange rounded hover:bg-primary-orange/30 transition-colors"
+                          className="px-3 py-1 text-xs bg-accent-brand/20 text-accent-brand rounded hover:bg-accent-brand/30 transition-colors"
                         >
                           View Details
                         </button>
@@ -3421,7 +3421,7 @@ function TrackingSystemTab() {
           </div>
           {isLoadingMetrics ? (
             <div className="p-8 text-center">
-              <div className="w-8 h-8 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+              <div className="w-8 h-8 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
               <p className="text-fg-muted">Loading metrics...</p>
             </div>
           ) : metrics.length === 0 ? (
@@ -3559,7 +3559,7 @@ function TrackingSystemTab() {
                       }
                     }}
                     placeholder="Ask a question about your KPI data..."
-                    className="flex-1 px-4 py-2 bg-primary-dark border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-blue-500"
+                    className="flex-1 px-4 py-2 bg-bg-base border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-blue-500"
                     disabled={isGeneratingChat || aggregations.length === 0}
                   />
                   <button

--- a/app/admin/vault/page.tsx
+++ b/app/admin/vault/page.tsx
@@ -406,7 +406,7 @@ export default function VaultManagementPage() {
         <div key={folder.path}>
           <div
             className={`flex items-center gap-2 p-2 rounded-lg cursor-pointer hover:bg-bg-elevated transition-colors ${
-              isSelected ? 'bg-primary-orange/20 border border-primary-orange/50' : ''
+              isSelected ? 'bg-accent-brand/20 border border-accent-brand/50' : ''
             }`}
             style={{ paddingLeft: `${level * 20 + 8}px` }}
             onClick={() => setSelectedFolderPath(folder.path)}
@@ -430,7 +430,7 @@ export default function VaultManagementPage() {
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
-              className="text-primary-orange"
+              className="text-accent-brand"
             >
               <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
             </svg>
@@ -443,7 +443,7 @@ export default function VaultManagementPage() {
                   setEditingFolder(folder)
                   setFolderForm({ name: folder.name, description: '' })
                 }}
-                className="p-1 text-fg-muted hover:text-primary-orange transition-colors"
+                className="p-1 text-fg-muted hover:text-accent-brand transition-colors"
                 title="Edit folder"
               >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -516,10 +516,10 @@ export default function VaultManagementPage() {
   if (isLoading) {
     console.log('[VAULT PAGE] Rendering loading state')
     return (
-      <div className="min-h-screen bg-primary-dark">
+      <div className="min-h-screen bg-bg-base">
         <Header />
         <div className="flex items-center justify-center h-[calc(100vh-80px)]">
-          <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+          <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
         </div>
       </div>
     )
@@ -529,7 +529,7 @@ export default function VaultManagementPage() {
   const currentFolderName = selectedFolderPath ? getFolderName(selectedFolderPath) : 'Root'
 
   return (
-    <div className="min-h-screen bg-primary-dark">
+    <div className="min-h-screen bg-bg-base">
       <Header />
       <SubtleCircuitBackground />
       <div className="container mx-auto px-4 py-8 relative z-10">
@@ -550,7 +550,7 @@ export default function VaultManagementPage() {
                     setFolderForm({ name: '', description: '' })
                     setShowCreateFolderModal(true)
                   }}
-                  className="px-3 py-1.5 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors text-sm font-medium"
+                  className="px-3 py-1.5 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors text-sm font-medium"
                 >
                   + New Folder
                 </button>
@@ -560,7 +560,7 @@ export default function VaultManagementPage() {
               <button
                 onClick={() => setSelectedFolderPath(null)}
                 className={`w-full flex items-center gap-2 p-2 rounded-lg hover:bg-bg-elevated transition-colors mb-2 ${
-                  selectedFolderPath === null ? 'bg-primary-orange/20 border border-primary-orange/50' : ''
+                  selectedFolderPath === null ? 'bg-accent-brand/20 border border-accent-brand/50' : ''
                 }`}
               >
                 <svg
@@ -570,7 +570,7 @@ export default function VaultManagementPage() {
                   fill="none"
                   stroke="currentColor"
                   strokeWidth="2"
-                  className="text-primary-orange"
+                  className="text-accent-brand"
                 >
                   <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z" />
                   <polyline points="9 22 9 12 15 12 15 22" />
@@ -599,7 +599,7 @@ export default function VaultManagementPage() {
                           {idx > 0 && <span className="mx-1">/</span>}
                           <button
                             onClick={() => setSelectedFolderPath(crumb.path)}
-                            className="hover:text-primary-orange transition-colors"
+                            className="hover:text-accent-brand transition-colors"
                           >
                             {crumb.name}
                           </button>
@@ -620,7 +620,7 @@ export default function VaultManagementPage() {
                     })
                     setShowCreateTemplateModal(true)
                   }}
-                  className="px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors text-sm font-medium"
+                  className="px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors text-sm font-medium"
                 >
                   + New Document
                 </button>
@@ -668,7 +668,7 @@ export default function VaultManagementPage() {
                         )}
                         <div className="flex items-center gap-4 text-xs text-fg-muted">
                           {template.category && (
-                            <span className="px-2 py-0.5 bg-primary-orange/20 text-primary-orange rounded">
+                            <span className="px-2 py-0.5 bg-accent-brand/20 text-accent-brand rounded">
                               {template.category}
                             </span>
                           )}
@@ -686,7 +686,7 @@ export default function VaultManagementPage() {
                               isMandatory: template.is_mandatory,
                             })
                           }}
-                          className="p-2 text-fg-muted hover:text-primary-orange transition-colors"
+                          className="p-2 text-fg-muted hover:text-accent-brand transition-colors"
                           title="Edit"
                         >
                           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -728,7 +728,7 @@ export default function VaultManagementPage() {
                   type="text"
                   value={folderForm.name}
                   onChange={(e) => setFolderForm({ ...folderForm, name: e.target.value })}
-                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                   placeholder="Enter folder name"
                 />
               </div>
@@ -737,21 +737,21 @@ export default function VaultManagementPage() {
                 <textarea
                   value={folderForm.description}
                   onChange={(e) => setFolderForm({ ...folderForm, description: e.target.value })}
-                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                   placeholder="Enter folder description"
                   rows={3}
                 />
               </div>
               {selectedFolderPath && !editingFolder && (
                 <div className="text-sm text-fg-muted">
-                  Creating in: <span className="text-primary-orange">{selectedFolderPath}</span>
+                  Creating in: <span className="text-accent-brand">{selectedFolderPath}</span>
                 </div>
               )}
               <div className="flex items-center gap-3">
                 <button
                   onClick={editingFolder ? handleUpdateFolder : handleCreateFolder}
                   disabled={isCreatingFolder || !folderForm.name.trim()}
-                  className="flex-1 px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex-1 px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isCreatingFolder ? 'Saving...' : editingFolder ? 'Update' : 'Create'}
                 </button>
@@ -785,7 +785,7 @@ export default function VaultManagementPage() {
                   type="text"
                   value={templateForm.name}
                   onChange={(e) => setTemplateForm({ ...templateForm, name: e.target.value })}
-                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                   placeholder="e.g., GSTR-3B Filed Copy"
                 />
               </div>
@@ -797,7 +797,7 @@ export default function VaultManagementPage() {
                     const value = e.target.value as 'one-time' | 'monthly' | 'quarterly' | 'yearly'
                     setTemplateForm({ ...templateForm, frequency: value })
                   }}
-                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                 >
                   <option value="one-time">One-Time</option>
                   <option value="monthly">Monthly</option>
@@ -811,7 +811,7 @@ export default function VaultManagementPage() {
                   type="text"
                   value={templateForm.category}
                   onChange={(e) => setTemplateForm({ ...templateForm, category: e.target.value })}
-                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                   placeholder="e.g., GST, Income Tax"
                 />
               </div>
@@ -820,7 +820,7 @@ export default function VaultManagementPage() {
                 <textarea
                   value={templateForm.description}
                   onChange={(e) => setTemplateForm({ ...templateForm, description: e.target.value })}
-                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange"
+                  className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand"
                   placeholder="Enter document description"
                   rows={3}
                 />
@@ -831,7 +831,7 @@ export default function VaultManagementPage() {
                   id="isMandatory"
                   checked={templateForm.isMandatory}
                   onChange={(e) => setTemplateForm({ ...templateForm, isMandatory: e.target.checked })}
-                  className="w-4 h-4 text-primary-orange bg-bg-card border-line/15 rounded focus:ring-primary-orange"
+                  className="w-4 h-4 text-accent-brand bg-bg-card border-line/15 rounded focus:ring-accent-brand"
                 />
                 <label htmlFor="isMandatory" className="text-sm text-fg-secondary">
                   Mandatory Document
@@ -839,14 +839,14 @@ export default function VaultManagementPage() {
               </div>
               {selectedFolderPath && (
                 <div className="text-sm text-fg-muted">
-                  Creating in: <span className="text-primary-orange">{selectedFolderPath}</span>
+                  Creating in: <span className="text-accent-brand">{selectedFolderPath}</span>
                 </div>
               )}
               <div className="flex items-center gap-3">
                 <button
                   onClick={editingTemplate ? handleUpdateTemplate : handleCreateTemplate}
                   disabled={isCreatingTemplate || !templateForm.name.trim()}
-                  className="flex-1 px-4 py-2 bg-primary-orange text-white rounded-lg hover:bg-primary-orange/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="flex-1 px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-accent-brand/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isCreatingTemplate ? 'Saving...' : editingTemplate ? 'Update' : 'Create'}
                 </button>

--- a/app/auth/auth-code-error/page.tsx
+++ b/app/auth/auth-code-error/page.tsx
@@ -7,7 +7,7 @@ export default function AuthCodeErrorPage() {
   const router = useRouter()
 
   return (
-    <div className="min-h-screen bg-primary-dark flex flex-col items-center justify-center px-4 relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base flex flex-col items-center justify-center px-4 relative overflow-hidden">
       <div className="relative z-10 w-full max-w-md text-center">
         <div className="mb-8 flex justify-center">
           <div className="w-16 h-16 bg-red-500/10 border border-red-500/20 rounded-xl flex items-center justify-center">

--- a/app/auth/link-password/page.tsx
+++ b/app/auth/link-password/page.tsx
@@ -73,13 +73,13 @@ function LinkPasswordPageInner() {
 
   if (!token) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
         <div className="w-full max-w-md bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-8">
           <h1 className="text-2xl font-light text-fg-primary mb-2">Link Password</h1>
           <p className="text-sm text-red-400 mb-4">Missing verification token.</p>
           <Link
             href="/login"
-            className="block w-full bg-primary-orange text-white px-4 py-2.5 rounded-lg hover:bg-primary-orange/90 transition-colors text-center"
+            className="block w-full bg-accent-brand text-white px-4 py-2.5 rounded-lg hover:bg-accent-brand/90 transition-colors text-center"
           >
             Go to Login
           </Link>
@@ -90,7 +90,7 @@ function LinkPasswordPageInner() {
 
   if (success) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
         <div className="w-full max-w-md bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-8">
           <h1 className="text-2xl font-light text-fg-primary mb-2">Password Linked!</h1>
           <p className="text-sm text-green-400 mb-4">
@@ -102,7 +102,7 @@ function LinkPasswordPageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+    <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
       <div className="w-full max-w-md bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-8">
         <h1 className="text-2xl font-light text-fg-primary mb-2">Set Password</h1>
         <p className="text-sm text-fg-muted mb-6">
@@ -117,7 +117,7 @@ function LinkPasswordPageInner() {
                 type={showPassword ? 'text' : 'password'}
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 pr-10 text-fg-primary focus:border-primary-orange focus:outline-none"
+                className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 pr-10 text-fg-primary focus:border-accent-brand focus:outline-none"
                 placeholder="At least 6 characters"
                 required
                 minLength={6}
@@ -147,7 +147,7 @@ function LinkPasswordPageInner() {
               type={showPassword ? 'text' : 'password'}
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
-              className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 text-fg-primary focus:border-primary-orange focus:outline-none"
+              className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 text-fg-primary focus:border-accent-brand focus:outline-none"
               placeholder="Confirm your password"
               required
               minLength={6}
@@ -163,7 +163,7 @@ function LinkPasswordPageInner() {
           <button
             type="submit"
             disabled={isSubmitting}
-            className="w-full bg-primary-orange text-white px-4 py-2.5 rounded-lg hover:bg-primary-orange/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full bg-accent-brand text-white px-4 py-2.5 rounded-lg hover:bg-accent-brand/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {isSubmitting ? 'Linking password...' : 'Link Password'}
           </button>
@@ -176,8 +176,8 @@ function LinkPasswordPageInner() {
 export default function LinkPasswordPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
-        <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
       </div>
     }>
       <LinkPasswordPageInner />

--- a/app/auth/reset-password/page.tsx
+++ b/app/auth/reset-password/page.tsx
@@ -99,7 +99,7 @@ function ResetPasswordPageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark flex flex-col relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base flex flex-col relative overflow-hidden">
       {/* Top Navigation Bar */}
       <nav className="relative z-10 w-full px-6 py-6 border-b border-line/10">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
@@ -265,7 +265,7 @@ function ResetPasswordPageInner() {
 export default function ResetPasswordPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="w-8 h-8 border-2 border-line/30 border-t-transparent rounded-full animate-spin" />
       </div>
     }>

--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -5,7 +5,7 @@ import Header from '@/components/layout/Header'
 
 export default function ComingSoonPage() {
   return (
-    <div className="min-h-screen bg-primary-dark">
+    <div className="min-h-screen bg-bg-base">
       <Header />
       <div className="flex items-center justify-center min-h-[calc(100vh-80px)] px-4">
         <div className="text-center max-w-2xl">

--- a/app/company-onboarding/page.tsx
+++ b/app/company-onboarding/page.tsx
@@ -46,7 +46,7 @@ export default function CompanyOnboardingPage() {
   })
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <SubtleCircuitBackground />
       <PublicHeader />
       

--- a/app/compliance-tracker/page.tsx
+++ b/app/compliance-tracker/page.tsx
@@ -47,7 +47,7 @@ export default function ComplianceTrackerPage() {
   })
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <SubtleCircuitBackground />
       <PublicHeader />
       

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -80,7 +80,7 @@ function ContactPageContent() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark flex flex-col relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base flex flex-col relative overflow-hidden">
       {/* Navigation Bar */}
       <PublicHeader />
       
@@ -357,7 +357,7 @@ export const dynamic = 'force-dynamic'
 export default function ContactPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="text-fg-primary">Loading...</div>
       </div>
     }>

--- a/app/customers/page.tsx
+++ b/app/customers/page.tsx
@@ -17,7 +17,7 @@ const clients = [
 
 export default function CustomersPage() {
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <SubtleCircuitBackground />
       <PublicHeader />
       

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -4,7 +4,7 @@ import CircuitBackground from '@/components/ui/CircuitBackground'
 
 export default function DashboardPage() {
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <CircuitBackground />
       <div className="relative z-10 container mx-auto px-4 py-8">
         <h1 className="text-4xl font-light text-fg-primary mb-4">Dashboard</h1>

--- a/app/data-room/components/DataRoomBootShell.tsx
+++ b/app/data-room/components/DataRoomBootShell.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import Header from '@/components/layout/Header'
 import TrackerCategoryAccordionView from './tracker/TrackerCategoryAccordionView'
 import { getCountryConfig } from '@/lib/config/countries'
+import { useRotatingLoadingMessage } from '@/hooks/useRotatingLoadingMessage'
+import { DATA_ROOM_LOADING_MESSAGES } from '@/lib/ui/loading-messages'
 
 /**
  * Pre-data layout shell for the entire data-room page.
@@ -48,11 +50,27 @@ export default function DataRoomBootShell({
       ? config.compliance.defaultCategories
       : ['Income Tax', 'GST', 'Payroll', 'RoC', 'Renewals', 'Others']
 
+  // Rotating loading message — gives users something to read while the
+  // data-room boots. Cycles through DATA_ROOM_LOADING_MESSAGES every ~2s.
+  const loadingMessage = useRotatingLoadingMessage({
+    active: true,
+    messages: DATA_ROOM_LOADING_MESSAGES,
+  })
+
   return (
     <div className="min-h-screen bg-bg-base relative">
       <Header />
 
       <div className="relative z-10 container mx-auto px-3 sm:px-4 py-4 sm:py-8">
+        {/* Loading banner — small status pill above the company selector
+            so users see something is happening while the data-room boots. */}
+        <div className="mb-4 sm:mb-6 flex items-center gap-2 text-xs text-fg-muted">
+          <span className="inline-block w-2 h-2 rounded-full bg-accent-brand animate-pulse" aria-hidden="true" />
+          <span key={loadingMessage} className="animate-fadeIn">
+            {loadingMessage}
+          </span>
+        </div>
+
         {/* Company Selector slot — matches post-boot dimensions */}
         <div className="mb-4 sm:mb-6">
           <h2 className="text-fg-muted text-xs font-medium uppercase tracking-wider mb-2 sm:mb-3">My companies</h2>

--- a/app/data-room/page.tsx
+++ b/app/data-room/page.tsx
@@ -3944,7 +3944,7 @@ function DataRoomPageInner() {
   // 2. Initialization Error
   if (initError) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
         <div className="text-center max-w-md">
           <div className="text-red-500 text-4xl mb-4">⚠️</div>
           <h2 className="text-fg-primary text-xl font-medium mb-2">Failed to initialize</h2>
@@ -3964,7 +3964,7 @@ function DataRoomPageInner() {
   const isNoCompany = companies.length === 0;
   if ((isNoCompany || (currentCompany && !hasAccess && !accessLoading)) && !isDataRoomInitLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="text-center max-w-md px-4">
           <div className="relative mb-6">
             <div className="w-12 h-12 border-4 border-white/30 border-t-transparent rounded-full animate-spin mx-auto" />
@@ -3986,7 +3986,7 @@ function DataRoomPageInner() {
   // If owner without access, show redirect message (redirect happens via useEffect)
   if (currentCompany && isOwner && !hasAccess && !accessLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="text-center max-w-md px-4">
           <div className="relative mb-6">
             <div className="w-12 h-12 border-4 border-white/30 border-t-transparent rounded-full animate-spin mx-auto" />

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -46,7 +46,7 @@ function ForgotPasswordPageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark flex flex-col relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base flex flex-col relative overflow-hidden">
       {/* Top Navigation Bar */}
       <nav className="relative z-10 w-full px-4 sm:px-6 py-4 sm:py-6">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
@@ -142,8 +142,8 @@ function ForgotPasswordPageInner() {
 export default function ForgotPasswordPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
-        <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
       </div>
     }>
       <ForgotPasswordPageInner />

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -419,7 +419,7 @@ export default function HomePage() {
 
 
   return (
-    <div className="min-h-screen bg-primary-dark flex flex-col relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base flex flex-col relative overflow-hidden">
       <style jsx global>{`
         @keyframes fadeInUp {
           from {

--- a/app/invite/accept/InviteAcceptClient.tsx
+++ b/app/invite/accept/InviteAcceptClient.tsx
@@ -148,21 +148,21 @@ export default function InviteAcceptClient(props: { token?: string }) {
   }, [user, loading, status])
 
   return (
-    <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+    <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
       <div className="w-full max-w-md bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-8">
         <h1 className="text-2xl font-light text-fg-primary mb-2">Accept invitation</h1>
         <p className="text-sm text-fg-muted mb-6">{message}</p>
 
         {status === 'loading' && (
           <div className="flex items-center gap-3 text-fg-secondary">
-            <div className="w-4 h-4 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+            <div className="w-4 h-4 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
             <span>Loading invitation…</span>
           </div>
         )}
 
         {status === 'checking' && (
           <div className="flex items-center gap-3 text-fg-secondary">
-            <div className="w-4 h-4 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+            <div className="w-4 h-4 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
             <span>Processing…</span>
           </div>
         )}
@@ -185,7 +185,7 @@ export default function InviteAcceptClient(props: { token?: string }) {
                 type="text"
                 value={fullName}
                 onChange={(e) => setFullName(e.target.value)}
-                className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 text-fg-primary focus:border-primary-orange focus:outline-none"
+                className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 text-fg-primary focus:border-accent-brand focus:outline-none"
                 placeholder="John Doe"
               />
             </div>
@@ -197,7 +197,7 @@ export default function InviteAcceptClient(props: { token?: string }) {
                   type={showPassword ? 'text' : 'password'}
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 pr-10 text-fg-primary focus:border-primary-orange focus:outline-none"
+                  className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 pr-10 text-fg-primary focus:border-accent-brand focus:outline-none"
                   placeholder="At least 6 characters"
                   required
                 />
@@ -226,7 +226,7 @@ export default function InviteAcceptClient(props: { token?: string }) {
                 type={showPassword ? 'text' : 'password'}
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
-                className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 text-fg-primary focus:border-primary-orange focus:outline-none"
+                className="w-full bg-bg-card border border-line/15 rounded-lg px-4 py-2.5 text-fg-primary focus:border-accent-brand focus:outline-none"
                 placeholder="Confirm your password"
                 required
               />
@@ -241,7 +241,7 @@ export default function InviteAcceptClient(props: { token?: string }) {
             <button
               type="submit"
               disabled={isSubmitting}
-              className="w-full bg-primary-orange text-white px-4 py-2.5 rounded-lg hover:bg-primary-orange/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              className="w-full bg-accent-brand text-white px-4 py-2.5 rounded-lg hover:bg-accent-brand/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isSubmitting ? 'Creating account…' : 'Create account & accept invitation'}
             </button>
@@ -255,7 +255,7 @@ export default function InviteAcceptClient(props: { token?: string }) {
             </p>
             <Link
               href={`/login?returnTo=${encodeURIComponent(`/invite/accept?token=${props.token}`)}`}
-              className="block w-full bg-primary-orange text-white px-4 py-2.5 rounded-lg hover:bg-primary-orange/90 transition-colors text-center"
+              className="block w-full bg-accent-brand text-white px-4 py-2.5 rounded-lg hover:bg-accent-brand/90 transition-colors text-center"
             >
               Sign in to accept invitation
             </Link>
@@ -273,7 +273,7 @@ export default function InviteAcceptClient(props: { token?: string }) {
             <div className="text-sm text-red-400">{message}</div>
             <button
               onClick={() => router.push('/team')}
-              className="w-full bg-primary-orange text-white px-4 py-2.5 rounded-lg hover:bg-primary-orange/90 transition-colors"
+              className="w-full bg-accent-brand text-white px-4 py-2.5 rounded-lg hover:bg-accent-brand/90 transition-colors"
             >
               Go to Team
             </button>

--- a/app/invite/accept/page.tsx
+++ b/app/invite/accept/page.tsx
@@ -12,7 +12,7 @@ export default async function InviteAcceptPage({
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+        <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
           <div className="w-full max-w-md bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-8">
             <div className="text-sm text-fg-secondary">Loading…</div>
           </div>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -205,7 +205,7 @@ function LoginPageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark flex flex-col relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base flex flex-col relative overflow-hidden">
       {/* Top Navigation Bar */}
       <nav className="relative z-10 w-full px-4 sm:px-6 py-4 sm:py-6">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
@@ -578,8 +578,8 @@ function LoginPageInner() {
 export default function LoginPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
-        <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
       </div>
     }>
       <LoginPageInner />

--- a/app/manage-company/page.tsx
+++ b/app/manage-company/page.tsx
@@ -333,7 +333,7 @@ function ManageCompanyPageInner() {
 
   if (authLoading || isLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="text-fg-primary text-lg text-center font-light">
           <div className="w-8 h-8 border-2 border-line/30 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
           Loading Company Data...
@@ -343,7 +343,7 @@ function ManageCompanyPageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <CircuitBackground />
       <Header />
 
@@ -958,7 +958,7 @@ function ManageCompanyPageInner() {
 export default function ManageCompanyPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="text-fg-primary text-lg text-center font-light">
           <div className="w-8 h-8 border-2 border-line/30 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
           Loading...

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -181,7 +181,7 @@ export default function OnboardingPage() {
   // Show loading state while checking auth or subscription
   if (loading || subLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="w-8 h-8 border-2 border-line/30 border-t-transparent rounded-full animate-spin" />
       </div>
     )
@@ -198,7 +198,7 @@ export default function OnboardingPage() {
 
   if (!hasActiveAccess && currentCompanyCount === 0) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
         <div className="bg-bg-card border border-line/10 rounded-xl p-8 max-w-md text-center">
           <div className="w-16 h-16 bg-bg-elevated/50 border border-line/15 rounded-full flex items-center justify-center mx-auto mb-6">
             <svg className="w-8 h-8 text-fg-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -223,7 +223,7 @@ export default function OnboardingPage() {
   // Check if user has reached company limit (only check if they have active access)
   if (hasActiveAccess && !canCreateCompany) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
         <div className="bg-bg-card border border-line/10 rounded-xl p-8 max-w-md text-center">
           <div className="w-16 h-16 bg-yellow-500/10 border border-yellow-500/20 rounded-full flex items-center justify-center mx-auto mb-6">
             <svg className="w-8 h-8 text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1239,7 +1239,7 @@ export default function OnboardingPage() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       {/* Content */}
       <div className="relative z-10 container mx-auto px-3 sm:px-4 py-4 sm:py-8 max-w-4xl">
         {/* Header */}

--- a/app/owner-subscription-expired/page.tsx
+++ b/app/owner-subscription-expired/page.tsx
@@ -64,14 +64,14 @@ function OwnerExpiredPageInner() {
 
   if (authLoading || isLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
-        <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <SubtleCircuitBackground />
       
       <div className="relative z-10 flex items-center justify-center min-h-screen px-4">
@@ -102,8 +102,8 @@ function OwnerExpiredPageInner() {
             {/* Info Box */}
             <div className="bg-bg-card border border-line/15 rounded-xl p-4 mb-6">
               <div className="flex items-center gap-3 text-left">
-                <div className="w-10 h-10 bg-primary-orange/20 rounded-full flex items-center justify-center flex-shrink-0">
-                  <svg className="w-5 h-5 text-primary-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <div className="w-10 h-10 bg-accent-brand/20 rounded-full flex items-center justify-center flex-shrink-0">
+                  <svg className="w-5 h-5 text-accent-brand" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
                   </svg>
                 </div>
@@ -139,7 +139,7 @@ function OwnerExpiredPageInner() {
           <div className="text-center mt-8">
             <p className="text-fg-muted/60 text-sm">
               Need help? Contact{' '}
-              <a href="mailto:info@finacra.com" className="text-primary-orange hover:underline">
+              <a href="mailto:info@finacra.com" className="text-accent-brand hover:underline">
                 info@finacra.com
               </a>
             </p>
@@ -153,8 +153,8 @@ function OwnerExpiredPageInner() {
 export default function OwnerSubscriptionExpiredPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
-        <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
       </div>
     }>
       <OwnerExpiredPageInner />

--- a/app/pricing/page.tsx
+++ b/app/pricing/page.tsx
@@ -7,7 +7,7 @@ import PublicHeader from '@/components/layout/PublicHeader'
 
 function PricingContent() {
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <SubtleCircuitBackground />
       
       <div className="relative z-10">
@@ -21,7 +21,7 @@ function PricingContent() {
 export default function PricingPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+      <div className="min-h-screen bg-bg-base relative overflow-hidden">
         <SubtleCircuitBackground />
         <div className="relative z-10 flex items-center justify-center min-h-screen">
           <div className="text-fg-primary">Loading...</div>

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -13,7 +13,7 @@ export default function PrivacyPolicyPage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-primary-dark text-fg-secondary">
+    <div className="min-h-screen bg-bg-base text-fg-secondary">
       <PublicHeader />
       <div className="py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -360,7 +360,7 @@ function SubscribePageInner() {
 
   if (authLoading || subLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="w-8 h-8 border-2 border-line/30 border-t-transparent rounded-full animate-spin" />
       </div>
     )
@@ -375,7 +375,7 @@ function SubscribePageInner() {
   // Show trial upgrade prompt ONLY if user explicitly wants to upgrade during trial
   if (isTrial && trialDaysRemaining > 0 && showUpgrade) {
     return (
-      <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+      <div className="min-h-screen bg-bg-base relative overflow-hidden">
         <SubtleCircuitBackground />
         
         {/* Back Button and Logout */}
@@ -609,7 +609,7 @@ function SubscribePageInner() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <SubtleCircuitBackground />
       
       {/* Back Button and Logout */}
@@ -833,8 +833,8 @@ function SubscribePageInner() {
 export default function SubscribePage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
-        <div className="w-8 h-8 border-2 border-primary-orange border-t-transparent rounded-full animate-spin" />
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-accent-brand border-t-transparent rounded-full animate-spin" />
       </div>
     }>
       <SubscribePageInner />

--- a/app/subscription-required/page.tsx
+++ b/app/subscription-required/page.tsx
@@ -64,14 +64,14 @@ function SubscriptionRequiredInner() {
 
   if (authLoading || isLoading) {
     return (
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="w-8 h-8 border-2 border-line/30 border-t-transparent rounded-full animate-spin" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       <SubtleCircuitBackground />
       
       <div className="relative z-10 flex items-center justify-center min-h-screen px-4 py-8">
@@ -244,7 +244,7 @@ function SubscriptionRequiredInner() {
 export default function SubscriptionRequiredPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="w-8 h-8 border-2 border-line/30 border-t-transparent rounded-full animate-spin" />
       </div>
     }>

--- a/app/team/page.tsx
+++ b/app/team/page.tsx
@@ -327,7 +327,7 @@ export default function TeamPage() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark relative overflow-hidden">
+    <div className="min-h-screen bg-bg-base relative overflow-hidden">
       {/* Subtle Circuit Board Background */}
       <SubtleCircuitBackground />
 
@@ -413,7 +413,7 @@ export default function TeamPage() {
                       max="365"
                       value={extendDays}
                       onChange={(e) => setExtendDays(parseInt(e.target.value) || 15)}
-                      className="w-16 px-2 py-1.5 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm text-center focus:outline-none focus:border-primary-orange"
+                      className="w-16 px-2 py-1.5 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm text-center focus:outline-none focus:border-accent-brand"
                     />
                     <button
                       onClick={handleExtendTrial}
@@ -462,13 +462,13 @@ export default function TeamPage() {
                     max="365"
                     value={extendDays}
                     onChange={(e) => setExtendDays(parseInt(e.target.value) || 15)}
-                    className="w-16 px-2 py-1.5 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm text-center focus:outline-none focus:border-primary-orange"
+                    className="w-16 px-2 py-1.5 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm text-center focus:outline-none focus:border-accent-brand"
                     placeholder="Days"
                   />
                   <button
                     onClick={handleGrantTrial}
                     disabled={isGrantingTrial}
-                    className="px-4 py-2 bg-primary-orange text-white rounded-lg text-sm font-medium hover:bg-primary-orange/90 transition-colors disabled:opacity-50"
+                    className="px-4 py-2 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-accent-brand/90 transition-colors disabled:opacity-50"
                   >
                     {isGrantingTrial ? 'Granting...' : 'Grant Trial'}
                   </button>
@@ -481,7 +481,7 @@ export default function TeamPage() {
           {(canManage || isSuperadmin) && (
             <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl shadow-2xl p-4 sm:p-8">
               <div className="flex items-center gap-2 sm:gap-3 mb-2">
-                <div className="w-7 h-7 sm:w-8 sm:h-8 bg-primary-orange rounded-lg flex items-center justify-center flex-shrink-0">
+                <div className="w-7 h-7 sm:w-8 sm:h-8 bg-accent-brand rounded-lg flex items-center justify-center flex-shrink-0">
                   <svg
                     width="14"
                     height="14"
@@ -515,7 +515,7 @@ export default function TeamPage() {
                     type="email"
                     value={inviteEmail}
                     onChange={(e) => setInviteEmail(e.target.value)}
-                    className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     placeholder="colleague@example.com"
                   />
                 </div>
@@ -529,7 +529,7 @@ export default function TeamPage() {
                     type="text"
                     value={inviteName}
                     onChange={(e) => setInviteName(e.target.value)}
-                    className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                     placeholder="John Doe"
                   />
                 </div>
@@ -539,7 +539,7 @@ export default function TeamPage() {
                   <label className="block text-xs sm:text-sm font-medium text-fg-secondary mb-2">Role</label>
                   <button
                     onClick={() => setIsRoleDropdownOpen(!isRoleDropdownOpen)}
-                    className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base text-left flex items-center justify-between focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+                    className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base text-left flex items-center justify-between focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
                   >
                     <span className="truncate">{roles.find((r) => r.value === inviteRole)?.label}</span>
                     <svg
@@ -573,7 +573,7 @@ export default function TeamPage() {
                             }}
                             className={`w-full px-3 sm:px-4 py-2 sm:py-3 text-left hover:bg-bg-elevated transition-colors flex items-center justify-between text-sm sm:text-base ${
                               inviteRole === role.value
-                                ? 'bg-primary-orange/20 text-white'
+                                ? 'bg-accent-brand/20 text-white'
                                 : 'text-fg-secondary'
                             }`}
                           >
@@ -582,7 +582,7 @@ export default function TeamPage() {
                               <svg
                                 width="14"
                                 height="14"
-                                className="sm:w-4 sm:h-4 flex-shrink-0 ml-2 text-primary-orange"
+                                className="sm:w-4 sm:h-4 flex-shrink-0 ml-2 text-accent-brand"
                                 viewBox="0 0 24 24"
                                 fill="none"
                                 stroke="currentColor"
@@ -604,7 +604,7 @@ export default function TeamPage() {
                 <button
                   onClick={handleInvite}
                   disabled={isInviting || !inviteEmail}
-                  className="w-full bg-primary-orange text-white px-4 sm:px-6 py-2.5 sm:py-3 rounded-lg hover:bg-primary-orange/90 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base disabled:opacity-50 disabled:cursor-not-allowed"
+                  className="w-full bg-accent-brand text-white px-4 sm:px-6 py-2.5 sm:py-3 rounded-lg hover:bg-accent-brand/90 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                   {isInviting ? (
                     <>
@@ -638,7 +638,7 @@ export default function TeamPage() {
           {/* Team Members */}
           <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl shadow-2xl p-4 sm:p-8">
             <div className="flex items-center gap-2 sm:gap-3 mb-2">
-              <div className="w-7 h-7 sm:w-8 sm:h-8 bg-primary-orange rounded-lg flex items-center justify-center flex-shrink-0">
+              <div className="w-7 h-7 sm:w-8 sm:h-8 bg-accent-brand rounded-lg flex items-center justify-center flex-shrink-0">
                 <svg
                   width="14"
                   height="14"
@@ -666,7 +666,7 @@ export default function TeamPage() {
 
             {isLoading ? (
               <div className="py-8 sm:py-12 flex flex-col items-center justify-center">
-                <div className="w-8 h-8 sm:w-10 sm:h-10 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mb-3 sm:mb-4"></div>
+                <div className="w-8 h-8 sm:w-10 sm:h-10 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mb-3 sm:mb-4"></div>
                 <p className="text-fg-muted text-sm sm:text-base">Loading team members...</p>
               </div>
             ) : teamMembers.length === 0 ? (
@@ -726,7 +726,7 @@ export default function TeamPage() {
                         <select
                           value={member.role}
                           onChange={(e) => handleRoleChange(member.id, e.target.value as 'viewer' | 'editor' | 'admin')}
-                          className="px-2 sm:px-3 py-1 bg-bg-elevated text-fg-secondary rounded-full text-[10px] sm:text-xs font-medium border border-line/15 hover:border-primary-orange transition-colors cursor-pointer"
+                          className="px-2 sm:px-3 py-1 bg-bg-elevated text-fg-secondary rounded-full text-[10px] sm:text-xs font-medium border border-line/15 hover:border-accent-brand transition-colors cursor-pointer"
                         >
                           <option value="viewer">VIEWER</option>
                           <option value="editor">EDITOR</option>

--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -13,7 +13,7 @@ export default function TermsOfServicePage() {
   }, [])
 
   return (
-    <div className="min-h-screen bg-primary-dark text-fg-secondary">
+    <div className="min-h-screen bg-bg-base text-fg-secondary">
       <PublicHeader />
       <div className="py-12 px-4 sm:px-6 lg:px-8">
       <div className="max-w-4xl mx-auto">
@@ -97,8 +97,8 @@ export default function TermsOfServicePage() {
             <div className="grid md:grid-cols-2 gap-4">
               <div className="bg-bg-card/50 p-5 rounded-xl border border-line/10">
                 <div className="flex items-center gap-3 mb-2">
-                  <div className="w-8 h-8 bg-primary-orange/20 rounded-lg flex items-center justify-center">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-primary-orange">
+                  <div className="w-8 h-8 bg-accent-brand/20 rounded-lg flex items-center justify-center">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent-brand">
                       <path d="M9 12l2 2 4-4" />
                       <path d="M21 12c0 4.97-4.03 9-9 9s-9-4.03-9-9 4.03-9 9-9 9 4.03 9 9z" />
                     </svg>
@@ -109,8 +109,8 @@ export default function TermsOfServicePage() {
               </div>
               <div className="bg-bg-card/50 p-5 rounded-xl border border-line/10">
                 <div className="flex items-center gap-3 mb-2">
-                  <div className="w-8 h-8 bg-primary-orange/20 rounded-lg flex items-center justify-center">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-primary-orange">
+                  <div className="w-8 h-8 bg-accent-brand/20 rounded-lg flex items-center justify-center">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-accent-brand">
                       <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
                       <polyline points="14 2 14 8 20 8" />
                     </svg>

--- a/app/verify-email/page.tsx
+++ b/app/verify-email/page.tsx
@@ -105,7 +105,7 @@ function VerifyEmailContent() {
   }
 
   return (
-    <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+    <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
       <div className="max-w-md w-full">
         <div className="bg-bg-card border border-line/10 rounded-xl p-8">
           {success ? (
@@ -204,7 +204,7 @@ function VerifyEmailContent() {
 export default function VerifyEmailPage() {
   return (
     <Suspense fallback={
-      <div className="min-h-screen bg-primary-dark flex items-center justify-center px-4">
+      <div className="min-h-screen bg-bg-base flex items-center justify-center px-4">
         <div className="max-w-md w-full">
           <div className="bg-bg-card border border-line/10 rounded-xl p-8">
             <div className="flex items-center justify-center mb-6">

--- a/components/admin/AllUsersManagement.tsx
+++ b/components/admin/AllUsersManagement.tsx
@@ -139,7 +139,7 @@ export default function AllUsersManagement({ companies }: AllUsersManagementProp
   if (isLoading) {
     return (
       <div className="bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-12 flex flex-col items-center justify-center">
-        <div className="w-10 h-10 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mb-4"></div>
+        <div className="w-10 h-10 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mb-4"></div>
         <p className="text-fg-muted">Loading all users...</p>
       </div>
     )
@@ -187,7 +187,7 @@ export default function AllUsersManagement({ companies }: AllUsersManagementProp
               placeholder="Search by email, ID or company..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 pr-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-primary-orange w-72"
+              className="pl-10 pr-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-accent-brand w-72"
             />
           </div>
 
@@ -195,7 +195,7 @@ export default function AllUsersManagement({ companies }: AllUsersManagementProp
           <select
             value={filterType}
             onChange={(e) => setFilterType(e.target.value as any)}
-            className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-primary-orange"
+            className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-accent-brand"
           >
             <option value="all">All Users</option>
             <option value="owners">Company Owners</option>
@@ -223,10 +223,10 @@ export default function AllUsersManagement({ companies }: AllUsersManagementProp
           <div className="text-xs text-fg-muted">Total Users</div>
           <div className="text-[10px] text-fg-muted mt-1">All registered users</div>
         </div>
-        <div className="bg-primary-orange/10 border border-primary-orange/30 rounded-xl p-4">
-          <div className="text-2xl font-bold text-primary-orange">{totalOwners}</div>
-          <div className="text-xs text-primary-orange/80">Company Owners</div>
-          <div className="text-[10px] text-primary-orange/60 mt-1">Created companies</div>
+        <div className="bg-accent-brand/10 border border-accent-brand/30 rounded-xl p-4">
+          <div className="text-2xl font-bold text-accent-brand">{totalOwners}</div>
+          <div className="text-xs text-accent-brand/80">Company Owners</div>
+          <div className="text-[10px] text-accent-brand/60 mt-1">Created companies</div>
         </div>
         <div className="bg-blue-500/10 border border-blue-500/30 rounded-xl p-4">
           <div className="text-2xl font-bold text-blue-400">{totalTeamOnly}</div>
@@ -314,7 +314,7 @@ export default function AllUsersManagement({ companies }: AllUsersManagementProp
                           <div className="text-fg-muted text-xs flex items-center gap-2">
                             {user.companies_owned.length > 0 && (
                               <span className="flex items-center gap-1">
-                                <span className="w-2 h-2 bg-primary-orange rounded-full"></span>
+                                <span className="w-2 h-2 bg-accent-brand rounded-full"></span>
                                 {user.companies_owned.length} owned
                               </span>
                             )}
@@ -334,7 +334,7 @@ export default function AllUsersManagement({ companies }: AllUsersManagementProp
                       <div className="flex items-center gap-4">
                         {/* User Type Badge */}
                         {user.companies_owned.length > 0 ? (
-                          <span className="px-2 py-1 rounded text-xs font-medium bg-primary-orange/20 text-primary-orange border border-primary-orange/30">
+                          <span className="px-2 py-1 rounded text-xs font-medium bg-accent-brand/20 text-accent-brand border border-accent-brand/30">
                             Owner
                           </span>
                         ) : user.team_memberships.length > 0 ? (
@@ -400,8 +400,8 @@ export default function AllUsersManagement({ companies }: AllUsersManagementProp
                                     key={company.id} 
                                     className="flex items-center gap-2 p-2 bg-bg-elevated/30 rounded-lg overflow-hidden"
                                   >
-                                    <div className="w-6 h-6 bg-primary-orange/20 rounded flex-shrink-0 flex items-center justify-center">
-                                      <svg className="w-3 h-3 text-primary-orange" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <div className="w-6 h-6 bg-accent-brand/20 rounded flex-shrink-0 flex items-center justify-center">
+                                      <svg className="w-3 h-3 text-accent-brand" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4" />
                                       </svg>
                                     </div>

--- a/components/admin/TransactionHistory.tsx
+++ b/components/admin/TransactionHistory.tsx
@@ -120,7 +120,7 @@ export default function TransactionHistory() {
         </div>
         <div className="bg-bg-card border border-line/10 rounded-xl p-4">
           <div className="text-sm text-fg-muted mb-1">Total Revenue</div>
-          <div className="text-2xl font-light text-primary-orange">{formatCurrency(stats.totalRevenue)}</div>
+          <div className="text-2xl font-light text-accent-brand">{formatCurrency(stats.totalRevenue)}</div>
         </div>
       </div>
 
@@ -132,7 +132,7 @@ export default function TransactionHistory() {
             <select
               value={filter}
               onChange={(e) => setFilter(e.target.value as any)}
-              className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+              className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
             >
               <option value="all">All Status</option>
               <option value="completed">Completed</option>
@@ -146,7 +146,7 @@ export default function TransactionHistory() {
             <select
               value={sortBy}
               onChange={(e) => setSortBy(e.target.value as any)}
-              className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+              className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
             >
               <option value="date">Date</option>
               <option value="amount">Amount</option>
@@ -166,7 +166,7 @@ export default function TransactionHistory() {
               placeholder="Search by Order ID, Payment ID, Email, Company..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-primary-orange focus:ring-1 focus:ring-primary-orange transition-colors"
+              className="w-full px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-accent-brand focus:ring-1 focus:ring-accent-brand transition-colors"
             />
           </div>
         </div>
@@ -179,7 +179,7 @@ export default function TransactionHistory() {
         </div>
         {isLoading ? (
           <div className="p-12 flex flex-col items-center justify-center">
-            <div className="w-10 h-10 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mb-4"></div>
+            <div className="w-10 h-10 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mb-4"></div>
             <p className="text-fg-muted">Loading transactions...</p>
           </div>
         ) : filteredPayments.length === 0 ? (

--- a/components/admin/UsersManagement.tsx
+++ b/components/admin/UsersManagement.tsx
@@ -310,7 +310,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
   if (isLoading) {
     return (
       <div className="bg-bg-card border border-line/10 rounded-2xl shadow-2xl p-12 flex flex-col items-center justify-center">
-        <div className="w-10 h-10 border-4 border-primary-orange border-t-transparent rounded-full animate-spin mb-4"></div>
+        <div className="w-10 h-10 border-4 border-accent-brand border-t-transparent rounded-full animate-spin mb-4"></div>
         <p className="text-fg-muted">Loading users...</p>
       </div>
     )
@@ -356,7 +356,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
               placeholder="Search by email, ID or company..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-10 pr-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-primary-orange w-72"
+              className="pl-10 pr-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-accent-brand w-72"
             />
           </div>
 
@@ -364,7 +364,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
           <select
             value={filterStatus}
             onChange={(e) => setFilterStatus(e.target.value as any)}
-            className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-primary-orange"
+            className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-accent-brand"
           >
             <option value="all">All Company Owners</option>
             <option value="active">Paid Subscribers</option>
@@ -421,13 +421,13 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
       </div>
 
       {/* Info Box */}
-      <div className="bg-primary-orange/10 border border-primary-orange/30 rounded-xl p-4 flex items-start gap-3">
-        <svg className="w-5 h-5 text-primary-orange flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <div className="bg-accent-brand/10 border border-accent-brand/30 rounded-xl p-4 flex items-start gap-3">
+        <svg className="w-5 h-5 text-accent-brand flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
         </svg>
         <div className="text-sm">
-          <p className="text-primary-orange font-medium">Understanding Trial vs Paid Subscriptions</p>
-          <div className="text-primary-orange/80 mt-1 space-y-1">
+          <p className="text-accent-brand font-medium">Understanding Trial vs Paid Subscriptions</p>
+          <div className="text-accent-brand/80 mt-1 space-y-1">
             <p>• <strong>Active Trial:</strong> Free trial period (e.g., 15 days). User has access but hasn't paid yet.</p>
             <p>• <strong>Paid Subscriber:</strong> User has purchased a subscription plan (Starter/Professional/Enterprise).</p>
             <p>• <strong>Expired:</strong> Trial or subscription has ended. User and their team members lose access.</p>
@@ -493,8 +493,8 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                         </svg>
                         
                         {/* User Info */}
-                        <div className="w-10 h-10 bg-primary-orange/20 rounded-full flex items-center justify-center">
-                          <span className="text-primary-orange text-sm font-bold">
+                        <div className="w-10 h-10 bg-accent-brand/20 rounded-full flex items-center justify-center">
+                          <span className="text-accent-brand text-sm font-bold">
                             {user.email.includes('@') ? user.email.charAt(0).toUpperCase() : 'U'}
                           </span>
                         </div>
@@ -531,7 +531,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                 max="365"
                                 value={extendDays[user.id] || 15}
                                 onChange={(e) => setExtendDays(prev => ({ ...prev, [user.id]: parseInt(e.target.value) || 15 }))}
-                                className="w-14 px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-sm text-center focus:outline-none focus:border-primary-orange"
+                                className="w-14 px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-sm text-center focus:outline-none focus:border-accent-brand"
                               />
                               <button
                                 onClick={() => handleExtendTrial(user.id, user.subscription!.id)}
@@ -558,12 +558,12 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                 max="365"
                                 value={extendDays[user.id] || 15}
                                 onChange={(e) => setExtendDays(prev => ({ ...prev, [user.id]: parseInt(e.target.value) || 15 }))}
-                                className="w-14 px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-sm text-center focus:outline-none focus:border-primary-orange"
+                                className="w-14 px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-sm text-center focus:outline-none focus:border-accent-brand"
                               />
                               <button
                                 onClick={() => handleGrantTrial(user.id, 'enterprise')}
                                 disabled={isGranting[user.id]}
-                                className="px-3 py-1 bg-primary-orange text-white rounded text-xs font-medium hover:bg-primary-orange/90 transition-colors disabled:opacity-50"
+                                className="px-3 py-1 bg-accent-brand text-white rounded text-xs font-medium hover:bg-accent-brand/90 transition-colors disabled:opacity-50"
                                 title="Grant Enterprise trial (covers all companies)"
                               >
                                 {isGranting[user.id] ? '...' : 'Grant Trial'}
@@ -654,7 +654,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                                   }
                                                 }}
                                                 disabled={isChangingTier[company.id]}
-                                                className="px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-xs focus:outline-none focus:border-primary-orange disabled:opacity-50"
+                                                className="px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-xs focus:outline-none focus:border-accent-brand disabled:opacity-50"
                                               >
                                                 <option value="starter">Starter</option>
                                                 <option value="professional">Professional</option>
@@ -667,7 +667,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                                 max="365"
                                                 value={companyExtendDays[company.id] || 15}
                                                 onChange={(e) => setCompanyExtendDays(prev => ({ ...prev, [company.id]: parseInt(e.target.value) || 15 }))}
-                                                className="w-12 px-1 py-0.5 bg-bg-card border border-line/15 rounded text-fg-primary text-xs text-center focus:outline-none focus:border-primary-orange"
+                                                className="w-12 px-1 py-0.5 bg-bg-card border border-line/15 rounded text-fg-primary text-xs text-center focus:outline-none focus:border-accent-brand"
                                               />
                                               <button
                                                 onClick={() => handleExtendCompanyTrial(company.id, company.subscription!.id, company.name)}
@@ -702,7 +702,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                                   <select
                                                     value={companyTier[company.id] || company.subscription.tier}
                                                     onChange={(e) => setCompanyTier(prev => ({ ...prev, [company.id]: e.target.value as 'starter' | 'professional' }))}
-                                                    className="px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-xs focus:outline-none focus:border-primary-orange"
+                                                    className="px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-xs focus:outline-none focus:border-accent-brand"
                                                   >
                                                     <option value="starter">Starter</option>
                                                     <option value="professional">Professional</option>
@@ -713,12 +713,12 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                                     max="365"
                                                     value={companyExtendDays[company.id] || 15}
                                                     onChange={(e) => setCompanyExtendDays(prev => ({ ...prev, [company.id]: parseInt(e.target.value) || 15 }))}
-                                                    className="w-12 px-1 py-0.5 bg-bg-card border border-line/15 rounded text-fg-primary text-xs text-center focus:outline-none focus:border-primary-orange"
+                                                    className="w-12 px-1 py-0.5 bg-bg-card border border-line/15 rounded text-fg-primary text-xs text-center focus:outline-none focus:border-accent-brand"
                                                   />
                                                   <button
                                                     onClick={() => handleGrantCompanyTrial(company.id, user.id, companyTier[company.id] || (company.subscription?.tier as 'starter' | 'professional') || 'starter', company.name)}
                                                     disabled={isGrantingCompany[company.id]}
-                                                    className="px-2 py-1 bg-primary-orange text-white rounded text-xs font-medium hover:bg-primary-orange/90 transition-colors disabled:opacity-50"
+                                                    className="px-2 py-1 bg-accent-brand text-white rounded text-xs font-medium hover:bg-accent-brand/90 transition-colors disabled:opacity-50"
                                                   >
                                                     {isGrantingCompany[company.id] ? '...' : 'Grant Trial'}
                                                   </button>
@@ -742,7 +742,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                                 <select
                                                   value={companyTier[company.id] || 'starter'}
                                                   onChange={(e) => setCompanyTier(prev => ({ ...prev, [company.id]: e.target.value as 'starter' | 'professional' }))}
-                                                  className="px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-xs focus:outline-none focus:border-primary-orange"
+                                                  className="px-2 py-1 bg-bg-card border border-line/15 rounded text-fg-primary text-xs focus:outline-none focus:border-accent-brand"
                                                 >
                                                   <option value="starter">Starter</option>
                                                   <option value="professional">Professional</option>
@@ -753,14 +753,14 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                                   max="365"
                                                   value={companyExtendDays[company.id] || 15}
                                                   onChange={(e) => setCompanyExtendDays(prev => ({ ...prev, [company.id]: parseInt(e.target.value) || 15 }))}
-                                                  className="w-12 px-1 py-0.5 bg-bg-card border border-line/15 rounded text-fg-primary text-xs text-center focus:outline-none focus:border-primary-orange"
+                                                  className="w-12 px-1 py-0.5 bg-bg-card border border-line/15 rounded text-fg-primary text-xs text-center focus:outline-none focus:border-accent-brand"
                                                 />
                                                 <button
                                                   onClick={() => {
                                                     handleGrantCompanyTrial(company.id, user.id, companyTier[company.id] || 'starter', company.name)
                                                   }}
                                                   disabled={isGrantingCompany[company.id]}
-                                                  className="px-2 py-1 bg-primary-orange text-white rounded text-xs font-medium hover:bg-primary-orange/90 transition-colors disabled:opacity-50"
+                                                  className="px-2 py-1 bg-accent-brand text-white rounded text-xs font-medium hover:bg-accent-brand/90 transition-colors disabled:opacity-50"
                                                 >
                                                   {isGrantingCompany[company.id] ? '...' : 'Grant Trial'}
                                                 </button>
@@ -799,7 +799,7 @@ export default function UsersManagement({ companies }: UsersManagementProps) {
                                                   {member.email.includes('@') ? member.email : `User ${member.user_id.substring(0, 8)}...`}
                                                 </div>
                                                 {member.user_id === user.id && (
-                                                  <span className="text-xs text-primary-orange">Owner</span>
+                                                  <span className="text-xs text-accent-brand">Owner</span>
                                                 )}
                                               </div>
                                             </div>

--- a/components/features/BulkTemplateUpload.tsx
+++ b/components/features/BulkTemplateUpload.tsx
@@ -295,7 +295,7 @@ export default function BulkTemplateUpload({ onUpload, onClose }: BulkTemplateUp
               onDrop={handleDrop}
               className={`border-2 border-dashed rounded-xl p-10 text-center transition-colors cursor-pointer ${
                 dragOver
-                  ? 'border-primary-orange bg-primary-orange/10'
+                  ? 'border-accent-brand bg-accent-brand/10'
                   : 'border-line/30 hover:border-line/40'
               }`}
               onClick={() => fileInputRef.current?.click()}
@@ -442,7 +442,7 @@ export default function BulkTemplateUpload({ onUpload, onClose }: BulkTemplateUp
               disabled={!validation?.valid}
               className={`px-6 py-2 rounded-lg font-medium transition-colors ${
                 validation?.valid
-                  ? 'bg-primary-orange hover:bg-primary-orange/90 text-white'
+                  ? 'bg-accent-brand hover:bg-accent-brand/90 text-white'
                   : 'bg-bg-hover text-fg-muted cursor-not-allowed'
               }`}
             >
@@ -459,7 +459,7 @@ export default function BulkTemplateUpload({ onUpload, onClose }: BulkTemplateUp
     return (
       <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/80">
         <div className="bg-bg-card border border-line/15 rounded-xl p-8 text-center">
-          <div className="animate-spin w-12 h-12 border-4 border-primary-orange border-t-transparent rounded-full mx-auto mb-4"></div>
+          <div className="animate-spin w-12 h-12 border-4 border-accent-brand border-t-transparent rounded-full mx-auto mb-4"></div>
           <p className="text-fg-primary text-lg">Uploading templates...</p>
           <p className="text-fg-muted text-sm mt-2">This may take a moment</p>
         </div>
@@ -493,7 +493,7 @@ export default function BulkTemplateUpload({ onUpload, onClose }: BulkTemplateUp
           )}
           <button
             onClick={onClose}
-            className="px-6 py-2 bg-primary-orange hover:bg-primary-orange/90 text-white rounded-lg font-medium transition-colors"
+            className="px-6 py-2 bg-accent-brand hover:bg-accent-brand/90 text-white rounded-lg font-medium transition-colors"
           >
             Done
           </button>
@@ -535,7 +535,7 @@ export default function BulkTemplateUpload({ onUpload, onClose }: BulkTemplateUp
             </button>
             <button
               onClick={onClose}
-              className="px-4 py-2 bg-primary-orange hover:bg-primary-orange/90 text-white rounded-lg font-medium transition-colors"
+              className="px-4 py-2 bg-accent-brand hover:bg-accent-brand/90 text-white rounded-lg font-medium transition-colors"
             >
               Close
             </button>


### PR DESCRIPTION
## Summary

User smoke-tested live light mode and reported visibility issues. Diagnosis: the body bg correctly flipped to off-white (PR-3 worked), but every page-level wrapper had hard-coded `bg-primary-dark` covering it with `#0a0a0a` — text became invisible against the dark backdrop while cards stayed white.

**Plus** the data-room boot shell was silent — user wanted the rotating messages there too.

## Changes

### 1. Sweep `bg-primary-dark` → `bg-bg-base` (token)
**59 occurrences across 27 files.** Page wrappers (admin, vault, login, forgot-password, contact, customers, dashboard, manage-company, subscribe, owner-subscription-expired, subscription-required, team, onboarding error pages, etc.) now flip with the theme.

Also catches:
- `bg-primary-dark-card` → `bg-bg-card`
- `bg-primary-dark-gray` → `bg-bg-elevated`

### 2. Sweep `primary-orange` → `accent-brand` (token)
**289 occurrences across 14 files.** All variants:
- `text-primary-orange` → `text-accent-brand`
- `border-primary-orange` → `border-accent-brand`
- `bg-primary-orange` → `bg-accent-brand`
- `ring-primary-orange` → `ring-accent-brand`
- `focus:border-primary-orange` → `focus:border-accent-brand`
- `focus:ring-primary-orange` → `focus:ring-accent-brand`
- `primary-orange/<alpha>` → `accent-brand/<alpha>`

This was the legacy "orange" brand alias from before PR-13's indigo brand swap.

### 3. DataRoomBootShell rotating messages
The boot shell rendered skeletons silently — user asked for loading messages there too. Wired `DATA_ROOM_LOADING_MESSAGES` (already defined in `lib/ui/loading-messages.ts`) via the existing `useRotatingLoadingMessage` hook.

Small pill above the company selector slot: indigo dot + cycling Indian-compliance-themed message every ~2s:
- "🛰️ Initiating secure handshake with compliance grid…"
- "🏛️ Synchronizing with the Ministry of Corporate Affairs…"
- "🤖 Spinning up the CIA neural agent…"
- etc.

## Functional safety
- 32 files, 268 ins / 250 del. Pure className substitution + tiny boot-shell addition.
- Legacy keys (`primary.dark`, `primary.orange`) **preserved in tailwind.config.ts** so the 380+ unrelated usages of `primary.navy`, `primary.green`, `primary.dark-card` (already swept), etc. don't break.
- `DATA_ROOM_LOADING_MESSAGES` array already existed; this PR just consumes it.
- `tsc --noEmit` clean.

## Branch hygiene
- Branched off `origin/main` after PR #108.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic loading messages in the data room initialization screen.

* **Style**
  * Updated accent color scheme across the application for a refreshed visual design.
  * Adjusted page background colors for improved visual consistency throughout the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->