### PR TITLE
fix(deadline-engine): addMonths rollover dropped Tax Audit / MGT-7 / AGM into wrong month

### DIFF
--- a/lib/compliance/rules/sets/company-type.ts
+++ b/lib/compliance/rules/sets/company-type.ts
@@ -264,7 +264,7 @@ export const COMPANY_TYPE_RULES: ComplianceRule[] = [
     authority: 'Ministry of Corporate Affairs (MCA)',
     frequency: 'annual',
     dueDateFormula: 'months_after_fy_end:7,day:30',
-    dueDescription: '30th October (within 30 days from 6 months after FY end)',
+    dueDescription: '30th October (within 30 days of AGM, 7 months from FY end)',
     penalty: '₹100/day per designated partner. LLP can be struck off.',
     isCritical: true,
     documentsRequired: ['Form 8', 'Statement of Account', 'Solvency Statement', 'Digital Signature of Designated Partners'],

--- a/lib/compliance/rules/sets/company-type.ts
+++ b/lib/compliance/rules/sets/company-type.ts
@@ -20,8 +20,8 @@ export const COMPANY_TYPE_RULES: ComplianceRule[] = [
     section: 'Section 137',
     authority: 'Ministry of Corporate Affairs (MCA)',
     frequency: 'annual',
-    dueDateFormula: 'months_after_fy_end:6,day:30', // 30th October for March FY
-    dueDescription: 'Within 30 days of AGM (6 months from FY end)',
+    dueDateFormula: 'months_after_fy_end:7,day:30', // 30th October for March FY (30 days after AGM)
+    dueDescription: 'Within 30 days of AGM (7 months from FY end)',
     penalty: '₹100/day per default (company) + ₹100/day per director (max ₹10L each). Additional ₹1,000/day after first default.',
     isCritical: true,
     documentsRequired: ['Audited Financial Statements', 'Board Report', 'Auditor Report', 'Digital Signature'],
@@ -263,7 +263,7 @@ export const COMPANY_TYPE_RULES: ComplianceRule[] = [
     section: 'Section 34(3)',
     authority: 'Ministry of Corporate Affairs (MCA)',
     frequency: 'annual',
-    dueDateFormula: 'months_after_fy_end:6,day:30',
+    dueDateFormula: 'months_after_fy_end:7,day:30',
     dueDescription: '30th October (within 30 days from 6 months after FY end)',
     penalty: '₹100/day per designated partner. LLP can be struck off.',
     isCritical: true,

--- a/lib/services/deadline-engine.ts
+++ b/lib/services/deadline-engine.ts
@@ -278,8 +278,17 @@ function daysInMonth(year: number, month: number): number {
 }
 
 function addMonths(date: Date, months: number): Date {
-  const d = new Date(date)
-  d.setMonth(d.getMonth() + months)
+  // Naive `setMonth(getMonth() + N)` rolls end-of-month dates into the
+  // following month: setMonth on Mar 31 + 6 → Sep 31 → rolls to Oct 1.
+  // For Indian FY anchored on Mar 31, formulas like
+  // `months_after_fy_end:6` (tax audit, AGM, CSR) and `:8` (MGT-7) then
+  // landed in Oct / Dec instead of Sep / Nov. Build the target month
+  // explicitly and clamp the day to that month's length.
+  const targetYear = date.getFullYear()
+  const targetMonth = date.getMonth() + months
+  const sourceDay = date.getDate()
+  const d = new Date(targetYear, targetMonth, 1)
+  d.setDate(Math.min(sourceDay, daysInMonth(d.getFullYear(), d.getMonth())))
   return d
 }
 


### PR DESCRIPTION
## Summary

CA tester flagged **Tax Audit** showing Oct 30 (should be **Sep 30**), **MGT-7** showing Dec (should be **Nov 29**), and AGM / CSR / MR-3 silently in the same boat. Root cause is a JS \`setMonth\` quirk in [\`addMonths()\`](lib/services/deadline-engine.ts):

\`\`\`js
new Date(2027, 2, 31).setMonth(8)
// → October 1, 2027 (Sep has 30 days, so \"Sep 31\" rolls to Oct 1)
\`\`\`

Indian FY ends \`March 31\`, so every formula \`months_after_fy_end:N\` with **N ∈ {1, 3, 6, 8}** landed in the wrong calendar month — N=6 went to Oct, N=8 to Dec, N=3 to Jul.

## What changed

- **\`addMonths\` rewritten** to construct via \`new Date(year, month, 1)\` then clamp the day to that month's length. No more rollover.
- **AOC-4 + LLP Form 8 formulas** bumped from \`months_after_fy_end:6,day:30\` → \`:7,day:30\`. Both had been silently compensating for the bug — \`:6\` happened to produce Oct 30 only *because* of the rollover. After the engine fix they would have regressed to Sep 30, which is wrong (AOC-4 is 30 days after AGM = Oct 30). \`:7\` is what the formula should have said all along.

## Rules unmasked by the fix (no edit needed — formulas were already correct)

| Rule | Formula | Was producing | Now produces |
|------|---------|---------------|--------------|
| Tax Audit | \`months_after_fy_end:6,day:30\` | Oct 30 ✗ | **Sep 30** ✓ |
| AGM | \`months_after_fy_end:6,day:30\` | Oct 30 ✗ | **Sep 30** ✓ |
| CSR | \`months_after_fy_end:6,day:30\` | Oct 30 ✗ | **Sep 30** ✓ |
| Secretarial Audit (MR-3) | \`months_after_fy_end:6,day:30\` | Oct 30 ✗ | **Sep 30** ✓ |
| MGT-7 | \`months_after_fy_end:8,day:29\` | Dec 29 ✗ | **Nov 29** ✓ |
| DPIIT startup self-cert | \`months_after_fy_end:3,day:30\` | Jul 30 ✗ | **Jun 30** ✓ |
| RBI NBFC annual | \`months_after_fy_end:3,day:30\` | Jul 30 ✗ | **Jun 30** ✓ |
| SEZ IT/ITES | \`months_after_fy_end:3,day:30\` | Jul 30 ✗ | **Jun 30** ✓ |
| ITR (companies) | \`months_after_fy_end:7,day:31\` | Oct 31 ✓ | Oct 31 ✓ (no rollover at N=7) |

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] Verified \`addMonths(March 31, N)\` for N=1..12 lands in the intended month every time
- [ ] Wipe + regenerate compliance for a test company on FY 2026-27, confirm:
  - Tax Audit shows Sep 30, 2027 (not Oct 30)
  - MGT-7 shows Nov 29, 2027 (not Dec)
  - AOC-4 still shows Oct 30, 2027 (regression check)
  - DPT-3 still shows Jun 30 (uses \`fixed:jun30\`, untouched by this PR)

## Related

This is **PR-A** of 4 fixes from the CA-tester audit. PR-B handles the FY-filter bug (March-skip), PR-C handles quarterly/QRMP labelling, PR-D renames the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed deadline calculations for end-of-month dates to prevent incorrect month advancement.

* **Updates**
  * Adjusted compliance due dates for Companies Act annual financial statements and LLP annual returns to 7 months after fiscal year end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->