### PR TITLE
fix(ui): final light-mode sweep — bg-white CTAs, border-white alpha, bg-black cards (PR-30)

### DIFF
--- a/app/admin/bulk-upload/page.tsx
+++ b/app/admin/bulk-upload/page.tsx
@@ -933,7 +933,7 @@ function BulkUploadPage() {
             {validation && (
               <span className={`px-3 py-1 rounded text-xs font-medium ${
                 validation.valid
-                  ? 'bg-white/20 text-fg-primary'
+                  ? 'bg-bg-hover text-fg-primary'
                   : 'bg-red-500 text-white'
               }`}>
                 {nonEmptyRowCount} rows • {validation.valid ? 'Ready to upload' : `${validation.errors.length} errors`}
@@ -941,10 +941,10 @@ function BulkUploadPage() {
             )}
             {/* Auto-save indicator */}
             {lastSaved && (
-              <span className="px-3 py-1 rounded text-xs font-medium bg-white/10 text-fg-primary/80 flex items-center gap-1.5">
+              <span className="px-3 py-1 rounded text-xs font-medium bg-bg-hover text-fg-primary/80 flex items-center gap-1.5">
                 {isSaving ? (
                   <>
-                    <div className="w-3 h-3 border-2 border-white/50 border-t-transparent rounded-full animate-spin"></div>
+                    <div className="w-3 h-3 border-2 border-line/50 border-t-transparent rounded-full animate-spin"></div>
                     Saving...
                   </>
                 ) : (
@@ -961,14 +961,14 @@ function BulkUploadPage() {
           <div className="flex items-center gap-2">
             <button
               onClick={downloadCSVTemplate}
-              className="px-3 py-1.5 bg-white/10 hover:bg-white/20 text-fg-primary text-sm rounded transition-colors flex items-center gap-2"
+              className="px-3 py-1.5 bg-bg-hover hover:bg-bg-hover text-fg-primary text-sm rounded transition-colors flex items-center gap-2"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
               </svg>
               Template
             </button>
-            <label className="px-3 py-1.5 bg-white/10 hover:bg-white/20 text-fg-primary text-sm rounded transition-colors cursor-pointer flex items-center gap-2">
+            <label className="px-3 py-1.5 bg-bg-hover hover:bg-bg-hover text-fg-primary text-sm rounded transition-colors cursor-pointer flex items-center gap-2">
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
               </svg>
@@ -986,7 +986,7 @@ function BulkUploadPage() {
                 <select
                   value={resolveMode}
                   onChange={(e) => setResolveMode(e.target.value as 'auto' | 'custom')}
-                  className="px-3 py-2 bg-white/10 hover:bg-white/20 text-fg-primary text-sm rounded border border-white/20 focus:outline-none focus:border-white/40 transition-colors"
+                  className="px-3 py-2 bg-bg-hover hover:bg-bg-hover text-fg-primary text-sm rounded border border-line/20 focus:outline-none focus:border-line/40 transition-colors"
                 >
                   <option value="auto">Auto Resolve</option>
                   <option value="custom">Custom Resolver</option>
@@ -1033,7 +1033,7 @@ function BulkUploadPage() {
               className={`px-5 py-2 rounded-lg text-sm font-semibold transition-all flex items-center gap-2 shadow-md ${
                 validation?.valid && nonEmptyRowCount > 0 && !isUploading
                   ? 'bg-white text-[#217346] hover:bg-bg-elevated hover:shadow-lg'
-                  : 'bg-white/30 text-fg-primary/50 cursor-not-allowed'
+                  : 'bg-bg-hover text-fg-primary/50 cursor-not-allowed'
               }`}
             >
               {isUploading ? (

--- a/app/admin/error.tsx
+++ b/app/admin/error.tsx
@@ -38,7 +38,7 @@ export default function AdminError({
           </button>
           <Link
             href="/data-room"
-            className="px-6 py-2.5 rounded-xl border border-white/10 hover:bg-white/5 text-fg-secondary text-sm font-medium transition-colors"
+            className="px-6 py-2.5 rounded-xl border border-line/10 hover:bg-bg-hover text-fg-secondary text-sm font-medium transition-colors"
           >
             Go to Dashboard
           </Link>

--- a/app/coming-soon/page.tsx
+++ b/app/coming-soon/page.tsx
@@ -22,7 +22,7 @@ export default function ComingSoonPage() {
           </div>
           <Link
             href="/home"
-            className="inline-block px-8 py-3 bg-white text-black rounded-lg hover:bg-bg-elevated transition-colors font-light text-sm sm:text-base"
+            className="inline-block px-8 py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-elevated transition-colors font-light text-sm sm:text-base"
           >
             Back to Home
           </Link>

--- a/app/data-room/components/AgentAssistedBulkUploadModal.tsx
+++ b/app/data-room/components/AgentAssistedBulkUploadModal.tsx
@@ -370,13 +370,13 @@ export default function AgentAssistedBulkUploadModal({
               <div className="flex items-center justify-center gap-3">
                 <label
                   htmlFor="bulk-agent-upload-files"
-                  className="inline-block px-5 py-2.5 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated cursor-pointer"
+                  className="inline-block px-5 py-2.5 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated cursor-pointer"
                 >
                   Choose files
                 </label>
                 <label
                   htmlFor="bulk-agent-upload-folder"
-                  className="inline-block px-5 py-2.5 border border-white/20 text-fg-primary rounded-lg text-sm font-medium hover:bg-white/5 cursor-pointer"
+                  className="inline-block px-5 py-2.5 border border-line/20 text-fg-primary rounded-lg text-sm font-medium hover:bg-bg-hover cursor-pointer"
                   title="Pick a whole directory — we'll walk it recursively"
                 >
                   Choose folder
@@ -425,13 +425,13 @@ export default function AgentAssistedBulkUploadModal({
                     />
                     <label
                       htmlFor="bulk-agent-add-files"
-                      className="text-[11px] px-2.5 py-1 border border-white/15 text-fg-secondary rounded hover:bg-white/5 cursor-pointer"
+                      className="text-[11px] px-2.5 py-1 border border-line/15 text-fg-secondary rounded hover:bg-bg-hover cursor-pointer"
                     >
                       + Add files
                     </label>
                     <label
                       htmlFor="bulk-agent-add-folder"
-                      className="text-[11px] px-2.5 py-1 border border-white/15 text-fg-secondary rounded hover:bg-white/5 cursor-pointer"
+                      className="text-[11px] px-2.5 py-1 border border-line/15 text-fg-secondary rounded hover:bg-bg-hover cursor-pointer"
                     >
                       + Add folder
                     </label>
@@ -548,7 +548,7 @@ export default function AgentAssistedBulkUploadModal({
             </button>
             <button
               onClick={handleSaveAll}
-              className="px-6 py-2 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated disabled:opacity-50"
+              className="px-6 py-2 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated disabled:opacity-50"
               disabled={totals.readySelected === 0}
             >
               Save {totals.readySelected} document{totals.readySelected === 1 ? '' : 's'}
@@ -560,7 +560,7 @@ export default function AgentAssistedBulkUploadModal({
           <div className="p-6 border-t border-line/10 flex items-center justify-end">
             <button
               onClick={handleClose}
-              className="px-6 py-2 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated"
+              className="px-6 py-2 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated"
             >
               Close
             </button>

--- a/app/data-room/components/AgentAssistedUploadModal.tsx
+++ b/app/data-room/components/AgentAssistedUploadModal.tsx
@@ -312,7 +312,7 @@ export default function AgentAssistedUploadModal({
               />
               <label
                 htmlFor="agent-upload-input"
-                className="inline-block px-6 py-3 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated cursor-pointer"
+                className="inline-block px-6 py-3 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated cursor-pointer"
               >
                 Choose file
               </label>
@@ -519,7 +519,7 @@ export default function AgentAssistedUploadModal({
             </button>
             <button
               onClick={handleSave}
-              className="px-6 py-2 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated disabled:opacity-50"
+              className="px-6 py-2 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated disabled:opacity-50"
               disabled={!form.fileName.trim() || !form.documentName.trim() || !form.folderId}
             >
               Save document

--- a/app/data-room/components/DocumentsTab.tsx
+++ b/app/data-room/components/DocumentsTab.tsx
@@ -1099,7 +1099,7 @@ export default function DocumentsTab({
         <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3">
           <button
             onClick={() => setIsExportModalOpen(true)}
-            className="bg-black border border-white/20 text-fg-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:border-white/40/50 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
+            className="bg-black border border-line/20 text-fg-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:border-line/40 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
           >
             <svg
               width="16"
@@ -1121,7 +1121,7 @@ export default function DocumentsTab({
           </button>
           <button
             onClick={() => setIsSendModalOpen(true)}
-            className="bg-black border border-white/20 text-fg-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:border-white/40/50 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
+            className="bg-black border border-line/20 text-fg-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:border-line/40 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
           >
             <svg
               width="16"
@@ -1145,7 +1145,7 @@ export default function DocumentsTab({
               setAgentUploadDefaultFolderId(null)
               setIsAgentBulkOpen(true)
             }}
-            className="bg-black border border-white/20 text-fg-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:border-white/40/50 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
+            className="bg-black border border-line/20 text-fg-primary px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:border-line/40 transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
           >
             <svg
               width="16"
@@ -1171,7 +1171,7 @@ export default function DocumentsTab({
               setAgentUploadDefaultFolderId(null)
               setIsAgentUploadOpen(true)
             }}
-            className="bg-white text-black px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
+            className="bg-accent-brand text-white px-4 sm:px-6 py-2 sm:py-3 rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base"
           >
             <svg
               width="16"
@@ -1212,7 +1212,7 @@ export default function DocumentsTab({
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             placeholder="Search documents by name, type, folder, or period..."
-            className="w-full pl-9 sm:pl-12 pr-4 py-2.5 sm:py-3 bg-black border border-white/20 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+            className="w-full pl-9 sm:pl-12 pr-4 py-2.5 sm:py-3 bg-black border border-line/20 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
           />
           {searchQuery && (
             <button
@@ -1232,7 +1232,7 @@ export default function DocumentsTab({
           <select
             value={selectedFY}
             onChange={(e) => setSelectedFY(e.target.value)}
-            className="px-3 sm:px-4 py-2 bg-black border border-white/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+            className="px-3 sm:px-4 py-2 bg-black border border-line/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
             style={{
               backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a0a0a0' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
               backgroundRepeat: 'no-repeat',
@@ -1252,7 +1252,7 @@ export default function DocumentsTab({
           <select
             value={sortOption}
             onChange={(e) => setSortOption(e.target.value as typeof sortOption)}
-            className="px-3 sm:px-4 py-2 bg-black border border-white/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+            className="px-3 sm:px-4 py-2 bg-black border border-line/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
             style={{
               backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a0a0a0' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
               backgroundRepeat: 'no-repeat',
@@ -1272,7 +1272,7 @@ export default function DocumentsTab({
           <select
             value={expiringSoonFilter}
             onChange={(e) => setExpiringSoonFilter(e.target.value as typeof expiringSoonFilter)}
-            className="px-3 sm:px-4 py-2 bg-black border border-white/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+            className="px-3 sm:px-4 py-2 bg-black border border-line/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
             style={{
               backgroundImage: `url("data:image/svg+xml,%3Csvg width='10' height='10' viewBox='0 0 24 24' fill='none' stroke='%23a0a0a0' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E")`,
               backgroundRepeat: 'no-repeat',
@@ -1362,7 +1362,7 @@ export default function DocumentsTab({
           {/* Storage Stats */}
           <button
             onClick={() => setIsStorageBreakdownOpen(true)}
-            className="w-full bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6 text-left hover:border-white/20 transition-colors"
+            className="w-full bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6 text-left hover:border-line/20 transition-colors"
           >
             <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
               <svg
@@ -1397,7 +1397,7 @@ export default function DocumentsTab({
           </button>
     
           {/* Recent Activity */}
-          <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+          <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
             <h3 className="text-base sm:text-lg font-light text-fg-primary mb-3 sm:mb-4">Recent Activity</h3>
             <div className="space-y-2 sm:space-y-3">
               <div className="flex items-center gap-2 sm:gap-3">
@@ -1466,7 +1466,7 @@ export default function DocumentsTab({
                   <div className="relative">
                     <button
                       onClick={() => setIsFolderDropdownOpen(!isFolderDropdownOpen)}
-                      className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-between font-medium text-sm sm:text-base"
+                      className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-between font-medium text-sm sm:text-base"
                     >
                       <span className="truncate">{uploadFormData.folder || 'Select folder'}</span>
                       <svg
@@ -1626,7 +1626,7 @@ export default function DocumentsTab({
                                 setUploadFormData((prev) => ({ ...prev, documentName: e.target.value }))
                               }
                             }}
-                            className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+                            className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
                           >
                             <option value="">Select from predefined documents</option>
                             {folderDocNames.map((name: string) => (
@@ -1641,7 +1641,7 @@ export default function DocumentsTab({
                             setUploadFormData((prev) => ({ ...prev, documentName: e.target.value }))
                           }}
                           placeholder={folderDocNames.length > 0 ? "Or type a custom document name" : "Enter document name"}
-                          className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                          className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                         />
                       </div>
                     )
@@ -1699,7 +1699,7 @@ export default function DocumentsTab({
                           onChange={(e) =>
                             setUploadFormData((prev) => ({ ...prev, frequency: e.target.value as 'one-time' | 'monthly' | 'quarterly' | 'annually' }))
                           }
-                          className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer"
+                          className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer"
                         >
                           <option value="one-time">One-time</option>
                           <option value="monthly">Monthly</option>
@@ -1724,7 +1724,7 @@ export default function DocumentsTab({
                                 registrationDate: e.target.value,
                               }))
                             }
-                            className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                            className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                           />
                         </div>
                         <div>
@@ -1740,7 +1740,7 @@ export default function DocumentsTab({
                                 expiryDate: e.target.value,
                               }))
                             }
-                            className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                            className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                           />
                         </div>
                       </div>
@@ -1767,7 +1767,7 @@ export default function DocumentsTab({
     
                       {/* External Portal Credentials */}
                       {uploadFormData.hasNote && (
-                        <div className="bg-white/5 border border-white/40/30 rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4">
+                        <div className="bg-bg-hover border border-line/40/30 rounded-lg p-3 sm:p-4 space-y-3 sm:space-y-4">
                           <h3 className="text-fg-primary font-medium text-sm sm:text-base">External Portal Credentials</h3>
                           <div>
                             <label className="block text-xs sm:text-sm font-medium text-fg-secondary mb-2">
@@ -1783,7 +1783,7 @@ export default function DocumentsTab({
                                 }))
                               }
                               placeholder="portal@example.com"
-                              className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                              className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                             />
                           </div>
                           <div>
@@ -1800,7 +1800,7 @@ export default function DocumentsTab({
                                 }))
                               }
                               placeholder="Enter password"
-                              className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                              className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-sm sm:text-base placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                             />
                           </div>
                         </div>
@@ -1814,10 +1814,10 @@ export default function DocumentsTab({
                   <label className="block text-xs sm:text-sm font-medium text-fg-secondary mb-2">
                     Upload File
                   </label>
-                  <label className="flex flex-col items-center justify-center w-full h-32 sm:h-48 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-white/40 transition-colors bg-bg-card/50">
+                  <label className="flex flex-col items-center justify-center w-full h-32 sm:h-48 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-line/40 transition-colors bg-bg-card/50">
                     <div className="flex flex-col items-center justify-center pt-4 sm:pt-5 pb-4 sm:pb-6 px-4">
                       {isUploading ? (
-                        <div className="w-8 h-8 sm:w-12 sm:h-12 border-4 border-white/40 border-t-transparent rounded-full animate-spin mb-3 sm:mb-4"></div>
+                        <div className="w-8 h-8 sm:w-12 sm:h-12 border-4 border-line/40 border-t-transparent rounded-full animate-spin mb-3 sm:mb-4"></div>
                       ) : (
                         <svg
                           width="32"
@@ -1868,7 +1868,7 @@ export default function DocumentsTab({
                   <button
                     onClick={handleUpload}
                     disabled={isUploading || !uploadFormData.file || !uploadFormData.folder || !uploadFormData.documentName}
-                    className="w-full sm:w-auto px-4 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium disabled:opacity-50 text-sm sm:text-base"
+                    className="w-full sm:w-auto px-4 sm:px-6 py-2.5 sm:py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium disabled:opacity-50 text-sm sm:text-base"
                   >
                     {isUploading ? (
                       <>
@@ -1964,7 +1964,7 @@ export default function DocumentsTab({
                   <div className="relative">
                     <button
                       onClick={() => setIsFolderDropdownOpen(!isFolderDropdownOpen)}
-                      className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-between font-medium text-sm sm:text-base"
+                      className="w-full px-3 sm:px-4 py-2 sm:py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-between font-medium text-sm sm:text-base"
                     >
                       <span className="truncate">{uploadFormData.folder || 'Select folder'}</span>
                       <svg
@@ -2005,7 +2005,7 @@ export default function DocumentsTab({
                   <label className="block text-xs sm:text-sm font-medium text-fg-secondary mb-2">
                     Select Multiple Files <span className="text-red-500">*</span>
                   </label>
-                  <label className="flex flex-col items-center justify-center w-full h-40 sm:h-48 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-white/40 transition-colors bg-bg-card/50">
+                  <label className="flex flex-col items-center justify-center w-full h-40 sm:h-48 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-line/40 transition-colors bg-bg-card/50">
                     <div className="flex flex-col items-center justify-center pt-4 sm:pt-5 pb-4 sm:pb-6 px-4">
                       <svg
                         width="32"
@@ -2176,7 +2176,7 @@ export default function DocumentsTab({
                                         }))
                                       }}
                                       placeholder="Select from list or type custom name"
-                                      className="w-full px-3 py-2 pr-8 bg-black border border-line/15 rounded-lg text-fg-primary text-xs placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                                      className="w-full px-3 py-2 pr-8 bg-black border border-line/15 rounded-lg text-fg-primary text-xs placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                                     />
                                     <button
                                       type="button"
@@ -2257,7 +2257,7 @@ export default function DocumentsTab({
                                         [fileKey]: { ...prev[fileKey], frequency: e.target.value as 'one-time' | 'monthly' | 'quarterly' | 'annually' }
                                       }))
                                     }}
-                                    className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer"
+                                    className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer"
                                   >
                                     <option value="one-time">One-time</option>
                                     <option value="monthly">Monthly</option>
@@ -2282,7 +2282,7 @@ export default function DocumentsTab({
                                           [fileKey]: { ...prev[fileKey], registrationDate: e.target.value }
                                         }))
                                       }}
-                                      className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                                      className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                                     />
                                   </div>
                                   <div>
@@ -2298,7 +2298,7 @@ export default function DocumentsTab({
                                           [fileKey]: { ...prev[fileKey], expiryDate: e.target.value }
                                         }))
                                       }}
-                                      className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                                      className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                                     />
                                   </div>
                                 </div>
@@ -2321,7 +2321,7 @@ export default function DocumentsTab({
                                   </label>
                                   
                                   {fileOptions.hasNote && (
-                                    <div className="mt-2 space-y-2 bg-white/5 border border-white/10 rounded-lg p-2.5">
+                                    <div className="mt-2 space-y-2 bg-bg-hover border border-line/10 rounded-lg p-2.5">
                                       <div>
                                         <label className="block text-xs font-medium text-fg-secondary mb-1.5">
                                           Portal Email
@@ -2336,7 +2336,7 @@ export default function DocumentsTab({
                                             }))
                                           }}
                                           placeholder="portal@example.com"
-                                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                                         />
                                       </div>
                                       <div>
@@ -2353,7 +2353,7 @@ export default function DocumentsTab({
                                             }))
                                           }}
                                           placeholder="Enter password"
-                                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                                         />
                                       </div>
                                     </div>
@@ -2510,7 +2510,7 @@ export default function DocumentsTab({
                       }
                     }}
                     disabled={isUploading || !uploadFormData.folder || bulkUploadFiles.length === 0}
-                    className="w-full sm:w-auto px-4 sm:px-6 py-2.5 sm:py-3 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium disabled:opacity-50 text-sm sm:text-base"
+                    className="w-full sm:w-auto px-4 sm:px-6 py-2.5 sm:py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium disabled:opacity-50 text-sm sm:text-base"
                   >
                     {isUploading ? (
                       <>
@@ -2605,7 +2605,7 @@ export default function DocumentsTab({
                   {allDocuments.map((doc) => (
                     <label
                       key={doc.id}
-                      className="flex items-center gap-3 p-4 bg-bg-card rounded-lg border border-line/10 hover:border-white/40/50 transition-colors cursor-pointer"
+                      className="flex items-center gap-3 p-4 bg-bg-card rounded-lg border border-line/10 hover:border-line/40 transition-colors cursor-pointer"
                     >
                       <input
                         type="checkbox"
@@ -2635,7 +2635,7 @@ export default function DocumentsTab({
                       setIsExportModalOpen(false)
                       setSelectedDocuments(new Set())
                     }}
-                    className="px-6 py-3 bg-transparent border border-white/20 text-fg-primary rounded-lg hover:border-white/40 hover:text-fg-primary transition-colors"
+                    className="px-6 py-3 bg-transparent border border-line/20 text-fg-primary rounded-lg hover:border-line/40 hover:text-fg-primary transition-colors"
                   >
                     Cancel
                   </button>
@@ -2748,7 +2748,7 @@ export default function DocumentsTab({
                       }
                     }}
                     disabled={selectedDocuments.size === 0 || allDocuments.length === 0}
-                    className="px-6 py-3 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-6 py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     <svg
                       width="18"
@@ -2832,7 +2832,7 @@ export default function DocumentsTab({
                   {allDocuments.map((doc) => (
                     <label
                       key={doc.id}
-                      className="flex items-center gap-3 p-4 bg-bg-card rounded-lg border border-line/10 hover:border-white/40/50 transition-colors cursor-pointer"
+                      className="flex items-center gap-3 p-4 bg-bg-card rounded-lg border border-line/10 hover:border-line/40 transition-colors cursor-pointer"
                     >
                       <input
                         type="checkbox"
@@ -2862,14 +2862,14 @@ export default function DocumentsTab({
                       setIsSendModalOpen(false)
                       setSelectedDocumentsToSend(new Set())
                     }}
-                    className="px-6 py-3 bg-transparent border border-white/20 text-fg-primary rounded-lg hover:border-white/40 hover:text-fg-primary transition-colors"
+                    className="px-6 py-3 bg-transparent border border-line/20 text-fg-primary rounded-lg hover:border-line/40 hover:text-fg-primary transition-colors"
                   >
                     Cancel
                   </button>
                   <button
                     onClick={handleSendNext}
                     disabled={selectedDocumentsToSend.size === 0}
-                    className="px-6 py-3 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-6 py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     Next
                     <svg
@@ -2937,7 +2937,7 @@ export default function DocumentsTab({
               {/* Modal Content */}
               <div className="p-6 space-y-6">
                 {/* Selected Documents Info */}
-                <div className="bg-black rounded-lg p-4 border border-white/10">
+                <div className="bg-black rounded-lg p-4 border border-line/10">
                   <div className="text-sm text-fg-muted mb-2">Selected Documents:</div>
                   <div className="text-fg-primary">
                     {selectedDocumentsToSend.size} document
@@ -2957,7 +2957,7 @@ export default function DocumentsTab({
                       setEmailData((prev) => ({ ...prev, recipients: e.target.value }))
                     }
                     placeholder="Enter email addresses (comma separated)"
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                   />
                   <p className="text-fg-muted text-xs mt-1">
                     Separate multiple email addresses with commas
@@ -2976,7 +2976,7 @@ export default function DocumentsTab({
                       setEmailData((prev) => ({ ...prev, subject: e.target.value }))
                     }
                     placeholder="Email subject"
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                   />
                 </div>
     
@@ -2992,7 +2992,7 @@ export default function DocumentsTab({
                     }
                     rows={10}
                     placeholder="Write your email message here..."
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors resize-none"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors resize-none"
                   />
                 </div>
     
@@ -3010,7 +3010,7 @@ export default function DocumentsTab({
                         includeAttachments: false,
                       })
                     }}
-                    className="px-6 py-3 bg-transparent border border-white/20 text-fg-primary rounded-lg hover:border-white/40 hover:text-fg-primary transition-colors"
+                    className="px-6 py-3 bg-transparent border border-line/20 text-fg-primary rounded-lg hover:border-line/40 hover:text-fg-primary transition-colors"
                   >
                     Cancel
                   </button>
@@ -3073,7 +3073,7 @@ export default function DocumentsTab({
                       !emailData.subject.trim() ||
                       !emailData.body.trim()
                     }
-                    className="px-6 py-3 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                    className="px-6 py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 font-medium disabled:opacity-50 disabled:cursor-not-allowed"
                   >
                     {isSendingEmail ? (
                       <>
@@ -3406,7 +3406,7 @@ export default function DocumentsTab({
                       />
                       <label
                         htmlFor="tracker-file-upload-input"
-                        className="mt-3 inline-block px-4 py-2 bg-white text-black rounded-lg hover:bg-bg-elevated transition-colors cursor-pointer text-sm font-medium"
+                        className="mt-3 inline-block px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-bg-elevated transition-colors cursor-pointer text-sm font-medium"
                       >
                         Browse Files
                       </label>
@@ -3494,7 +3494,7 @@ export default function DocumentsTab({
                     }
                   }}
                   disabled={!uploadFile || uploadingDocument || !handleTrackerDocumentUpload}
-                  className="px-4 py-2 bg-white text-black rounded-lg hover:bg-bg-elevated transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 font-medium"
+                  className="px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-bg-elevated transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2 font-medium"
                 >
                   {uploadingDocument ? (
                     <>

--- a/app/data-room/components/DscDinTab.tsx
+++ b/app/data-room/components/DscDinTab.tsx
@@ -105,7 +105,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                 {/* Director Header */}
                 <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 sm:gap-4 pb-4 border-b border-line/10">
                   <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-white/10 flex items-center justify-center text-fg-primary font-medium text-lg sm:text-xl">
+                    <div className="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-bg-hover flex items-center justify-center text-fg-primary font-medium text-lg sm:text-xl">
                       {directorName.charAt(0).toUpperCase()}
                     </div>
                     <div>
@@ -165,7 +165,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                         </div>
                       </div>
                     ) : (
-                      <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-white/40 transition-colors bg-bg-card/50">
+                      <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-line/40 transition-colors bg-bg-card/50">
                         <div className="flex flex-col items-center justify-center pt-4 pb-4 px-4">
                           <svg className="w-8 h-8 text-fg-muted mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
@@ -227,7 +227,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                         </div>
                       </div>
                     ) : (
-                      <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-white/40 transition-colors bg-bg-card/50">
+                      <label className="flex flex-col items-center justify-center w-full h-32 border-2 border-dashed border-line/15 rounded-lg cursor-pointer hover:border-line/40 transition-colors bg-bg-card/50">
                         <div className="flex flex-col items-center justify-center pt-4 pb-4 px-4">
                           <svg className="w-8 h-8 text-fg-muted mb-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M7 16a4 4 0 01-.88-7.903A5 5 0 1115.9 6L16 6a5 5 0 011 9.9M15 13l-3-3m0 0l-3 3m3-3v12" />
@@ -276,7 +276,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                   </label>
 
                   {directorData.hasCredentials && (
-                    <div className="bg-white/5 border border-white/10 rounded-lg p-4 space-y-3">
+                    <div className="bg-bg-hover border border-line/10 rounded-lg p-4 space-y-3">
                       <div>
                         <label className="block text-xs sm:text-sm font-medium text-fg-secondary mb-1.5">
                           Portal Email
@@ -291,7 +291,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                             }))
                           }}
                           placeholder="portal@example.com"
-                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs sm:text-sm placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs sm:text-sm placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                         />
                       </div>
                       <div>
@@ -308,7 +308,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                             }))
                           }}
                           placeholder="Enter password"
-                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs sm:text-sm placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                          className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs sm:text-sm placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                         />
                       </div>
                     </div>
@@ -330,7 +330,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                           [directorId]: { ...prev[directorId] || getDefaultDirectorData(), expiryDate: e.target.value }
                         }))
                       }}
-                      className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs sm:text-sm focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                      className="w-full px-3 py-2 bg-black border border-line/15 rounded-lg text-fg-primary text-xs sm:text-sm focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                     />
                     <p className="text-[10px] sm:text-xs text-fg-muted mt-1">Default: September 30 (yearly)</p>
                   </div>
@@ -362,7 +362,7 @@ export default function DscDinTab({ entityDetails }: DscDinTabProps) {
                       // In a real implementation, this would save to the database
                       showToast('DSC/DIN data saved successfully for ' + directorName, 'success')
                     }}
-                    className="w-full sm:w-auto px-4 sm:px-6 py-2 sm:py-3 bg-white text-black rounded-lg hover:bg-bg-elevated transition-colors font-medium text-sm sm:text-base"
+                    className="w-full sm:w-auto px-4 sm:px-6 py-2 sm:py-3 bg-accent-brand text-white rounded-lg hover:bg-bg-elevated transition-colors font-medium text-sm sm:text-base"
                   >
                     Save Changes
                   </button>

--- a/app/data-room/components/GSTTab.tsx
+++ b/app/data-room/components/GSTTab.tsx
@@ -85,7 +85,7 @@ export default function GSTTab({
                   onChange={(e) => setGstCredentials({ ...gstCredentials, gstin: e.target.value.toUpperCase() })}
                   placeholder="Enter your 15-digit GSTIN"
                   maxLength={15}
-                  className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors font-mono tracking-wider"
+                  className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors font-mono tracking-wider"
                 />
                 <p className="mt-1 text-xs text-fg-muted">Example: 27AQOPD9471C3ZM</p>
               </div>
@@ -99,7 +99,7 @@ export default function GSTTab({
                   value={gstCredentials.gstUsername}
                   onChange={(e) => setGstCredentials({ ...gstCredentials, gstUsername: e.target.value })}
                   placeholder="Enter your GST portal username"
-                  className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                  className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                 />
               </div>
 
@@ -215,7 +215,7 @@ export default function GSTTab({
                   onChange={(e) => setGstOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
                   placeholder="Enter 6-digit OTP"
                   maxLength={6}
-                  className="w-full px-4 py-4 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-center text-2xl font-mono tracking-[0.5em] placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                  className="w-full px-4 py-4 bg-bg-card border border-line/15 rounded-lg text-fg-primary text-center text-2xl font-mono tracking-[0.5em] placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                 />
                 <p className="mt-2 text-center text-xs text-fg-muted">
                   OTP expires in <span className="text-fg-primary">5:00</span> minutes
@@ -341,7 +341,7 @@ export default function GSTTab({
                 <select
                   value={selectedGstPeriod}
                   onChange={(e) => setSelectedGstPeriod(e.target.value)}
-                  className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-white/40"
+                  className="px-4 py-2 bg-bg-card border border-line/15 rounded-lg text-fg-primary focus:outline-none focus:border-line/40"
                 >
                   <option value="012026">January 2026</option>
                   <option value="122025">December 2025</option>
@@ -378,7 +378,7 @@ export default function GSTTab({
                 key={tab.id}
                 onClick={() => setGstActiveSection(tab.id as any)}
                 className={`px-4 py-2 rounded-lg transition-colors flex items-center gap-2 whitespace-nowrap ${gstActiveSection === tab.id
-                    ? 'bg-white text-black'
+                    ? 'bg-accent-brand text-white'
                     : 'bg-bg-elevated text-fg-muted hover:text-fg-primary hover:bg-bg-hover'
                   }`}
               >
@@ -702,7 +702,7 @@ export default function GSTTab({
                   </div>
                 </div>
 
-                <div className="bg-white/5 border border-white/40/30 rounded-xl p-6">
+                <div className="bg-bg-hover border border-line/40/30 rounded-xl p-6">
                   <h4 className="text-fg-muted text-sm mb-4">Tax Paid</h4>
                   <p className="text-3xl font-light text-fg-primary mb-2">₹{gstData.gstr3b.taxPaid.toLocaleString('en-IN')}</p>
                   <div className="text-xs text-fg-muted space-y-1">

--- a/app/data-room/components/GstRegistrationsSection.tsx
+++ b/app/data-room/components/GstRegistrationsSection.tsx
@@ -130,7 +130,7 @@ export default function GstRegistrationsSection({ companyId }: Props) {
                 type="button"
                 onClick={handleSaveEdit}
                 disabled={busyId === r.id}
-                className="px-3 py-1 text-xs bg-white text-black rounded hover:bg-bg-elevated disabled:opacity-50"
+                className="px-3 py-1 text-xs bg-accent-brand text-white rounded hover:bg-bg-elevated disabled:opacity-50"
               >
                 Save
               </button>
@@ -202,7 +202,7 @@ export default function GstRegistrationsSection({ companyId }: Props) {
           type="button"
           onClick={handleAdd}
           disabled={busyId === '__new' || newGstin.length !== 15}
-          className="px-4 py-2 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated transition-colors disabled:opacity-50"
+          className="px-4 py-2 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated transition-colors disabled:opacity-50"
         >
           {busyId === '__new' ? 'Adding…' : 'Add GSTIN'}
         </button>

--- a/app/data-room/components/NoticesTab.tsx
+++ b/app/data-room/components/NoticesTab.tsx
@@ -145,7 +145,7 @@ export default function NoticesTab({
             <select
               value={noticesFilter}
               onChange={(e) => setNoticesFilter(e.target.value as any)}
-              className="px-4 py-2 bg-black border border-white/20 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-white/40"
+              className="px-4 py-2 bg-black border border-line/20 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-line/40"
             >
               <option value="all">All Status</option>
               <option value="pending">Pending</option>
@@ -156,7 +156,7 @@ export default function NoticesTab({
             <select
               value={noticesTypeFilter}
               onChange={(e) => setNoticesTypeFilter(e.target.value)}
-              className="px-4 py-2 bg-black border border-white/20 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-white/40"
+              className="px-4 py-2 bg-black border border-line/20 rounded-lg text-fg-primary text-sm focus:outline-none focus:border-line/40"
             >
               <option value="all">All Types</option>
               {complianceCategories.map((category) => (
@@ -165,7 +165,7 @@ export default function NoticesTab({
             </select>
             <button
               onClick={() => setIsAddNoticeModalOpen(true)}
-              className="px-4 py-2 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 text-sm"
+              className="px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 text-sm"
             >
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M12 5v14M5 12h14" />
@@ -177,7 +177,7 @@ export default function NoticesTab({
 
         {/* Stats Cards */}
         <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-          <div className="bg-black border border-white/10 rounded-xl p-4">
+          <div className="bg-bg-card border border-line/10 rounded-xl p-4">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-red-500/20 rounded-lg flex items-center justify-center">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#EF4444" strokeWidth="2">
@@ -192,7 +192,7 @@ export default function NoticesTab({
               </div>
             </div>
           </div>
-          <div className="bg-black border border-white/10 rounded-xl p-4">
+          <div className="bg-bg-card border border-line/10 rounded-xl p-4">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-yellow-500/20 rounded-lg flex items-center justify-center">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#EAB308" strokeWidth="2">
@@ -206,7 +206,7 @@ export default function NoticesTab({
               </div>
             </div>
           </div>
-          <div className="bg-black border border-white/10 rounded-xl p-4">
+          <div className="bg-bg-card border border-line/10 rounded-xl p-4">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-green-500/20 rounded-lg flex items-center justify-center">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#22C55E" strokeWidth="2">
@@ -220,7 +220,7 @@ export default function NoticesTab({
               </div>
             </div>
           </div>
-          <div className="bg-black border border-white/10 rounded-xl p-4">
+          <div className="bg-bg-card border border-line/10 rounded-xl p-4">
             <div className="flex items-center gap-3">
               <div className="w-10 h-10 bg-purple-500/20 rounded-lg flex items-center justify-center">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#A855F7" strokeWidth="2">
@@ -245,7 +245,7 @@ export default function NoticesTab({
               <div
                 key={notice.id}
                 onClick={() => setSelectedNotice(notice)}
-                className={`bg-black border rounded-xl p-4 cursor-pointer transition-all hover:border-white/40/50 ${selectedNotice?.id === notice.id ? 'border-white/40' : 'border-white/10'
+                className={`bg-black border rounded-xl p-4 cursor-pointer transition-all hover:border-line/40 ${selectedNotice?.id === notice.id ? 'border-line/40' : 'border-line/10'
                   }`}
               >
                 <div className="flex items-start justify-between gap-3 mb-2">
@@ -285,9 +285,9 @@ export default function NoticesTab({
               const authority = getAuthorityForCategory(selectedNotice.type || '')
 
               return (
-                <div className="bg-black border border-white/10 rounded-2xl overflow-hidden">
+                <div className="bg-bg-card border border-line/10 rounded-2xl overflow-hidden">
                   {/* Detail Header */}
-                  <div className="bg-black p-6 border-b border-white/10">
+                  <div className="bg-black p-6 border-b border-line/10">
                     <div className="flex items-start justify-between gap-4 mb-4">
                       <div className="flex items-center gap-3">
                         <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${selectedNotice.type === 'Income Tax' ? 'bg-blue-500/20' :
@@ -382,7 +382,7 @@ export default function NoticesTab({
                     {/* Description */}
                     <div>
                       <h4 className="text-fg-muted text-sm font-medium mb-2">Notice Description</h4>
-                      <p className="text-fg-primary text-sm leading-relaxed bg-black border border-white/10 p-4 rounded-lg">
+                      <p className="text-fg-primary text-sm leading-relaxed bg-bg-card border border-line/10 p-4 rounded-lg">
                         {selectedNotice.description}
                       </p>
                     </div>
@@ -429,14 +429,14 @@ export default function NoticesTab({
 
                     {/* Response Section (only for pending notices) */}
                     {selectedNotice.status === 'pending' && (
-                      <div className="border-t border-white/10 pt-6">
+                      <div className="border-t border-line/10 pt-6">
                         <h4 className="text-fg-muted text-sm font-medium mb-3">Submit Response</h4>
                         <textarea
                           value={noticeResponse}
                           onChange={(e) => setNoticeResponse(e.target.value)}
                           placeholder="Enter your response or remarks..."
                           rows={4}
-                          className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors resize-none"
+                          className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors resize-none"
                         />
                         <div className="flex items-center justify-between mt-4">
                           <button className="px-4 py-2 bg-bg-elevated text-fg-secondary rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 text-sm">
@@ -454,7 +454,7 @@ export default function NoticesTab({
                               setIsSubmittingResponse(false)
                             }}
                             disabled={isSubmittingResponse || !noticeResponse.trim()}
-                            className="px-6 py-2 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                            className="px-6 py-2 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                           >
                             {isSubmittingResponse ? (
                               <>
@@ -477,7 +477,7 @@ export default function NoticesTab({
 
                     {/* Actions for responded/resolved notices */}
                     {selectedNotice.status !== 'pending' && (
-                      <div className="border-t border-white/10 pt-6 flex items-center gap-3">
+                      <div className="border-t border-line/10 pt-6 flex items-center gap-3">
                         <button className="px-4 py-2 bg-bg-elevated text-fg-secondary rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2 text-sm">
                           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                             <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
@@ -508,7 +508,7 @@ export default function NoticesTab({
                 </div>
               )
             })() : (
-              <div className="bg-black border border-white/10 rounded-2xl h-full flex flex-col items-center justify-center py-20">
+              <div className="bg-bg-card border border-line/10 rounded-2xl h-full flex flex-col items-center justify-center py-20">
                 <div className="w-20 h-20 bg-bg-elevated rounded-full flex items-center justify-center mb-6">
                   <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="#6B7280" strokeWidth="1.5">
                     <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -528,9 +528,9 @@ export default function NoticesTab({
       {/* Add Notice Modal */}
       {isAddNoticeModalOpen && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-          <div className="bg-black border border-white/10 rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-y-auto">
+          <div className="bg-bg-card border border-line/10 rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-y-auto">
             {/* Modal Header */}
-            <div className="sticky top-0 bg-black border-b border-white/10 p-6 flex items-center justify-between z-10">
+            <div className="sticky top-0 bg-black border-b border-line/10 p-6 flex items-center justify-between z-10">
               <div>
                 <h2 className="text-2xl font-light text-fg-primary mb-1">Add New Notice</h2>
                 <p className="text-fg-muted text-sm">Enter the details of the government notice received</p>
@@ -572,7 +572,7 @@ export default function NoticesTab({
                   <select
                     value={newNoticeForm.type}
                     onChange={(e) => setNewNoticeForm({ ...newNoticeForm, type: e.target.value })}
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                   >
                     {/* Country-aware notice types based on compliance categories */}
                     {countryConfig?.compliance?.defaultCategories?.map((category: string) => (
@@ -598,7 +598,7 @@ export default function NoticesTab({
                     value={newNoticeForm.subType}
                     onChange={(e) => setNewNoticeForm({ ...newNoticeForm, subType: e.target.value })}
                     placeholder="e.g., Scrutiny Notice, Show Cause Notice"
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                   />
                 </div>
               </div>
@@ -614,7 +614,7 @@ export default function NoticesTab({
                     value={newNoticeForm.section}
                     onChange={(e) => setNewNoticeForm({ ...newNoticeForm, section: e.target.value })}
                     placeholder="e.g., Section 143(2), Section 73"
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                   />
                 </div>
 
@@ -625,7 +625,7 @@ export default function NoticesTab({
                   <select
                     value={newNoticeForm.priority}
                     onChange={(e) => setNewNoticeForm({ ...newNoticeForm, priority: e.target.value as any })}
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                   >
                     <option value="low">Low</option>
                     <option value="medium">Medium</option>
@@ -645,7 +645,7 @@ export default function NoticesTab({
                   value={newNoticeForm.subject}
                   onChange={(e) => setNewNoticeForm({ ...newNoticeForm, subject: e.target.value })}
                   placeholder="Enter the notice subject/title"
-                  className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                  className="w-full px-4 py-3 bg-bg-card border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                 />
               </div>
 
@@ -660,7 +660,7 @@ export default function NoticesTab({
                     value={newNoticeForm.issuedBy}
                     onChange={(e) => setNewNoticeForm({ ...newNoticeForm, issuedBy: e.target.value })}
                     placeholder="e.g., Income Tax Department"
-                    className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                    className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                   />
                 </div>
 
@@ -684,7 +684,7 @@ export default function NoticesTab({
                         }
                       }}
                       placeholder="Select date"
-                      className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer pr-10"
+                      className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer pr-10"
                     />
                     <input
                       type="date"
@@ -725,7 +725,7 @@ export default function NoticesTab({
                         }
                       }}
                       placeholder="Select date"
-                      className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer pr-10"
+                      className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors cursor-pointer pr-10"
                     />
                     <input
                       type="date"
@@ -757,7 +757,7 @@ export default function NoticesTab({
                   onChange={(e) => setNewNoticeForm({ ...newNoticeForm, description: e.target.value })}
                   placeholder="Enter the full notice description and requirements..."
                   rows={5}
-                  className="w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors resize-none"
+                  className="w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors resize-none"
                 />
               </div>
 
@@ -812,7 +812,7 @@ export default function NoticesTab({
                         }
                       }}
                       placeholder="Enter document name and press Enter"
-                      className="flex-1 px-4 py-2 bg-black border border-white/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                      className="flex-1 px-4 py-2 bg-black border border-line/20 rounded-lg text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                     />
                     <button
                       onClick={() => {
@@ -824,7 +824,7 @@ export default function NoticesTab({
                           setNewDocument('')
                         }
                       }}
-                      className="px-4 py-2 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2"
+                      className="px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center gap-2"
                     >
                       <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                         <path d="M12 5v14M5 12h14" />
@@ -836,7 +836,7 @@ export default function NoticesTab({
               </div>
 
               {/* Form Actions */}
-              <div className="flex items-center justify-end gap-3 pt-4 border-t border-white/10">
+              <div className="flex items-center justify-end gap-3 pt-4 border-t border-line/10">
                 <button
                   onClick={() => {
                     setIsAddNoticeModalOpen(false)
@@ -919,7 +919,7 @@ export default function NoticesTab({
                     setIsSubmittingNotice(false)
                   }}
                   disabled={isSubmittingNotice}
-                  className="px-6 py-2.5 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                  className="px-6 py-2.5 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
                 >
                   {isSubmittingNotice ? (
                     <>

--- a/app/data-room/components/OverviewTab.tsx
+++ b/app/data-room/components/OverviewTab.tsx
@@ -107,7 +107,7 @@ export default function OverviewTab({
 
   return (
     <div>
-      <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl shadow-2xl p-4 sm:p-8">
+      <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl shadow-2xl p-4 sm:p-8">
         {/* Card Header - Stack on Mobile */}
         <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-3 mb-4 sm:mb-6">
           <div className="flex items-center gap-3">
@@ -141,7 +141,7 @@ export default function OverviewTab({
           <div className="sm:ml-auto w-full sm:w-auto">
             <button
               onClick={() => router.push(`/manage-company?company_id=${currentCompany?.id || ''}`)}
-              className="w-full sm:w-auto px-3 sm:px-4 py-2 bg-white/10 border border-white/40 text-fg-primary rounded-lg hover:bg-white/20 transition-colors text-xs sm:text-sm flex items-center justify-center gap-2"
+              className="w-full sm:w-auto px-3 sm:px-4 py-2 bg-bg-hover border border-line/40 text-fg-primary rounded-lg hover:bg-bg-hover transition-colors text-xs sm:text-sm flex items-center justify-center gap-2"
             >
               <svg width="14" height="14" className="sm:w-4 sm:h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
@@ -154,7 +154,7 @@ export default function OverviewTab({
 
         {isLoading ? (
           <div className="py-8 sm:py-12 flex flex-col items-center justify-center">
-            <div className="w-8 h-8 sm:w-10 sm:h-10 border-4 border-white/40 border-t-transparent rounded-full animate-spin mb-4"></div>
+            <div className="w-8 h-8 sm:w-10 sm:h-10 border-4 border-line/40 border-t-transparent rounded-full animate-spin mb-4"></div>
             <p className="text-fg-muted text-sm sm:text-base">Loading company details...</p>
           </div>
         ) : entityDetails ? (
@@ -168,7 +168,7 @@ export default function OverviewTab({
             {/* Type */}
             <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-4">
               <label className="text-xs sm:text-sm text-fg-muted sm:w-32 sm:flex-shrink-0">Type</label>
-              <span className="inline-block bg-white text-black px-3 py-1 rounded-full text-xs sm:text-sm font-medium w-fit">
+              <span className="inline-block bg-accent-brand text-white px-3 py-1 rounded-full text-xs sm:text-sm font-medium w-fit">
                 {entityDetails.type}
               </span>
             </div>
@@ -211,7 +211,7 @@ export default function OverviewTab({
 
             {/* NIC Classification Card — derived from CIN */}
             {parsedCIN && (
-              <div className="mt-2 p-3 sm:p-4 bg-bg-card/60 border border-white/10 rounded-lg space-y-2">
+              <div className="mt-2 p-3 sm:p-4 bg-bg-card/60 border border-line/10 rounded-lg space-y-2">
                 <div className="flex items-center gap-2 mb-2">
                   <svg width="14" height="14" className="sm:w-4 sm:h-4 text-emerald-400 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                     <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
@@ -236,7 +236,7 @@ export default function OverviewTab({
 
                 {parsedCIN.nicDetails && (
                   <>
-                    <div className="border-t border-white/5 my-2"></div>
+                    <div className="border-t border-line/5 my-2"></div>
                     <div className="text-xs sm:text-sm font-medium text-fg-secondary mb-1">Industry Classification (NIC 2008)</div>
                     <div className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs sm:text-sm">
                       <span className="text-fg-muted">Section</span>
@@ -261,7 +261,7 @@ export default function OverviewTab({
 
             {/* MCA / CIN API Data */}
             {(entityDetails.authorisedCapital || entityDetails.paidUpCapital || entityDetails.rocName || entityDetails.companyStatus) && (
-              <div className="mt-2 p-3 sm:p-4 bg-bg-card/60 border border-white/10 rounded-lg">
+              <div className="mt-2 p-3 sm:p-4 bg-bg-card/60 border border-line/10 rounded-lg">
                 <div className="text-xs sm:text-sm font-medium text-fg-secondary mb-2">MCA Records</div>
                 <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 text-xs sm:text-sm">
                   {entityDetails.companyStatus && (
@@ -312,7 +312,7 @@ export default function OverviewTab({
 
             {/* GST Registrations — IN-only, one card per GSTIN */}
             {currentCompany?.country_code === 'IN' && gstRegs.length > 0 && (
-              <div className="mt-2 p-3 sm:p-4 bg-bg-card/60 border border-white/10 rounded-lg">
+              <div className="mt-2 p-3 sm:p-4 bg-bg-card/60 border border-line/10 rounded-lg">
                 <div className="flex items-center justify-between mb-2">
                   <div className="flex items-center gap-2">
                     <svg width="14" height="14" className="sm:w-4 sm:h-4 text-blue-400 flex-shrink-0" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -337,7 +337,7 @@ export default function OverviewTab({
                   {gstRegs.map((g) => {
                     const isHome = gstHomeState && g.state && g.state.toLowerCase() === gstHomeState.toLowerCase()
                     return (
-                      <div key={g.id} className="flex items-center justify-between gap-3 px-3 py-2 bg-black/40 border border-white/5 rounded-md">
+                      <div key={g.id} className="flex items-center justify-between gap-3 px-3 py-2 bg-black/40 border border-line/5 rounded-md">
                         <div className="flex items-center gap-2 min-w-0">
                           <span className="font-mono text-xs sm:text-sm text-fg-primary tracking-wider">{g.gstin}</span>
                           {isHome && (
@@ -363,7 +363,7 @@ export default function OverviewTab({
             )}
 
             {currentCompany?.country_code === 'IN' && gstRegs.length === 0 && (
-              <div className="mt-2 p-3 sm:p-4 bg-bg-card/40 border border-dashed border-white/10 rounded-lg flex items-center justify-between">
+              <div className="mt-2 p-3 sm:p-4 bg-bg-card/40 border border-dashed border-line/10 rounded-lg flex items-center justify-between">
                 <div className="flex items-center gap-2 text-xs sm:text-sm text-fg-muted">
                   <svg width="14" height="14" className="sm:w-4 sm:h-4 text-fg-muted" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                     <rect x="3" y="4" width="18" height="16" rx="2" />
@@ -393,7 +393,7 @@ export default function OverviewTab({
                         e.preventDefault()
                         setSelectedDirectorId(e.target.value || null)
                       }}
-                      className="w-full px-3 sm:px-4 py-2.5 sm:py-3 bg-black border border-white/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
+                      className="w-full px-3 sm:px-4 py-2.5 sm:py-3 bg-black border border-line/20 rounded-lg text-fg-primary text-sm sm:text-base focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors appearance-none cursor-pointer"
                     >
                       <option value="">Select a director to view profile</option>
                       {entityDetails.directors.map((director: any) => (
@@ -403,7 +403,7 @@ export default function OverviewTab({
                       ))}
                     </select>
                   ) : (
-                    <div className="w-full px-3 sm:px-4 py-2.5 sm:py-3 bg-black border border-white/20 rounded-lg text-fg-muted text-sm sm:text-base">
+                    <div className="w-full px-3 sm:px-4 py-2.5 sm:py-3 bg-black border border-line/20 rounded-lg text-fg-muted text-sm sm:text-base">
                       No directors found for this company
                     </div>
                   )}
@@ -417,12 +417,12 @@ export default function OverviewTab({
                   return (
                     <div className={`p-4 sm:p-6 bg-black border rounded-lg ${director.verified
                         ? 'border-green-500/50 bg-green-500/5'
-                        : 'border-white/10'
+                        : 'border-line/10'
                       }`}>
                       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 sm:gap-4 mb-4">
                         <div className="flex-1">
                           <div className="flex flex-col sm:flex-row sm:items-center gap-3 mb-4">
-                            <div className="w-10 h-10 sm:w-12 sm:h-12 bg-white/10 rounded-full flex items-center justify-center flex-shrink-0">
+                            <div className="w-10 h-10 sm:w-12 sm:h-12 bg-bg-hover rounded-full flex items-center justify-center flex-shrink-0">
                               <span className="text-fg-primary font-semibold text-base sm:text-lg">
                                 {director.firstName?.[0] || ''}{director.lastName?.[0] || ''}
                               </span>
@@ -451,31 +451,31 @@ export default function OverviewTab({
                           {/* Director Details Grid */}
                           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4">
                             {director.din && (
-                              <div className="p-3 bg-black border border-white/10 rounded-lg">
+                              <div className="p-3 bg-bg-card border border-line/10 rounded-lg">
                                 <div className="text-xs text-fg-muted mb-1">{countryConfig.labels.directorId || 'Director ID'}</div>
                                 <div className="text-fg-primary font-mono text-sm sm:text-base break-all">{director.din}</div>
                               </div>
                             )}
                             {director.pan && (
-                              <div className="p-3 bg-black border border-white/10 rounded-lg">
+                              <div className="p-3 bg-bg-card border border-line/10 rounded-lg">
                                 <div className="text-xs text-fg-muted mb-1">{countryConfig.labels.taxId}</div>
                                 <div className="text-fg-primary font-mono text-sm sm:text-base break-all">{director.pan}</div>
                               </div>
                             )}
                             {director.dob && (
-                              <div className="p-3 bg-black border border-white/10 rounded-lg">
+                              <div className="p-3 bg-bg-card border border-line/10 rounded-lg">
                                 <div className="text-xs text-fg-muted mb-1">Date of Birth</div>
                                 <div className="text-fg-primary text-sm sm:text-base">{formatDateForDisplay(director.dob)}</div>
                               </div>
                             )}
                             {director.email && (
-                              <div className="p-3 bg-black border border-white/10 rounded-lg">
+                              <div className="p-3 bg-bg-card border border-line/10 rounded-lg">
                                 <div className="text-xs text-fg-muted mb-1">Email Address</div>
                                 <div className="text-fg-primary text-sm sm:text-base break-all">{director.email}</div>
                               </div>
                             )}
                             {director.mobile && (
-                              <div className="p-3 bg-black border border-white/10 rounded-lg">
+                              <div className="p-3 bg-bg-card border border-line/10 rounded-lg">
                                 <div className="text-xs text-fg-muted mb-1">Mobile Number</div>
                                 <div className="text-fg-primary text-sm sm:text-base break-all">{director.mobile}</div>
                               </div>

--- a/app/data-room/components/ReportsTab.tsx
+++ b/app/data-room/components/ReportsTab.tsx
@@ -1053,14 +1053,14 @@ export default function ReportsTab({
   return (
     <div className="space-y-4 sm:space-y-6">
       {/* Header */}
-      <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+      <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-3 sm:mb-4">
           <h2 className="text-xl sm:text-2xl font-light text-fg-primary">Compliance Reports</h2>
           <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 sm:gap-3">
             <button
               onClick={exportPDFReport}
               disabled={isGeneratingEnhancedPDF}
-              className="px-3 sm:px-4 py-2 bg-white text-black rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base disabled:opacity-50 disabled:cursor-not-allowed"
+              className="px-3 sm:px-4 py-2 bg-accent-brand text-white rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 font-medium text-sm sm:text-base disabled:opacity-50 disabled:cursor-not-allowed"
             >
               {isGeneratingEnhancedPDF ? (
                 <>
@@ -1086,7 +1086,7 @@ export default function ReportsTab({
             </button>
             <button
               onClick={exportComplianceReport}
-              className="px-3 sm:px-4 py-2 bg-white/10 border border-white/40 text-fg-primary rounded-lg hover:bg-white/20 transition-colors flex items-center justify-center gap-2 text-sm sm:text-base"
+              className="px-3 sm:px-4 py-2 bg-bg-hover border border-line/40 text-fg-primary rounded-lg hover:bg-bg-hover transition-colors flex items-center justify-center gap-2 text-sm sm:text-base"
             >
               <svg width="14" height="14" className="sm:w-4 sm:h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
@@ -1114,7 +1114,7 @@ export default function ReportsTab({
             )}
           </div>
           {isGeneratingEnhancedPDF && (
-            <div className="mt-4 p-4 bg-white/5 border border-white/40/30 rounded-lg">
+            <div className="mt-4 p-4 bg-bg-hover border border-line/40/30 rounded-lg">
               <div className="flex items-center gap-3">
                 <svg className="animate-spin h-5 w-5 text-fg-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
@@ -1141,7 +1141,7 @@ export default function ReportsTab({
       {/* Statistics Overview */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6">
         {/* Total Compliances */}
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h3 className="text-base sm:text-lg font-medium text-fg-secondary">Total Compliances</h3>
             <div className="w-10 h-10 sm:w-12 sm:h-12 bg-blue-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -1156,7 +1156,7 @@ export default function ReportsTab({
         </div>
 
         {/* Completed */}
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h3 className="text-base sm:text-lg font-medium text-fg-secondary">Completed</h3>
             <div className="w-10 h-10 sm:w-12 sm:h-12 bg-green-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -1172,7 +1172,7 @@ export default function ReportsTab({
         </div>
 
         {/* Overdue */}
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h3 className="text-base sm:text-lg font-medium text-fg-secondary">Overdue</h3>
             <div className="w-10 h-10 sm:w-12 sm:h-12 bg-red-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -1190,7 +1190,7 @@ export default function ReportsTab({
         </div>
 
         {/* Pending */}
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h3 className="text-base sm:text-lg font-medium text-fg-secondary">Pending</h3>
             <div className="w-10 h-10 sm:w-12 sm:h-12 bg-yellow-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -1206,7 +1206,7 @@ export default function ReportsTab({
         </div>
 
         {/* Not Started */}
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h3 className="text-base sm:text-lg font-medium text-fg-secondary">Not Started</h3>
             <div className="w-10 h-10 sm:w-12 sm:h-12 bg-bg-hover/20 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -1222,7 +1222,7 @@ export default function ReportsTab({
         </div>
 
         {/* Compliance Score */}
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h3 className="text-base sm:text-lg font-medium text-fg-secondary">Compliance Score</h3>
             <div className="flex items-center gap-2">
@@ -1260,7 +1260,7 @@ export default function ReportsTab({
         </div>
 
         {/* Total Penalty */}
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h3 className="text-base sm:text-lg font-medium text-fg-secondary">Total Penalty</h3>
             <div className="w-10 h-10 sm:w-12 sm:h-12 bg-red-500/20 rounded-lg flex items-center justify-center flex-shrink-0">
@@ -1279,7 +1279,7 @@ export default function ReportsTab({
       </div>
 
       {/* Status Breakdown Chart */}
-      <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+      <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
         <h3 className="text-lg sm:text-xl font-light text-fg-primary mb-4 sm:mb-6">Status Breakdown</h3>
         <div className="space-y-3 sm:space-y-4">
           {Object.entries(statusBreakdown).map(([status, count]) => {
@@ -1313,7 +1313,7 @@ export default function ReportsTab({
       </div>
 
       {/* Category Breakdown */}
-      <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+      <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
         <h3 className="text-lg sm:text-xl font-light text-fg-primary mb-4 sm:mb-6">Category Breakdown</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
           {Object.entries(categoryBreakdown)
@@ -1321,7 +1321,7 @@ export default function ReportsTab({
             .map(([category, count]) => {
               const percentage = totalCompliances > 0 ? ((count as number) / totalCompliances) * 100 : 0
               return (
-                <div key={category} className="border border-white/10 rounded-lg p-3 sm:p-4">
+                <div key={category} className="border border-line/10 rounded-lg p-3 sm:p-4">
                   <div className="flex items-center justify-between mb-2">
                     <span className="text-fg-primary font-medium text-sm sm:text-base break-words">{category}</span>
                     <span className="text-fg-primary font-semibold text-sm sm:text-base flex-shrink-0 ml-2">{count}</span>
@@ -1340,7 +1340,7 @@ export default function ReportsTab({
       </div>
 
       {/* Compliance Type Breakdown */}
-      <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+      <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
         <h3 className="text-lg sm:text-xl font-light text-fg-primary mb-4 sm:mb-6">Compliance Type Breakdown</h3>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
           {Object.entries(complianceTypeBreakdown)
@@ -1386,7 +1386,7 @@ export default function ReportsTab({
                       <span className="text-fg-muted font-medium">{data.notStarted}</span>
                     </div>
                   </div>
-                  <div className="mt-2 sm:mt-3 pt-2 sm:pt-3 border-t border-white/10">
+                  <div className="mt-2 sm:mt-3 pt-2 sm:pt-3 border-t border-line/10">
                     <div className="flex items-center justify-between mb-1">
                       <span className="text-[10px] sm:text-xs text-fg-muted">Completion Rate</span>
                       <span className={`text-[10px] sm:text-xs font-semibold ${colors.text}`}>{Math.round(completionRate)}%</span>
@@ -1406,7 +1406,7 @@ export default function ReportsTab({
 
       {/* Financial Year Breakdown */}
       {Object.keys(fyBreakdown).length > 0 && (
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <h3 className="text-lg sm:text-xl font-light text-fg-primary mb-4 sm:mb-6">Financial Year Breakdown</h3>
           <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4">
             {Object.entries(fyBreakdown)
@@ -1420,7 +1420,7 @@ export default function ReportsTab({
                 return getYear(b) - getYear(a)
               })
               .map(([fy, count]) => (
-                <div key={fy} className="border border-white/10 rounded-lg p-3 sm:p-4 text-center">
+                <div key={fy} className="border border-line/10 rounded-lg p-3 sm:p-4 text-center">
                   <div className="text-xl sm:text-2xl font-light text-fg-primary mb-1">{count}</div>
                   <div className="text-xs sm:text-sm text-fg-muted break-words">{fy}</div>
                 </div>
@@ -1431,7 +1431,7 @@ export default function ReportsTab({
 
       {/* Overdue Compliances Detail */}
       {overdueCompliances.length > 0 && (
-        <div className="bg-black border border-white/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
+        <div className="bg-bg-card border border-line/10 rounded-xl sm:rounded-2xl p-4 sm:p-6">
           <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 sm:gap-0 mb-4 sm:mb-6">
             <h3 className="text-lg sm:text-xl font-light text-fg-primary">Overdue Compliances</h3>
             <span className="px-2 sm:px-3 py-1 bg-red-500/20 text-red-400 rounded-full text-xs sm:text-sm font-medium w-fit">
@@ -1445,7 +1445,7 @@ export default function ReportsTab({
                 const delay = calculateDelayMemoized(req.dueDate, req.status)
                 const penalty = calculatePenalty(req.penalty || '', delay, req.penalty_base_amount)
                 return (
-                  <div key={req.id} className="bg-black border border-white/10 rounded-lg p-3 space-y-2">
+                  <div key={req.id} className="bg-bg-card border border-line/10 rounded-lg p-3 space-y-2">
                     <div>
                       <div className="text-xs text-fg-muted mb-1">Category</div>
                       <div className="text-fg-primary text-sm font-medium break-words">{req.category}</div>
@@ -1483,7 +1483,7 @@ export default function ReportsTab({
             {/* Desktop Table View */}
             <table className="hidden sm:table w-full">
               <thead>
-                <tr className="border-b border-white/10">
+                <tr className="border-b border-line/10">
                   <th className="text-left py-3 px-4 text-sm font-medium text-fg-muted">Category</th>
                   <th className="text-left py-3 px-4 text-sm font-medium text-fg-muted">Requirement</th>
                   <th className="text-left py-3 px-4 text-sm font-medium text-fg-muted">Due Date</th>
@@ -1497,7 +1497,7 @@ export default function ReportsTab({
                   const delay = calculateDelay(req.dueDate, req.status)
                   const penalty = calculatePenalty(req.penalty || '', delay, req.penalty_base_amount)
                   return (
-                    <tr key={req.id} className="border-b border-white/10 hover:bg-black/50">
+                    <tr key={req.id} className="border-b border-line/10 hover:bg-black/50">
                       <td className="py-3 px-4 text-fg-primary">{req.category}</td>
                       <td className="py-3 px-4 text-fg-primary">{req.requirement}</td>
                       <td className="py-3 px-4 text-fg-muted">{req.dueDate}</td>

--- a/app/data-room/components/cia/CIAChatPanel.tsx
+++ b/app/data-room/components/cia/CIAChatPanel.tsx
@@ -143,9 +143,9 @@ export default function CIAChatPanel({ companyId, isOpen, onClose, suggestedQues
             : 'inset-y-0 right-0 w-full sm:w-[520px]'
         } ${isOpen ? 'translate-x-0' : 'translate-x-full'}`}
       >
-        <div className="flex-1 flex flex-col bg-bg-base border-l border-white/10 shadow-2xl">
+        <div className="flex-1 flex flex-col bg-bg-base border-l border-line/10 shadow-2xl">
           {/* Header */}
-          <div className="flex items-center justify-between px-4 py-3 border-b border-white/5">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-line/5">
             <div className="flex items-center gap-2.5">
               <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center">
                 <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
@@ -166,7 +166,7 @@ export default function CIAChatPanel({ companyId, isOpen, onClose, suggestedQues
                 onClick={() => setIsFullscreen(v => !v)}
                 title={isFullscreen ? 'Collapse to side panel' : 'Expand to fullscreen'}
                 aria-label={isFullscreen ? 'Collapse chat' : 'Expand chat'}
-                className="w-7 h-7 rounded-md hover:bg-white/10 flex items-center justify-center text-fg-muted hover:text-fg-primary transition-colors"
+                className="w-7 h-7 rounded-md hover:bg-bg-hover flex items-center justify-center text-fg-muted hover:text-fg-primary transition-colors"
               >
                 {isFullscreen ? (
                   <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -181,7 +181,7 @@ export default function CIAChatPanel({ companyId, isOpen, onClose, suggestedQues
               <button
                 onClick={onClose}
                 aria-label="Close chat"
-                className="w-7 h-7 rounded-md hover:bg-white/10 flex items-center justify-center text-fg-muted hover:text-fg-primary transition-colors"
+                className="w-7 h-7 rounded-md hover:bg-bg-hover flex items-center justify-center text-fg-muted hover:text-fg-primary transition-colors"
               >
                 <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
                   <path d="M3 3l8 8M11 3l-8 8" />

--- a/app/data-room/components/cia/CIAInput.tsx
+++ b/app/data-room/components/cia/CIAInput.tsx
@@ -49,7 +49,7 @@ export default function CIAInput({ onSend, onStop, onAttach, isStreaming, disabl
               key={i}
               onClick={() => onSend(q)}
               disabled={isStreaming || disabled}
-              className="text-xs px-3 py-1.5 rounded-full bg-white/5 border border-white/10 text-fg-secondary hover:bg-white/10 hover:border-white/20 transition-all duration-200 disabled:opacity-40"
+              className="text-xs px-3 py-1.5 rounded-full bg-bg-hover border border-line/10 text-fg-secondary hover:bg-bg-hover hover:border-line/20 transition-all duration-200 disabled:opacity-40"
             >
               {q}
             </button>
@@ -58,12 +58,12 @@ export default function CIAInput({ onSend, onStop, onAttach, isStreaming, disabl
       )}
 
       {/* Input area */}
-      <div className="relative flex items-end gap-2 bg-white/5 border border-white/10 rounded-xl px-3 py-2 focus-within:border-blue-500/40 transition-colors">
+      <div className="relative flex items-end gap-2 bg-bg-hover border border-line/10 rounded-xl px-3 py-2 focus-within:border-blue-500/40 transition-colors">
         {onAttach && (
           <button
             onClick={onAttach}
             disabled={isStreaming || disabled}
-            className="flex-shrink-0 w-8 h-8 rounded-lg bg-white/5 text-fg-muted hover:bg-white/10 hover:text-fg-primary flex items-center justify-center transition-colors disabled:opacity-30 mb-0.5"
+            className="flex-shrink-0 w-8 h-8 rounded-lg bg-bg-hover text-fg-muted hover:bg-bg-hover hover:text-fg-primary flex items-center justify-center transition-colors disabled:opacity-30 mb-0.5"
             title="Upload a document"
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">

--- a/app/data-room/components/cia/CIASidebar.tsx
+++ b/app/data-room/components/cia/CIASidebar.tsx
@@ -57,8 +57,8 @@ function ConversationItem({
       onMouseLeave={() => setShowDelete(false)}
       className={`w-full text-left px-3 py-2 rounded-lg text-sm truncate transition-all duration-150 group relative ${
         isActive
-          ? 'bg-white/10 text-fg-primary'
-          : 'text-fg-muted hover:bg-white/5 hover:text-fg-secondary'
+          ? 'bg-bg-hover text-fg-primary'
+          : 'text-fg-muted hover:bg-bg-hover hover:text-fg-secondary'
       }`}
     >
       <span className="truncate block pr-5">{displayName}</span>
@@ -82,12 +82,12 @@ function ConversationItem({
 
 export default function CIASidebar({ conversations, activeId, onSelect, onNew, onDelete }: Props) {
   return (
-    <div className="w-[160px] flex-shrink-0 border-r border-white/5 flex flex-col h-full">
+    <div className="w-[160px] flex-shrink-0 border-r border-line/5 flex flex-col h-full">
       {/* New Chat button */}
       <div className="p-2">
         <button
           onClick={onNew}
-          className="w-full flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm text-fg-secondary bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 transition-all"
+          className="w-full flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm text-fg-secondary bg-bg-hover hover:bg-bg-hover border border-line/10 hover:border-line/20 transition-all"
         >
           <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
             <path d="M6 2v8M2 6h8" />

--- a/app/data-room/components/tracker/ComplianceIntakeForm.tsx
+++ b/app/data-room/components/tracker/ComplianceIntakeForm.tsx
@@ -337,7 +337,7 @@ export default function ComplianceIntakeForm({ companyId, financialYear, initial
         <button
           onClick={handleSubmit}
           disabled={saving}
-          className="px-6 py-2.5 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated disabled:opacity-50"
+          className="px-6 py-2.5 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated disabled:opacity-50"
         >
           {saving ? 'Saving...' : 'Save & generate tracker'}
         </button>
@@ -360,14 +360,14 @@ function Question({ label, value, onChange, hint }: {
         <button
           type="button"
           onClick={() => onChange(true)}
-          className={`px-4 py-1.5 rounded text-sm transition-colors ${value === true ? 'bg-white text-black' : 'bg-bg-elevated text-fg-muted hover:text-fg-primary'}`}
+          className={`px-4 py-1.5 rounded text-sm transition-colors ${value === true ? 'bg-accent-brand text-white' : 'bg-bg-elevated text-fg-muted hover:text-fg-primary'}`}
         >
           Yes
         </button>
         <button
           type="button"
           onClick={() => onChange(false)}
-          className={`px-4 py-1.5 rounded text-sm transition-colors ${value === false ? 'bg-white text-black' : 'bg-bg-elevated text-fg-muted hover:text-fg-primary'}`}
+          className={`px-4 py-1.5 rounded text-sm transition-colors ${value === false ? 'bg-accent-brand text-white' : 'bg-bg-elevated text-fg-muted hover:text-fg-primary'}`}
         >
           No
         </button>

--- a/app/data-room/components/tracker/RequirementDesktopTableView.tsx
+++ b/app/data-room/components/tracker/RequirementDesktopTableView.tsx
@@ -193,7 +193,7 @@ export default function RequirementDesktopTableView({
 
   return (
     <table className="hidden sm:table w-full">
-      <thead className="bg-black border-b border-white/10">
+      <thead className="bg-black border-b border-line/10">
         <tr>
           {canEdit && (
             <th className="px-4 py-4 text-left text-xs font-medium text-fg-muted uppercase tracking-wider w-12">
@@ -275,7 +275,7 @@ export default function RequirementDesktopTableView({
               const authority = getAuthorityForCategory(req.category)
 
               return (
-                <tr key={`${group.category}-${req.id}-${itemIndex}`} className="hover:bg-black/50 transition-colors border-t border-white/10">
+                <tr key={`${group.category}-${req.id}-${itemIndex}`} className="hover:bg-black/50 transition-colors border-t border-line/10">
                   {canEdit && (
                     <td className="px-4 py-4">
                       <input
@@ -349,7 +349,7 @@ export default function RequirementDesktopTableView({
                                 ? 'bg-yellow-500/10 text-yellow-400/90 hover:bg-yellow-500/20'
                                 : req.status === 'upcoming'
                                   ? 'bg-blue-500/10 text-blue-400/90 hover:bg-blue-500/20'
-                                  : 'bg-white/5 text-fg-muted hover:bg-white/10'
+                                  : 'bg-bg-hover text-fg-muted hover:bg-bg-hover'
                           }`}
                         style={{
                           appearance: 'none',
@@ -375,7 +375,7 @@ export default function RequirementDesktopTableView({
                                 ? 'bg-yellow-500/10 text-yellow-400/90'
                                 : req.status === 'upcoming'
                                   ? 'bg-blue-500/10 text-blue-400/90'
-                                  : 'bg-white/5 text-fg-muted'
+                                  : 'bg-bg-hover text-fg-muted'
                           }`}
                       >
                         {req.status === 'completed'
@@ -633,7 +633,7 @@ export default function RequirementDesktopTableView({
                                 value={inputVal}
                                 onChange={e => setBaseAmountInputs(prev => ({ ...prev, [req.id]: e.target.value }))}
                                 placeholder="e.g. 50000"
-                                className="w-24 px-2 py-1 text-xs bg-bg-elevated border border-line/30 rounded text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/40"
+                                className="w-24 px-2 py-1 text-xs bg-bg-elevated border border-line/30 rounded text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/40"
                                 onKeyDown={async e => {
                                   if (e.key === 'Enter') {
                                     const amount = parseFloat(inputVal)
@@ -941,8 +941,8 @@ function AmountInputCell({
         focused
           ? 'border-blue-400/60 bg-bg-card/80 text-fg-primary'
           : value != null
-            ? 'border-white/10 text-fg-primary hover:border-white/25'
-            : 'border-dashed border-white/10 text-fg-muted hover:border-white/25 hover:text-fg-secondary'
+            ? 'border-line/10 text-fg-primary hover:border-line/25'
+            : 'border-dashed border-line/10 text-fg-muted hover:border-line/25 hover:text-fg-secondary'
       }`}
     />
   )

--- a/app/data-room/components/tracker/RequirementFormModal.tsx
+++ b/app/data-room/components/tracker/RequirementFormModal.tsx
@@ -193,14 +193,14 @@ export default function RequirementFormModal({
   }
 
   const inputClass =
-    'w-full px-4 py-3 bg-black border border-white/20 rounded-lg text-fg-primary focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors'
+    'w-full px-4 py-3 bg-black border border-line/20 rounded-lg text-fg-primary focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors'
   const labelClass = 'block text-sm font-medium text-fg-secondary mb-2'
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm">
       <div className="bg-bg-card border border-line/10 rounded-2xl shadow-2xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
         {/* Header */}
-        <div className="p-6 border-b border-white/10">
+        <div className="p-6 border-b border-line/10">
           <div className="flex items-center justify-between">
             <h3 className="text-2xl font-light text-fg-primary">
               {isEdit ? 'Edit Compliance Requirement' : 'Create Compliance Requirement'}
@@ -342,7 +342,7 @@ export default function RequirementFormModal({
           </div>
 
           {/* ── Penalty Calculator (structured config) ───────────────────────── */}
-          <div className="border border-white/10 rounded-xl p-4 space-y-4 bg-white/[0.02]">
+          <div className="border border-line/10 rounded-xl p-4 space-y-4 bg-white/[0.02]">
             <div className="flex items-center gap-2 mb-1">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="text-yellow-400">
                 <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
@@ -509,7 +509,7 @@ export default function RequirementFormModal({
                     }))
                   }
                 }}
-                className="flex-1 px-4 py-2 bg-black border border-white/20 rounded-lg text-fg-primary focus:outline-none focus:border-white/40 focus:ring-1 focus:ring-white/40 transition-colors"
+                className="flex-1 px-4 py-2 bg-black border border-line/20 rounded-lg text-fg-primary focus:outline-none focus:border-line/40 focus:ring-1 focus:ring-white/40 transition-colors"
                 placeholder="Type document name and press Enter or Add"
               />
               <button
@@ -523,7 +523,7 @@ export default function RequirementFormModal({
                     }))
                   }
                 }}
-                className="px-4 py-2 bg-white/10 text-fg-primary rounded-lg hover:bg-white/20 transition-colors text-sm"
+                className="px-4 py-2 bg-bg-hover text-fg-primary rounded-lg hover:bg-bg-hover transition-colors text-sm"
               >
                 Add
               </button>
@@ -585,7 +585,7 @@ export default function RequirementFormModal({
           <div className="flex items-center gap-3 pt-2">
             <button
               onClick={handleSubmit}
-              className="flex-1 bg-white text-black px-6 py-3 rounded-lg hover:bg-bg-elevated transition-colors font-medium"
+              className="flex-1 bg-accent-brand text-white px-6 py-3 rounded-lg hover:bg-bg-elevated transition-colors font-medium"
             >
               {isEdit ? 'Update' : 'Create'}
             </button>

--- a/app/data-room/components/vault/ReviewIngestModal.tsx
+++ b/app/data-room/components/vault/ReviewIngestModal.tsx
@@ -105,11 +105,11 @@ export default function ReviewIngestModal({ companyId, documentId, onClose, onLi
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm" onClick={onClose}>
       <div
-        className="bg-[#0e0e0e] border border-white/10 rounded-2xl w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl"
+        className="bg-[#0e0e0e] border border-line/10 rounded-2xl w-full max-w-2xl max-h-[85vh] flex flex-col shadow-2xl"
         onClick={e => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="px-6 py-4 border-b border-white/10 flex items-start justify-between gap-4">
+        <div className="px-6 py-4 border-b border-line/10 flex items-start justify-between gap-4">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 mb-1">
               <span className="text-[10px] uppercase tracking-wider text-yellow-400">Review pending</span>
@@ -146,20 +146,20 @@ export default function ReviewIngestModal({ companyId, documentId, onClose, onLi
 
         {/* Reasoning (collapsible if long) */}
         {agent?.reasoning && (
-          <div className="px-6 py-3 border-b border-white/5 text-[12px] text-fg-muted bg-white/[0.02]">
+          <div className="px-6 py-3 border-b border-line/5 text-[12px] text-fg-muted bg-white/[0.02]">
             <span className="text-fg-muted">Reasoning: </span>
             {agent.reasoning}
           </div>
         )}
 
         {/* Search */}
-        <div className="px-6 py-3 border-b border-white/5">
+        <div className="px-6 py-3 border-b border-line/5">
           <input
             type="text"
             value={search}
             onChange={e => setSearch(e.target.value)}
             placeholder="Filter requirements…"
-            className="w-full px-3 py-2 bg-black border border-white/10 rounded-lg text-sm text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-white/30"
+            className="w-full px-3 py-2 bg-bg-card border border-line/10 rounded-lg text-sm text-fg-primary placeholder:text-fg-muted focus:outline-none focus:border-line/30"
           />
         </div>
 
@@ -187,7 +187,7 @@ export default function ReviewIngestModal({ companyId, documentId, onClose, onLi
                       className={`w-full text-left px-4 py-2.5 rounded-lg border transition-colors ${
                         picked
                           ? 'bg-blue-500/10 border-blue-500/40'
-                          : 'border-transparent hover:bg-white/[0.04] hover:border-white/10'
+                          : 'border-transparent hover:bg-white/[0.04] hover:border-line/10'
                       }`}
                     >
                       <div className="flex items-start gap-3">
@@ -217,21 +217,21 @@ export default function ReviewIngestModal({ companyId, documentId, onClose, onLi
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-3 border-t border-white/10 flex items-center justify-between gap-3">
+        <div className="px-6 py-3 border-t border-line/10 flex items-center justify-between gap-3">
           <span className="text-[11px] text-fg-muted">
             {pickedId ? 'Press Save to link this document.' : 'Pick a requirement to link this document to.'}
           </span>
           <div className="flex items-center gap-2">
             <button
               onClick={onClose}
-              className="px-3 py-1.5 text-xs rounded-lg border border-white/10 text-fg-secondary hover:bg-white/5"
+              className="px-3 py-1.5 text-xs rounded-lg border border-line/10 text-fg-secondary hover:bg-bg-hover"
             >
               Cancel
             </button>
             <button
               onClick={onSave}
               disabled={!pickedId || linking}
-              className="px-4 py-1.5 text-xs rounded-lg bg-white text-black hover:bg-bg-elevated disabled:opacity-40 disabled:cursor-not-allowed"
+              className="px-4 py-1.5 text-xs rounded-lg bg-accent-brand text-white hover:bg-bg-elevated disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {linking ? 'Linking…' : 'Link'}
             </button>

--- a/app/data-room/components/vault/VaultTreeView.tsx
+++ b/app/data-room/components/vault/VaultTreeView.tsx
@@ -390,7 +390,7 @@ export default function VaultTreeView({ companyId, canEdit, onUploadToFolder, on
           {selected.size > 0 && (
             <button
               onClick={clearSelection}
-              className="text-[11px] px-2.5 py-1 border border-white/10 text-fg-muted rounded hover:text-fg-primary hover:border-white/20"
+              className="text-[11px] px-2.5 py-1 border border-line/10 text-fg-muted rounded hover:text-fg-primary hover:border-line/20"
             >
               Clear
             </button>
@@ -398,7 +398,7 @@ export default function VaultTreeView({ companyId, canEdit, onUploadToFolder, on
           {canEdit && (
             <button
               onClick={() => handleCreateFolder(null)}
-              className="text-[11px] px-2.5 py-1 border border-white/10 text-fg-secondary rounded hover:text-fg-primary hover:border-white/20"
+              className="text-[11px] px-2.5 py-1 border border-line/10 text-fg-secondary rounded hover:text-fg-primary hover:border-line/20"
             >
               + New folder
             </button>
@@ -532,7 +532,7 @@ function FolderNode({
 
   const depthPadding = depth === 0 ? '' : `pl-${Math.min(depth * 4, 16)}`
   const bgColor = depth === 0 ? 'bg-bg-card/40' : 'bg-bg-card/20'
-  const borderColor = depth === 0 ? 'border-white/10' : 'border-white/5'
+  const borderColor = depth === 0 ? 'border-line/10' : 'border-line/5'
 
   return (
     <div className={`border ${borderColor} rounded-lg ${bgColor} overflow-hidden`} style={{ marginLeft: depth > 0 ? `${depth * 16}px` : 0 }}>
@@ -595,7 +595,7 @@ function FolderNode({
 
       {/* Expanded contents */}
       {isExpanded && (
-        <div className="border-t border-white/5">
+        <div className="border-t border-line/5">
           {docs.length > 0 && (
             <div className="divide-y divide-white/[0.03]">
               {docs.map(doc => (
@@ -819,41 +819,41 @@ function DocActionsMenu({
         <>
           <div className="fixed inset-0 z-40" onClick={onClose} />
           <div
-            className="fixed z-50 w-44 bg-bg-card border border-white/10 rounded-lg shadow-2xl py-1 text-xs"
+            className="fixed z-50 w-44 bg-bg-card border border-line/10 rounded-lg shadow-2xl py-1 text-xs"
             style={{ top: coords.top, right: coords.right }}
             onClick={(e) => e.stopPropagation()}
           >
             <button
               onClick={() => { onClose(); openDocumentInTab(companyId, doc.id) }}
-              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-white/5"
+              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-bg-hover"
             >
               View document
             </button>
-            <div className="h-px bg-white/5 my-1" />
+            <div className="h-px bg-bg-hover my-1" />
             {onUploadNewVersion && (
               <button
                 onClick={() => { onClose(); onUploadNewVersion(doc) }}
-                className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-white/5"
+                className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-bg-hover"
               >
                 Upload new version
               </button>
             )}
             <button
               onClick={() => { onClose(); onShowVersions(doc) }}
-              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-white/5"
+              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-bg-hover"
             >
               Version history
             </button>
-            <div className="h-px bg-white/5 my-1" />
+            <div className="h-px bg-bg-hover my-1" />
             <button
               onClick={() => { onClose(); onRename(doc) }}
-              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-white/5"
+              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-bg-hover"
             >
               Rename
             </button>
             <button
               onClick={() => { onClose(); onMove(doc) }}
-              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-white/5"
+              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-bg-hover"
             >
               Move to…
             </button>
@@ -914,13 +914,13 @@ function FolderActionsMenu({
         <>
           <div className="fixed inset-0 z-40" onClick={onClose} />
           <div
-            className="fixed z-50 w-44 bg-bg-card border border-white/10 rounded-lg shadow-2xl py-1 text-xs"
+            className="fixed z-50 w-44 bg-bg-card border border-line/10 rounded-lg shadow-2xl py-1 text-xs"
             style={{ top: coords.top, right: coords.right }}
             onClick={(e) => e.stopPropagation()}
           >
             <button
               onClick={() => { onClose(); onCreateSubfolder(folder.id) }}
-              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-white/5"
+              className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-bg-hover"
             >
               + New sub-folder
             </button>
@@ -928,7 +928,7 @@ function FolderActionsMenu({
               <>
                 <button
                   onClick={() => { onClose(); onRenameFolder(folder) }}
-                  className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-white/5"
+                  className="w-full text-left px-3 py-1.5 text-fg-secondary hover:bg-bg-hover"
                 >
                   Rename
                 </button>
@@ -980,7 +980,7 @@ function IngestChip({ ingest, onReview }: { ingest: IngestStatus | null; onRevie
   if (status === 'pending') {
     return (
       <span
-        className="text-[10px] px-1.5 py-0.5 rounded bg-white/5 text-fg-muted flex-shrink-0"
+        className="text-[10px] px-1.5 py-0.5 rounded bg-bg-hover text-fg-muted flex-shrink-0"
         title="Queued for AI extraction"
       >
         Queued

--- a/app/data-room/components/vault/VersionHistoryModal.tsx
+++ b/app/data-room/components/vault/VersionHistoryModal.tsx
@@ -80,7 +80,7 @@ export default function VersionHistoryModal({ isOpen, onClose, companyId, docume
                       ? 'bg-emerald-500/[0.05] border-emerald-500/20'
                       : v.deletedAt
                         ? 'bg-red-500/[0.03] border-red-500/10 opacity-60'
-                        : 'bg-white/[0.02] border-white/10'
+                        : 'bg-white/[0.02] border-line/10'
                   }`}
                 >
                   <div className="flex items-center justify-between gap-3">
@@ -114,7 +114,7 @@ export default function VersionHistoryModal({ isOpen, onClose, companyId, docume
           <button onClick={onClose} className="text-sm text-fg-muted hover:text-fg-primary">Close</button>
           <button
             onClick={() => { onClose(); onUploadNewVersion() }}
-            className="px-4 py-2 bg-white text-black rounded-lg text-sm font-medium hover:bg-bg-elevated"
+            className="px-4 py-2 bg-accent-brand text-white rounded-lg text-sm font-medium hover:bg-bg-elevated"
           >
             Upload new version
           </button>

--- a/app/data-room/error.tsx
+++ b/app/data-room/error.tsx
@@ -37,7 +37,7 @@ export default function DataRoomError({
           </button>
           <Link
             href="/"
-            className="px-6 py-2.5 rounded-xl border border-white/10 hover:bg-white/5 text-fg-secondary text-sm font-medium transition-colors"
+            className="px-6 py-2.5 rounded-xl border border-line/10 hover:bg-bg-hover text-fg-secondary text-sm font-medium transition-colors"
           >
             Go to Home
           </Link>

--- a/app/data-room/page.tsx
+++ b/app/data-room/page.tsx
@@ -3951,7 +3951,7 @@ function DataRoomPageInner() {
           <p className="text-fg-muted text-sm mb-6">{initError}</p>
           <button
             onClick={() => window.location.reload()}
-            className="px-6 py-2 bg-white text-black rounded-lg hover:bg-bg-elevated"
+            className="px-6 py-2 bg-accent-brand text-white rounded-lg hover:bg-bg-elevated"
           >
             Retry
           </button>
@@ -3967,7 +3967,7 @@ function DataRoomPageInner() {
       <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="text-center max-w-md px-4">
           <div className="relative mb-6">
-            <div className="w-12 h-12 border-4 border-white/30 border-t-transparent rounded-full animate-spin mx-auto" />
+            <div className="w-12 h-12 border-4 border-line/30 border-t-transparent rounded-full animate-spin mx-auto" />
             <div className="absolute inset-0 flex items-center justify-center">
               <div className="w-6 h-6 bg-gradient-to-br from-blue-500/30 to-purple-500/30 rounded-full animate-pulse" />
             </div>
@@ -3989,7 +3989,7 @@ function DataRoomPageInner() {
       <div className="min-h-screen bg-bg-base flex items-center justify-center">
         <div className="text-center max-w-md px-4">
           <div className="relative mb-6">
-            <div className="w-12 h-12 border-4 border-white/30 border-t-transparent rounded-full animate-spin mx-auto" />
+            <div className="w-12 h-12 border-4 border-line/30 border-t-transparent rounded-full animate-spin mx-auto" />
             <div className="absolute inset-0 flex items-center justify-center">
               <div className="w-6 h-6 bg-gradient-to-br from-blue-500/30 to-purple-500/30 rounded-full animate-pulse" />
             </div>
@@ -4277,7 +4277,7 @@ function DataRoomPageInner() {
           <Suspense
             fallback={
               <div className="flex items-center justify-center p-8">
-                <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+                <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
               </div>
             }
           >
@@ -4297,7 +4297,7 @@ function DataRoomPageInner() {
           <Suspense
             fallback={
               <div className="flex items-center justify-center p-8">
-                <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+                <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
               </div>
             }
           >
@@ -4327,7 +4327,7 @@ function DataRoomPageInner() {
           <Suspense
             fallback={
               <div className="flex items-center justify-center p-8">
-                <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+                <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
               </div>
             }
           >
@@ -4443,9 +4443,9 @@ function DataRoomPageInner() {
 
             return (
               <div className="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/60 backdrop-blur-sm">
-                <div className="bg-black border border-white/10 rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-y-auto">
+                <div className="bg-bg-card border border-line/10 rounded-2xl shadow-2xl w-full max-w-3xl max-h-[90vh] overflow-y-auto">
                   {/* Modal Header */}
-                  <div className="sticky top-0 bg-black border-b border-white/10 p-6 flex items-center justify-between z-10">
+                  <div className="sticky top-0 bg-black border-b border-line/10 p-6 flex items-center justify-between z-10">
                     <div>
                       <h2 className="text-2xl font-light text-fg-primary mb-1">
                         Compliance Details
@@ -4654,10 +4654,10 @@ function DataRoomPageInner() {
                   </div>
 
                   {/* Modal Footer */}
-                  <div className="sticky bottom-0 bg-black border-t border-white/10 p-6 flex items-center justify-end">
+                  <div className="sticky bottom-0 bg-black border-t border-line/10 p-6 flex items-center justify-end">
                     <button
                       onClick={() => setComplianceDetailsModal(null)}
-                      className="px-6 py-2.5 bg-white text-black rounded-lg hover:bg-bg-elevated transition-colors"
+                      className="px-6 py-2.5 bg-accent-brand text-white rounded-lg hover:bg-bg-elevated transition-colors"
                     >
                       Close
                     </button>
@@ -4671,7 +4671,7 @@ function DataRoomPageInner() {
           <Suspense
             fallback={
               <div className="flex items-center justify-center p-8">
-                <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+                <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
               </div>
             }
           >
@@ -4729,7 +4729,7 @@ function DataRoomPageInner() {
             <Suspense
               fallback={
                 <div className="flex items-center justify-center p-8">
-                  <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+                  <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
                 </div>
               }
             >
@@ -4742,7 +4742,7 @@ function DataRoomPageInner() {
           <Suspense
             fallback={
               <div className="flex items-center justify-center p-8">
-                <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+                <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
               </div>
             }
           >
@@ -4754,7 +4754,7 @@ function DataRoomPageInner() {
           <Suspense
             fallback={
               <div className="flex items-center justify-center p-8">
-                <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+                <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
               </div>
             }
           >
@@ -4836,7 +4836,7 @@ export default function DataRoomPage() {
     <Suspense
       fallback={
         <div className="flex items-center justify-center min-h-screen">
-          <div className="w-8 h-8 border-2 border-white/40 border-t-transparent rounded-full animate-spin" />
+          <div className="w-8 h-8 border-2 border-line/40 border-t-transparent rounded-full animate-spin" />
         </div>
       }
     >

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -37,7 +37,7 @@ export default function GlobalError({
           </button>
           <Link
             href="/data-room"
-            className="px-6 py-2.5 rounded-xl border border-white/10 hover:bg-white/5 text-fg-secondary text-sm font-medium transition-colors"
+            className="px-6 py-2.5 rounded-xl border border-line/10 hover:bg-bg-hover text-fg-secondary text-sm font-medium transition-colors"
           >
             Go to Dashboard
           </Link>

--- a/app/onboarding/error.tsx
+++ b/app/onboarding/error.tsx
@@ -37,7 +37,7 @@ export default function OnboardingError({
           </button>
           <Link
             href="/"
-            className="px-6 py-2.5 rounded-xl border border-white/10 hover:bg-white/5 text-fg-secondary text-sm font-medium transition-colors"
+            className="px-6 py-2.5 rounded-xl border border-line/10 hover:bg-bg-hover text-fg-secondary text-sm font-medium transition-colors"
           >
             Go to Home
           </Link>

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -39,7 +39,7 @@ export function ConfirmDialog({
       />
 
       {/* Dialog */}
-      <div className="relative bg-[#151515] border border-white/10 rounded-2xl shadow-2xl max-w-md w-full p-6 flex flex-col gap-4">
+      <div className="relative bg-[#151515] border border-line/10 rounded-2xl shadow-2xl max-w-md w-full p-6 flex flex-col gap-4">
         {/* Icon */}
         <div className={`w-12 h-12 rounded-full flex items-center justify-center mx-auto ${variant === 'danger' ? 'bg-red-500/10' : 'bg-[#1E3A5F]/20'}`}>
           {variant === 'danger' ? (
@@ -61,7 +61,7 @@ export function ConfirmDialog({
         <div className="flex gap-3 mt-2">
           <button
             onClick={onCancel}
-            className="flex-1 px-4 py-2.5 rounded-xl border border-white/10 text-fg-secondary hover:bg-white/5 transition-colors text-sm font-medium"
+            className="flex-1 px-4 py-2.5 rounded-xl border border-line/10 text-fg-secondary hover:bg-bg-hover transition-colors text-sm font-medium"
           >
             {cancelLabel}
           </button>


### PR DESCRIPTION
## Summary

Following PR-29 (which fixed `bg-primary-dark` wrappers + `primary-orange` brand sweep), this is the cleanup pass for remaining hard-coded white/black patterns that broke light-mode visibility.

## Changes

1. **Solid white CTA buttons** (`bg-white text-black`) — used in upload modals and action paths. In dark mode these read as white-pill-with-dark-text (intentional), but in **light mode they vanish into the white card background**. Swept to `bg-accent-brand text-white` (the indigo brand primary), matching every other primary CTA in the app since PR-13.

2. **Broken double-slash class** `hover:border-white/40/50` → `hover:border-line/40`. Tailwind silently drops the malformed class — was a stale typo from pre-token days.

3. **`bg-black border-white/10` cards** (inset wells / dropzones) → `bg-bg-card border-line/10` — themable, reads correctly against light bg.

4. **Alpha-layered classes:**
   - `bg-white/<N>` → `bg-bg-hover` (hover/pressed transparency layers)
   - `hover:bg-white/<N>` → `hover:bg-bg-hover`
   - `border-white/<N>` → `border-line/<N>` (preserves alpha tier)

## Intentionally NOT swept

**Modal backdrops** (`bg-black/70` and similar). They should stay dark in both themes (Apple/Stripe convention) so modal content pops on either background. Token semantics break here — `bg-fg-primary/X` would invert per theme; `bg-fg-inverse/X` would too. Hard-coded dark backdrop is the right answer.

## Functional safety
- 26 files, 225 ins / 225 del — pure 1:1 substitution.
- No state, handler, server-action, or hook signature changes.
- `tsc --noEmit` clean.

## Branch hygiene
- Branched off `origin/main` after PR #109.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)