### PR TITLE
feat(ocr): handle word-format dates + expand entity-fact extraction for COI/MOA/AOA

### DIFF
--- a/lib/compliance/document-agent.ts
+++ b/lib/compliance/document-agent.ts
@@ -6,6 +6,19 @@ import { getRulesInForce, fyPeriod } from './catalogue'
 import { currentIndianFY } from './facts'
 import { processDocumentContent } from '@/lib/utils/document-processor'
 import { applyGuardrails } from './agent-guardrails'
+import { normalizeWordDate } from '@/lib/utils/normalize-word-date'
+
+// Entity documents (COI / MOA / AOA / Share Cert / LLP Agreement) carry
+// far more structured content than monthly returns — directors, share
+// classes, object clauses — so they get a higher token ceiling and a
+// larger input window. Detected by keyword presence in the first ~2k
+// chars (header / title region).
+const ENTITY_DOC_PATTERNS =
+  /\b(memorandum of association|articles of association|certificate of incorporation|share certificate|llp agreement|incorporation certificate)\b/i
+
+function isEntityDoc(rawText: string): boolean {
+  return ENTITY_DOC_PATTERNS.test(rawText.slice(0, 2000))
+}
 
 /**
  * Document Intelligence Agent — v1
@@ -166,10 +179,20 @@ If unsure, pick the BEST match and return confidence 0.6 — do NOT invent a fol
 FIELD COMPLETION RULES — fill EVERY field, think holistically:
 - periodKey: for annual filings use the FY label (e.g., "2024-25"); for quarterly
   use "YYYY-Q1" through "Q4"; for monthly use "YYYY-MM".
+- DATE FORMAT — every date field MUST be strict ISO YYYY-MM-DD:
+  * If a date appears in WORDS ("Twenty-Fifth day of March, Two Thousand
+    Twenty-Three", "the 5th day of November 2024"), CONVERT it to YYYY-MM-DD.
+    Never return word-format dates.
+  * Numeric formats on Indian documents are DD/MM/YYYY (NOT US MM/DD/YYYY).
+    "05/03/2024" means 5 March 2024 → "2024-03-05".
+  * "DD-Mon-YYYY" / "DD Month YYYY" → convert ("25-Mar-2023" → "2023-03-25").
+  * If only month + year given ("March 2024"), use the 1st → "2024-03-01".
+  * If only year given ("2024"), use Jan 1 → "2024-01-01".
 - registrationDate: the date the document was FILED / signed / issued / stamped.
   Look for: MCA filing date, SRN date, digital signature date, "Date of filing",
-  "Date of signing", acknowledgement date, certificate issue date. If absent,
-  use the document's creation date or the earliest date mentioned.
+  "Date of signing", acknowledgement date, certificate issue date, or for COI
+  the "dated this Nth day of <Month> <Year>" line. If absent, use the document's
+  creation date or the earliest date mentioned.
 - expiryDate: when this document's validity or compliance window ENDS. Rules:
   * For annual compliances (MGT-7/7A, AOC-4, DIR-KYC, ITR, tax audit, GSTR-9):
     one day before the next year's due date.
@@ -195,20 +218,68 @@ the same kinds used elsewhere. Permitted kinds:
     rent.monthly_payment, contractor.annual_spend, salary.annual_bill,
     headcount.total, turnover.annual, gst.registered_state,
     director.remuneration, imports.annual_value, exports.annual_value
-  Entity facts (PAN/GST/COI/MOA cert OCR — populate from the cert
-  itself, not the prompt context):
-    entity.pan                — PAN string (10 chars), payload: { value: "ABCPK1234R" }
-    entity.gstn               — GSTN string (15 chars), payload: { value: "29AABCX1234R1ZM" }
-    entity.cin                — CIN string (21 chars), payload: { value: "U72200KA2019PTC123456" }
-    entity.tan                — TAN string (10 chars), payload: { value: "BLRA12345A" }
+  Entity facts (PAN/GST/COI/MOA/AOA OCR — populate from the document
+  itself, not the prompt context). For COI/MOA/AOA, extract EVERY
+  field present — directors, shareholders, capital, addresses, objects.
+  Identifiers:
+    entity.pan                — payload: { value: "ABCPK1234R" }       (10 chars)
+    entity.gstn               — payload: { value: "29AABCX1234R1ZM" } (15 chars)
+    entity.cin                — payload: { value: "U72200KA2019PTC123456" } (21 chars)
+    entity.tan                — payload: { value: "BLRA12345A" }      (10 chars)
+    entity.llpin              — payload: { value: "AAB-1234" }        (LLPs only)
+  Dates and capital:
     entity.incorporation_date — periodStart = the date itself, payload: {}
     entity.authorized_capital — amount in rupees, unit: "rupees", payload: {}
     entity.paid_up_capital    — amount in rupees, unit: "rupees", payload: {}
+    entity.face_value         — amount in rupees per share, unit: "rupees_per_share",
+                                payload: { share_class: "equity" | "preference" }
+    entity.share_capital_breakdown — payload: { class, total_shares, face_value, voting_rights }
+                                   (one fact per share class)
+  Address and contact:
+    entity.registered_office_address — payload: { value: "<full address>",
+                                                  state: "Karnataka",
+                                                  city: "Bengaluru",
+                                                  pincode: "560001" }
     entity.registered_state   — payload: { value: "Karnataka" }
+    entity.email              — payload: { value: "info@example.com" }
+    entity.phone              — payload: { value: "+91-80-12345678" }
+    entity.website            — payload: { value: "https://example.com" }
+  Governance — emit ONE fact per person (don't bundle into arrays):
+    entity.director           — payload: { name, din,
+                                          designation: "Director" | "Managing Director"
+                                                      | "Whole-time Director" | "Independent Director"
+                                                      | "Nominee Director",
+                                          appointed_on: "YYYY-MM-DD" | null,
+                                          is_independent: boolean,
+                                          nationality: "Indian" | string }
+    entity.shareholder        — payload: { name,
+                                          holding_pct: number | null,
+                                          share_count: number | null,
+                                          share_class: "equity" | "preference",
+                                          pan: string | null,
+                                          relation: "promoter" | "non-promoter" | null }
+    entity.subscriber         — payload: { name, share_count, address }
+                                (MOA subscribers — original incorporators)
+    entity.signatory          — payload: { name, role, signed_on: "YYYY-MM-DD" | null }
+                                (people who actually signed the document)
+  Constitutional content (MOA / AOA):
+    entity.main_object        — payload: { value: "<object clause text>",
+                                          clause_no: "III(A)(1)" | null }
+                                (one fact per object — emit all of them)
+    entity.ancillary_object   — payload: { value: "<text>", clause_no }
+                                (Object Clause III(B), things "necessary for attaining the main objects")
+    entity.other_object       — payload: { value, clause_no }
+                                (Object Clause III(C) on older MOAs)
+    entity.aoa_clause         — payload: { value: "<full clause text>",
+                                          clause_no: "12(a)" | null,
+                                          topic: "share-transfer" | "board-meetings" | "voting" | string }
+                                (only emit material clauses — share transfer, voting, borrowing limits)
 For entity.* facts that aren't period-bound, set periodStart and periodEnd
 to the document's registrationDate (or today if absent). Don't fabricate
-entity facts — only emit when the document literally contains them.
-Return { ..., "facts": [] } if nothing extractable.`
+entity facts — only emit when the document literally contains them. For
+COI/MOA/AOA: aim for completeness — emit every director, every subscriber,
+every main object you can find. Return { ..., "facts": [] } only if NOTHING
+is extractable.`
 
 function rulesForPrompt(rules: Awaited<ReturnType<typeof getRulesInForce>>): string {
   // Compact listing — enough for the model to map docs to rules without
@@ -236,7 +307,13 @@ export async function analyzeDocument(options: {
     errors.push('no_text_available')
     return { suggestion: null, errors }
   }
-  const truncated = text.length > 24000 ? text.slice(0, 24000) : text
+
+  // Entity docs get a larger window + higher token ceiling — directors,
+  // share classes, and full object clauses don't fit in the 2.5k default.
+  const entityDoc = isEntityDoc(text)
+  const truncationLimit = entityDoc ? 40000 : 24000
+  const maxTokens = entityDoc ? 6000 : 2500
+  const truncated = text.length > truncationLimit ? text.slice(0, truncationLimit) : text
 
   // Rules in force for this company's current FY. We scope to current FY
   // because most docs pertain to the current year; users can correct
@@ -251,17 +328,28 @@ export async function analyzeDocument(options: {
     options.companyState ?? null,
   )
 
+  console.log('[document-agent] LLM call', {
+    documentId: options.documentId,
+    entityDoc,
+    textLength: text.length,
+    truncationLimit,
+    maxTokens,
+  })
+
   const raw = await chatCompletion(
     [
       { role: 'system', content: system },
-      { role: 'user', content: `Document text (truncated to first 24k chars):\n\n${truncated}` },
+      { role: 'user', content: `Document text (truncated to first ${truncationLimit} chars):\n\n${truncated}` },
     ],
-    { maxTokens: 2500 },  // JSON with folder, period, requirement, 0-30 facts ≈ 400-1500 tokens
+    { maxTokens },
   )
   if (!raw) {
+    console.error('[document-agent] llm_unavailable', { documentId: options.documentId })
     errors.push('llm_unavailable')
     return { suggestion: null, errors }
   }
+
+  console.log('[document-agent] LLM raw response (first 2k chars):', raw.slice(0, 2000))
 
   const first = raw.indexOf('{')
   const last = raw.lastIndexOf('}')
@@ -296,6 +384,9 @@ export async function analyzeDocument(options: {
     if (candidate) candidateSupersedesDocumentId = candidate.id
   }
 
+  // Normalise every date field — the LLM is instructed to return ISO,
+  // but defence-in-depth handles word-format ("Twenty-Fifth day of...")
+  // and Indian DD/MM/YYYY that occasionally slip through.
   const suggestion: DocumentAgentSuggestion = {
     name: parsed.name ?? null,
     folderSlug: parsed.folderSlug ?? null,
@@ -304,21 +395,27 @@ export async function analyzeDocument(options: {
     periodType: parsed.periodType ?? null,
     periodFY: parsed.periodFY ?? null,
     periodKey: parsed.periodKey ?? null,
-    periodStart: parsed.periodStart ?? null,
-    periodEnd: parsed.periodEnd ?? null,
+    periodStart: normalizeWordDate(parsed.periodStart),
+    periodEnd: normalizeWordDate(parsed.periodEnd),
     frequency: parsed.frequency ?? null,
     requirementId: parsed.requirementId ?? null,
-    registrationDate: parsed.registrationDate ?? null,
-    expiryDate: parsed.expiryDate ?? null,
+    registrationDate: normalizeWordDate(parsed.registrationDate),
+    expiryDate: normalizeWordDate(parsed.expiryDate),
     confidence: typeof parsed.confidence === 'number'
       ? Math.max(0, Math.min(1, parsed.confidence))
       : 0.6,
     reasoning: parsed.reasoning ?? '',
     candidateSupersedesDocumentId,
-    facts: Array.isArray(parsed.facts) ? parsed.facts.filter((f: any) =>
-      typeof f?.kind === 'string' &&
-      typeof f?.confidence === 'number' && f.confidence >= 0.6
-    ) : [],
+    facts: Array.isArray(parsed.facts) ? parsed.facts
+      .filter((f: any) =>
+        typeof f?.kind === 'string' &&
+        typeof f?.confidence === 'number' && f.confidence >= 0.6
+      )
+      .map((f: any) => ({
+        ...f,
+        periodStart: normalizeWordDate(f.periodStart) ?? f.periodStart ?? '',
+        periodEnd: normalizeWordDate(f.periodEnd) ?? f.periodEnd ?? '',
+      })) : [],
   }
   return { suggestion, errors }
 }

--- a/lib/compliance/document-agent.ts
+++ b/lib/compliance/document-agent.ts
@@ -349,7 +349,19 @@ export async function analyzeDocument(options: {
     return { suggestion: null, errors }
   }
 
-  console.log('[document-agent] LLM raw response (first 2k chars):', raw.slice(0, 2000))
+  // Always log non-sensitive metadata so length-related bugs (truncation,
+  // empty response, malformed JSON) are diagnosable. The full raw body
+  // contains user document content (PII — director names, addresses on
+  // COI/MOA) so it's gated behind an explicit env flag for live debugging.
+  console.log('[document-agent] LLM response', {
+    documentId: options.documentId,
+    rawLength: raw.length,
+    firstChar: raw[0],
+    lastChar: raw[raw.length - 1],
+  })
+  if (process.env.DEBUG_DOCUMENT_AGENT === '1') {
+    console.log('[document-agent] LLM raw response (first 2k chars):', raw.slice(0, 2000))
+  }
 
   const first = raw.indexOf('{')
   const last = raw.lastIndexOf('}')
@@ -406,16 +418,23 @@ export async function analyzeDocument(options: {
       : 0.6,
     reasoning: parsed.reasoning ?? '',
     candidateSupersedesDocumentId,
+    // Normalise each fact's periodStart/End. Drop the fact entirely when
+    // either side won't normalise — preserving the un-parseable string
+    // would let "Twenty-Fifth day of March, …" reach `new Date()` in
+    // smart-ingest and produce Invalid Date rows. Same null-on-failure
+    // policy as the top-level date fields above.
     facts: Array.isArray(parsed.facts) ? parsed.facts
       .filter((f: any) =>
         typeof f?.kind === 'string' &&
         typeof f?.confidence === 'number' && f.confidence >= 0.6
       )
-      .map((f: any) => ({
-        ...f,
-        periodStart: normalizeWordDate(f.periodStart) ?? f.periodStart ?? '',
-        periodEnd: normalizeWordDate(f.periodEnd) ?? f.periodEnd ?? '',
-      })) : [],
+      .map((f: any) => {
+        const ps = normalizeWordDate(f.periodStart)
+        const pe = normalizeWordDate(f.periodEnd)
+        if (!ps || !pe) return null
+        return { ...f, periodStart: ps, periodEnd: pe }
+      })
+      .filter((f: any): f is NonNullable<typeof f> => f !== null) : [],
   }
   return { suggestion, errors }
 }

--- a/lib/utils/normalize-word-date.ts
+++ b/lib/utils/normalize-word-date.ts
@@ -116,8 +116,12 @@ export function normalizeWordDate(input: string | null | undefined): string | nu
     const [, d, monStr, y] = monMatch
     const monthNum = MONTH_WORDS[monStr.toLowerCase()]
     const yearNum = parseInt(y, 10)
-    if (monthNum && yearNum >= 1900 && yearNum <= 2100) {
-      return `${y}-${String(monthNum).padStart(2, '0')}-${d.padStart(2, '0')}`
+    const dayNum = parseInt(d, 10)
+    if (
+      monthNum && yearNum >= 1900 && yearNum <= 2100 &&
+      dayNum >= 1 && dayNum <= 31
+    ) {
+      return `${y}-${String(monthNum).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`
     }
   }
 
@@ -127,8 +131,12 @@ export function normalizeWordDate(input: string | null | undefined): string | nu
     const [, monStr, d, y] = monFirst
     const monthNum = MONTH_WORDS[monStr.toLowerCase()]
     const yearNum = parseInt(y, 10)
-    if (monthNum && yearNum >= 1900 && yearNum <= 2100) {
-      return `${y}-${String(monthNum).padStart(2, '0')}-${d.padStart(2, '0')}`
+    const dayNum = parseInt(d, 10)
+    if (
+      monthNum && yearNum >= 1900 && yearNum <= 2100 &&
+      dayNum >= 1 && dayNum <= 31
+    ) {
+      return `${y}-${String(monthNum).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`
     }
   }
 

--- a/lib/utils/normalize-word-date.ts
+++ b/lib/utils/normalize-word-date.ts
@@ -1,0 +1,177 @@
+/**
+ * Convert any common date representation found on Indian compliance
+ * documents to a strict ISO date string (YYYY-MM-DD).
+ *
+ * Handles:
+ *   - Already-ISO              "2023-03-25"          → "2023-03-25"
+ *   - Indian numeric           "25/03/2023"          → "2023-03-25"
+ *   - Indian numeric variants  "25-03-2023" / "25.03.2023"
+ *   - Day-Mon-Year             "25-Mar-2023" / "25 March 2023"
+ *   - Word format              "Twenty-Fifth day of March, Two Thousand Twenty-Three"
+ *   - Month + year only        "March 2024"          → "2024-03-01"
+ *   - Year only                "2024"                → "2024-01-01"
+ *
+ * Returns null when the input cannot be confidently parsed (caller should
+ * treat that as "no date" rather than store junk). Year is sanity-checked
+ * to fall in [1900, 2100].
+ */
+
+const MONTH_WORDS: Record<string, number> = {
+  january: 1, february: 2, march: 3, april: 4, may: 5, june: 6,
+  july: 7, august: 8, september: 9, october: 10, november: 11, december: 12,
+  jan: 1, feb: 2, mar: 3, apr: 4, jun: 6, jul: 7, aug: 8,
+  sep: 9, sept: 9, oct: 10, nov: 11, dec: 12,
+}
+
+const NUMBER_WORDS: Record<string, number> = {
+  zero: 0, one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, seven: 7,
+  eight: 8, nine: 9, ten: 10, eleven: 11, twelve: 12, thirteen: 13,
+  fourteen: 14, fifteen: 15, sixteen: 16, seventeen: 17, eighteen: 18,
+  nineteen: 19, twenty: 20, thirty: 30, forty: 40, fifty: 50, sixty: 60,
+  seventy: 70, eighty: 80, ninety: 90, hundred: 100, thousand: 1000,
+  // Ordinal forms commonly used for the day part
+  first: 1, second: 2, third: 3, fourth: 4, fifth: 5, sixth: 6, seventh: 7,
+  eighth: 8, ninth: 9, tenth: 10, eleventh: 11, twelfth: 12, thirteenth: 13,
+  fourteenth: 14, fifteenth: 15, sixteenth: 16, seventeenth: 17,
+  eighteenth: 18, nineteenth: 19, twentieth: 20, thirtieth: 30,
+}
+
+function wordsToNumber(input: string): number | null {
+  // Normalize: lowercase, replace hyphens with space, drop noise words
+  const tokens = input
+    .toLowerCase()
+    .replace(/-/g, ' ')
+    .split(/[\s,]+/)
+    .filter((t) => t && t !== 'and' && t !== 'of' && t !== 'the' && t !== 'day')
+
+  if (tokens.length === 0) return null
+
+  // Resolve each token to a number, trying the literal first
+  // ("fifth" → 5 directly), then digit form ("5th" → 5), then a
+  // suffix-stripped fallback ("twentieth" → 20 already handled by the
+  // dictionary; this catches odd compounds the dictionary missed).
+  function resolve(token: string): number | null {
+    if (NUMBER_WORDS[token] !== undefined) return NUMBER_WORDS[token]
+    const digitOrdinal = token.match(/^(\d+)(?:st|nd|rd|th)$/)
+    if (digitOrdinal) return parseInt(digitOrdinal[1], 10)
+    if (/^\d+$/.test(token)) return parseInt(token, 10)
+    const stripped = token.replace(/(?:st|nd|rd|th)$/, '')
+    if (stripped !== token && NUMBER_WORDS[stripped] !== undefined) {
+      return NUMBER_WORDS[stripped]
+    }
+    return null
+  }
+
+  let total = 0
+  let current = 0
+  for (const raw of tokens) {
+    const n = resolve(raw)
+    if (n === null) return null
+
+    if (n === 100) {
+      current = (current || 1) * 100
+    } else if (n === 1000) {
+      total += (current || 1) * 1000
+      current = 0
+    } else {
+      current += n
+    }
+  }
+  return total + current
+}
+
+export function normalizeWordDate(input: string | null | undefined): string | null {
+  if (!input) return null
+  const trimmed = String(input).trim()
+  if (!trimmed) return null
+
+  // Already ISO
+  const iso = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (iso) {
+    const [, y, m, d] = iso
+    const yearNum = parseInt(y, 10)
+    if (yearNum >= 1900 && yearNum <= 2100) return `${y}-${m}-${d}`
+    return null
+  }
+
+  // DD/MM/YYYY, DD-MM-YYYY, DD.MM.YYYY (Indian numeric convention)
+  const numericMatch = trimmed.match(/^(\d{1,2})[\/\-\.](\d{1,2})[\/\-\.](\d{4})$/)
+  if (numericMatch) {
+    const [, d, m, y] = numericMatch
+    const yearNum = parseInt(y, 10)
+    const monthNum = parseInt(m, 10)
+    const dayNum = parseInt(d, 10)
+    if (
+      yearNum >= 1900 && yearNum <= 2100 &&
+      monthNum >= 1 && monthNum <= 12 &&
+      dayNum >= 1 && dayNum <= 31
+    ) {
+      return `${y}-${String(monthNum).padStart(2, '0')}-${String(dayNum).padStart(2, '0')}`
+    }
+  }
+
+  // DD Mon YYYY (e.g., "25 March 2023", "25-Mar-2023", "25/Mar/2023")
+  const monMatch = trimmed.match(/^(\d{1,2})[\s\-\/]+([A-Za-z]+)[\s\-\/,]+(\d{4})$/)
+  if (monMatch) {
+    const [, d, monStr, y] = monMatch
+    const monthNum = MONTH_WORDS[monStr.toLowerCase()]
+    const yearNum = parseInt(y, 10)
+    if (monthNum && yearNum >= 1900 && yearNum <= 2100) {
+      return `${y}-${String(monthNum).padStart(2, '0')}-${d.padStart(2, '0')}`
+    }
+  }
+
+  // "Mon DD, YYYY" or "Mon DD YYYY" (e.g., "March 25, 2023")
+  const monFirst = trimmed.match(/^([A-Za-z]+)[\s\-\/]+(\d{1,2})[\s\-\/,]+(\d{4})$/)
+  if (monFirst) {
+    const [, monStr, d, y] = monFirst
+    const monthNum = MONTH_WORDS[monStr.toLowerCase()]
+    const yearNum = parseInt(y, 10)
+    if (monthNum && yearNum >= 1900 && yearNum <= 2100) {
+      return `${y}-${String(monthNum).padStart(2, '0')}-${d.padStart(2, '0')}`
+    }
+  }
+
+  // Word format: "Twenty-Fifth day of March, Two Thousand Twenty-Three"
+  // Strategy: locate the month word, parse day-words on the left,
+  // year-words on the right.
+  const lowered = trimmed.toLowerCase()
+  for (const [monthWord, monthNum] of Object.entries(MONTH_WORDS)) {
+    // Skip 3-letter abbreviations to avoid false matches inside other
+    // words like "marathon"; require word boundaries
+    if (monthWord.length < 4) continue
+    const re = new RegExp(`\\b${monthWord}\\b`, 'i')
+    const idx = lowered.search(re)
+    if (idx < 0) continue
+    const left = trimmed.slice(0, idx)
+    const right = trimmed.slice(idx + monthWord.length)
+    const day = wordsToNumber(left.replace(/day\s+of/i, ''))
+    const year = wordsToNumber(right)
+    if (day && day >= 1 && day <= 31 && year && year >= 1900 && year <= 2100) {
+      return `${year}-${String(monthNum).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+    }
+    // Stop after the first matched month word — multiple matches are
+    // ambiguous and we'd rather return null than guess.
+    break
+  }
+
+  // "Mon YYYY" (month + year only) → 1st of month
+  const monYearMatch = trimmed.match(/^([A-Za-z]+)[\s\-\/,]+(\d{4})$/)
+  if (monYearMatch) {
+    const [, monStr, y] = monYearMatch
+    const monthNum = MONTH_WORDS[monStr.toLowerCase()]
+    const yearNum = parseInt(y, 10)
+    if (monthNum && yearNum >= 1900 && yearNum <= 2100) {
+      return `${y}-${String(monthNum).padStart(2, '0')}-01`
+    }
+  }
+
+  // YYYY only → Jan 1
+  const yearOnly = trimmed.match(/^(\d{4})$/)
+  if (yearOnly) {
+    const yearNum = parseInt(yearOnly[1], 10)
+    if (yearNum >= 1900 && yearNum <= 2100) return `${yearOnly[1]}-01-01`
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary

OCR returned **null** for dates written in words (\"*Twenty-Fifth day of March, Two Thousand Twenty-Three*\") and silently dropped half the structured fields on MOA/AOA uploads (directors, shareholders, object clauses, registered office, etc.). Two fixes:

- **`lib/utils/normalize-word-date.ts`** (new) — converts every common Indian-doc date format to strict ISO `YYYY-MM-DD`. ISO, `25/03/2023`, `25-Mar-2023`, `March 25, 2023`, full word-format `\"Twenty-Fifth day of March, Two Thousand Twenty-Three\"`, month-only `\"March 2024\"`, year-only `\"2024\"`. Returns `null` for unparseable input — junk never lands in the DB.
- **`lib/compliance/document-agent.ts`** —
  - `SYSTEM_PROMPT` now has an explicit DATE FORMAT section telling the model to convert word-format and Indian `DD/MM/YYYY` to ISO (with examples so it doesn't assume US `MM/DD/YYYY`).
  - Entity-fact taxonomy expanded with `entity.director`, `entity.shareholder`, `entity.subscriber`, `entity.signatory`, `entity.main_object`, `entity.ancillary_object`, `entity.aoa_clause`, `entity.share_capital_breakdown`, `entity.face_value`, `entity.registered_office_address`, `entity.email`, `entity.phone`, `entity.website`, `entity.llpin`. Instruction to emit one fact per person/object so they're individually editable.
  - New `isEntityDoc()` heuristic. When the first 2k chars match `/memorandum of association|articles of association|certificate of incorporation|share certificate|llp agreement|incorporation certificate/i`, the agent runs with 40k char input + 6000 max tokens instead of 24k/2500. Monthly returns keep the cheaper budget.
  - Every returned date runs through `normalizeWordDate` post-process — defence in depth.
  - Added `[document-agent]` call/response logs per the project diagnostic rule.

No schema, persistence, or modal-rendering changes — `AgentAssistedUploadModal` already renders facts generically and `recordFact()` accepts any kind string, so new entity.* facts flow through automatically.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — clean
- [x] Verified `normalizeWordDate` against 11 real Indian COI date formats including `Twenty-Fifth day of March, Two Thousand Twenty-Three` → `2023-03-25` and `Thirty-First day of December, Two Thousand Twenty` → `2020-12-31`
- [ ] Manual smoke: upload a real COI / MOA / AOA, confirm Vercel logs show `entityDoc: true`, ISO dates, director/shareholder facts in the response
- [ ] Confirm `company_facts` rows persist for the new entity.* kinds after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added flexible date format normalization supporting Indian date formats (DD/MM/YYYY), written-out dates, ordinal day-month formats, and month-year conversions to ISO standard

* **Improvements**
  * Enhanced entity document classification and processing for compliance documents (COI, MOA, AOA, share certificates)
  * Stricter fact validation with confidence thresholds and consistent date normalization across document fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->