### PR TITLE
feat(tracker): add Filing Month column so April-period TDS isn't hidden under May

### DIFF
--- a/app/data-room/components/tracker/RequirementDesktopTableView.tsx
+++ b/app/data-room/components/tracker/RequirementDesktopTableView.tsx
@@ -16,6 +16,14 @@ async function openDocInNewTab(companyId: string, documentId: string) {
   window.open(res.url, '_blank', 'noopener,noreferrer')
 }
 
+// Render the period a filing covers (e.g. "Apr 2026", "Q1 2026", "FY2025-26").
+// Falls back to the period_key when the label is missing.
+function formatFilingPeriod(periodLabel?: string | null, periodKey?: string | null): string {
+  const raw = (periodLabel || periodKey || '').trim()
+  if (!raw) return ''
+  return raw.replace(/^For\s+/i, '')
+}
+
 interface Requirement {
   id: string
   requirement: string
@@ -215,6 +223,9 @@ export default function RequirementDesktopTableView({
             REQUIREMENT
           </th>
           <th className="px-6 py-4 text-left text-xs font-medium text-fg-muted uppercase tracking-wider">
+            FILING MONTH
+          </th>
+          <th className="px-6 py-4 text-left text-xs font-medium text-fg-muted uppercase tracking-wider">
             STATUS
           </th>
           <th className="px-6 py-4 text-left text-xs font-medium text-fg-muted uppercase tracking-wider">
@@ -263,7 +274,7 @@ export default function RequirementDesktopTableView({
             {/* Visual Separator between categories */}
             {groupIndex > 0 && (
               <tr>
-                <td colSpan={canEdit ? 14 : 13} className="px-0 py-0">
+                <td colSpan={canEdit ? 15 : 14} className="px-0 py-0">
                   <div className="h-0.5 bg-gradient-to-r from-transparent via-white/30 to-transparent my-2"></div>
                 </td>
               </tr>
@@ -335,6 +346,19 @@ export default function RequirementDesktopTableView({
                         )}
                       </div>
                     </div>
+                  </td>
+                  <td className="px-6 py-4">
+                    {(() => {
+                      const filingPeriod = formatFilingPeriod(req.period_label, req.period_key)
+                      if (!filingPeriod) {
+                        return <span className="text-fg-muted text-sm">—</span>
+                      }
+                      return (
+                        <span className="text-fg-primary text-sm font-mono tabular-nums whitespace-nowrap">
+                          {filingPeriod}
+                        </span>
+                      )
+                    })()}
                   </td>
                   <td className="px-6 py-4">
                     {canEdit ? (

--- a/app/data-room/components/tracker/RequirementMobileCardView.tsx
+++ b/app/data-room/components/tracker/RequirementMobileCardView.tsx
@@ -237,24 +237,53 @@ export default function RequirementMobileCardView({
                     )}
                   </div>
 
-                  {/* Due Date */}
-                  <div className="flex items-center gap-1.5 text-fg-primary">
-                    <svg
-                      width="14"
-                      height="14"
-                      className="flex-shrink-0 text-fg-muted"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      strokeWidth="2"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    >
-                      <circle cx="12" cy="12" r="10" />
-                      <polyline points="12 6 12 12 16 14" />
-                    </svg>
-                    <span className="text-xs">Due: {req.dueDate}</span>
-                  </div>
+                  {/* Filing Month + Due Date */}
+                  {(() => {
+                    const rawPeriod = (req.period_label || req.period_key || '').trim()
+                    const filingPeriod = rawPeriod ? rawPeriod.replace(/^For\s+/i, '') : ''
+                    return (
+                      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-fg-primary">
+                        {filingPeriod && (
+                          <div className="flex items-center gap-1.5">
+                            <svg
+                              width="14"
+                              height="14"
+                              className="flex-shrink-0 text-fg-muted"
+                              viewBox="0 0 24 24"
+                              fill="none"
+                              stroke="currentColor"
+                              strokeWidth="2"
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                            >
+                              <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                              <line x1="16" y1="2" x2="16" y2="6" />
+                              <line x1="8" y1="2" x2="8" y2="6" />
+                              <line x1="3" y1="10" x2="21" y2="10" />
+                            </svg>
+                            <span className="text-xs">Filing: {filingPeriod}</span>
+                          </div>
+                        )}
+                        <div className="flex items-center gap-1.5">
+                          <svg
+                            width="14"
+                            height="14"
+                            className="flex-shrink-0 text-fg-muted"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                            <polyline points="12 6 12 12 16 14" />
+                          </svg>
+                          <span className="text-xs">Due: {req.dueDate}</span>
+                        </div>
+                      </div>
+                    )
+                  })()}
 
                   {/* Delayed, Penalty, Calculated Penalty */}
                   <div className="grid grid-cols-2 gap-2 text-xs">

--- a/app/data-room/page.tsx
+++ b/app/data-room/page.tsx
@@ -3870,6 +3870,8 @@ function DataRoomPageInner() {
         filed_on: req.filed_on,
         filed_by: req.filed_by,
         status_reason: req.status_reason,
+        period_key: (req as any).period_key ?? null,
+        period_label: (req as any).period_label ?? null,
       }));
   }, [regulatoryRequirements, hiddenCompliances, formatDate]);
 

--- a/contexts/TrackerContext.tsx
+++ b/contexts/TrackerContext.tsx
@@ -232,6 +232,8 @@ export function TrackerContextProvider({
         amount_payable: req.amount_payable,
         amount_paid: req.amount_paid,
         filing_document_id: req.filing_document_id,
+        period_key: (req as any).period_key ?? null,
+        period_label: (req as any).period_label ?? null,
       }))
 
     const duration = performance.now() - startTime

--- a/domain/models/Requirement.ts
+++ b/domain/models/Requirement.ts
@@ -29,4 +29,6 @@ export interface Requirement {
   amount_payable?: number | null
   amount_paid?: number | null
   filing_document_id?: string | null
+  period_key?: string | null
+  period_label?: string | null
 }

--- a/infrastructure/persistence/prisma/PrismaRequirementRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaRequirementRepository.ts
@@ -304,6 +304,8 @@ export class PrismaRequirementRepository implements RequirementRepository {
       amount_payable: row.amount_payable != null ? Number(row.amount_payable) : null,
       amount_paid: row.amount_paid != null ? Number(row.amount_paid) : null,
       filing_document_id: row.filing_document_id ?? null,
+      period_key: row.period_key ?? null,
+      period_label: row.period_label ?? null,
       created_at: row.created_at ? (row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at)) : new Date().toISOString(),
       updated_at: row.updated_at ? (row.updated_at instanceof Date ? row.updated_at.toISOString() : String(row.updated_at)) : new Date().toISOString(),
       created_by: row.created_by ?? null,


### PR DESCRIPTION
## Summary

Users reported "April compliances aren't being generated" — but they were. The generator stores the work-period each row covers (`period_label = \"For Apr 2026\"`, `period_key = \"2026-04\"`) separately from `due_date`, but neither the desktop table nor the mobile card surfaced it. So a TDS row for April work showed only `Due: 2026-05-07`, and the calendar bucketed it under May. April looked empty.

This PR plumbs the existing field through the read path and adds a column.

### What changed

- **Desktop table** — new `FILING MONTH` column between `REQUIREMENT` and `STATUS`. `formatFilingPeriod()` strips the `\"For \"` prefix so users see `Apr 2026`, not `For Apr 2026`. Falls back to `period_key` when label is missing, dash when both are null. `colSpan` on the category separator bumped 14/13 → 15/14.

- **Mobile card** — the standalone `Due: …` line becomes a flex-wrap row with both `Filing: Apr 2026` (calendar icon) and `Due: 2026-05-07` (clock icon). Filing chip omitted for one-time rows where the field is null.

- **Read path plumbing** — `PrismaRequirementRepository.toDomain()` → `Requirement` model → `TrackerContext` mapping → `DataRoomPage` filtered-requirements memo. Five tiny additions of the form `period_key: row.period_key ?? null`. The DB column has existed for a while; only the read path was silently dropping it.

### What did NOT change

- No DB migration. `period_key` / `period_label` already exist on `regulatory_requirements`.
- No generator changes. The April-coverage row was already being created correctly — this PR just makes it visible.
- No calendar-view changes. Bucketing by `due_date` is still correct (that's when action is required); a separate \"covers Apr\" pill inside cells is a possible follow-up if needed.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx next lint` — clean
- [ ] Manual smoke: open `/data-room` tracker tab, confirm a recurring TDS row shows `FILING MONTH: Apr 2026` and `DUE DATE: 2026-05-07` side by side
- [ ] Confirm one-time obligations (e.g., COI-related) show `—` in the Filing Month column rather than rendering empty
- [ ] Mobile width: confirm the `Filing:` and `Due:` chips wrap correctly without overlapping
- [ ] Verify across all 12 monthly TDS rows for the current FY — the user's concern was that April \"looked missing\"; with this column they should see `Apr`, `May`, `Jun`, etc. in order

🤖 Generated with [Claude Code](https://claude.com/claude-code)