### PR TITLE
fix(tracker): filter by period_key FY (not due_date) — restores March-coverage rows + current-year annual filings

### DIFF
--- a/contexts/TrackerContext.tsx
+++ b/contexts/TrackerContext.tsx
@@ -11,6 +11,7 @@ import {
 } from 'react'
 import { EMPTY_REQUIREMENT_FORM, type RequirementForm } from '@/app/data-room/components/tracker/RequirementFormModal'
 import { isInFinancialYear as isInFinancialYearUtil } from '@/lib/utils/financial-year'
+import { periodKeyInFY } from '@/lib/utils/period-key-fy'
 import { performanceLogger } from '@/lib/utils/performance-logger'
 
 // ─── External data shape (passed in from page.tsx) ───────────────────────────
@@ -269,6 +270,17 @@ export function TrackerContextProvider({
     if (selectedTrackerFY) {
       try {
         filtered = filtered.filter((req) => {
+          // Recurring rows have a period_key set by the deadline engine
+          // (e.g. "2027-03" for the March-coverage TDS row whose
+          // due_date is April 7 2027). Filter by THAT — filtering by
+          // due_date FY put March-coverage rows into the next FY and
+          // hid them from the user. Annual rows like GSTR-9 / AOC-4 had
+          // the same problem (deadline lands in calendar year past FY
+          // end). Fall back to due_date FY only for one-time
+          // obligations that have no period_key.
+          if (req.period_key) {
+            return periodKeyInFY(req.period_key, selectedTrackerFY)
+          }
           if (!req.dueDate) return false
           return isInFY(parseDate(req.dueDate), selectedTrackerFY)
         })
@@ -381,7 +393,12 @@ export function TrackerContextProvider({
     }
     let filtered = displayRequirements
     if (selectedTrackerFY) {
-      filtered = filtered.filter((req) => req.dueDate && isInFY(parseDate(req.dueDate), selectedTrackerFY))
+      filtered = filtered.filter((req) => {
+        // Mirror filteredRequirements: prefer period_key for recurring
+        // rows, fall back to due_date FY for one-time obligations.
+        if (req.period_key) return periodKeyInFY(req.period_key, selectedTrackerFY)
+        return Boolean(req.dueDate) && isInFY(parseDate(req.dueDate), selectedTrackerFY)
+      })
     }
     if (selectedMonth) {
       const monthIndex = MONTHS.indexOf(selectedMonth)

--- a/lib/utils/period-key-fy.ts
+++ b/lib/utils/period-key-fy.ts
@@ -1,0 +1,79 @@
+/**
+ * Decide whether a compliance row's `period_key` falls inside a selected FY.
+ *
+ * The tracker UI used to filter by `due_date` FY, which dropped:
+ *   - The March-coverage row of every monthly compliance (TDS deadline
+ *     April 7 for March work — due_date in next FY, period_key in current).
+ *   - Every annual filing for the selected FY (GSTR-9 / AOC-4 / MGT-7 /
+ *     CSR / DPT-3 etc. — their due_date sits in the *next* calendar year
+ *     which lives in the *next* FY).
+ *
+ * Filtering by `period_key` puts each row in the FY it logically COVERS
+ * rather than the FY its deadline lands in. Callers should fall back to
+ * `due_date` filtering for one-time rows that have no period_key.
+ *
+ * Supported period_key shapes (from `lib/services/deadline-engine.ts`):
+ *   "YYYY-MM"          monthly                  e.g. "2026-04", "2027-03"
+ *   "YYYY-Q1".."Q4"    quarterly (FY-anchored)  e.g. "2026-Q1"
+ *   "FYYYYY-YY"        annual                   e.g. "FY2026-27"
+ *
+ * FY string is the tracker's selectedTrackerFY: typically "2026-27" but
+ * we accept "FY2026-27" too for safety. Indian FY runs April–March; YYYY
+ * is the start year (FY 2026-27 = April 2026 → March 2027).
+ *
+ * Note: this helper currently assumes Indian FY conventions. Other
+ * countries with different FY anchoring would need a country-aware
+ * variant — out of scope here.
+ */
+
+function parseFY(fy: string): number | null {
+  const m = fy.trim().match(/^(?:FY)?(\d{4})(?:[-/](\d{2,4}))?$/i)
+  if (!m) return null
+  const start = parseInt(m[1], 10)
+  if (!Number.isFinite(start)) return null
+  return start
+}
+
+export function periodKeyInFY(periodKey: string | null | undefined, fy: string): boolean {
+  if (!periodKey || !fy) return false
+  const fyStartYear = parseFY(fy)
+  if (fyStartYear === null) return false
+
+  // Order matters: monthly "YYYY-MM" and bare-form annual "YYYY-YY" are
+  // syntactically indistinguishable. Test monthly first with a strict
+  // month range (01..12). Anything that fails that and isn't quarterly
+  // must carry the literal "FY" prefix to be treated as an annual key —
+  // the deadline-engine always emits annual rows as "FYYYYY-YY".
+
+  // Monthly: "YYYY-MM" (MM in 01..12) → in FY if Apr–Dec of start year
+  // OR Jan–Mar of next year.
+  const monthlyMatch = periodKey.match(/^(\d{4})-(\d{2})$/)
+  if (monthlyMatch) {
+    const y = parseInt(monthlyMatch[1], 10)
+    const m = parseInt(monthlyMatch[2], 10)
+    if (m >= 1 && m <= 12) {
+      if (y === fyStartYear && m >= 4) return true
+      if (y === fyStartYear + 1 && m <= 3) return true
+      return false
+    }
+    // Falls through if MM is out-of-range (e.g. "27") — handled below
+    // as a bare-form FY label.
+  }
+
+  // Quarterly: "2026-Q1" — Q1=Apr-Jun, Q4=Jan-Mar of next year. We
+  // anchor by FY start year regardless of quarter.
+  const quarterMatch = periodKey.match(/^(\d{4})-Q[1-4]$/i)
+  if (quarterMatch) {
+    return parseInt(quarterMatch[1], 10) === fyStartYear
+  }
+
+  // Annual: "FY2026-27" (preferred) or bare "2026-27" / "2026" (fallback
+  // for older rows). The bare form is only reached after the monthly
+  // branch fails its range check.
+  const annualMatch = periodKey.match(/^(?:FY)?(\d{4})(?:[-/]\d{2,4})?$/i)
+  if (annualMatch) {
+    return parseInt(annualMatch[1], 10) === fyStartYear
+  }
+
+  return false
+}


### PR DESCRIPTION
## Summary

CA tester saw two related symptoms when viewing FY 2026-27:
- Monthly TDS / GST / PF / ESI / PT all stopped at **Feb-coverage**. The **March-coverage row** (due April 7 2027) was missing every time.
- Annual GSTR-9 / GSTR-9C / AOC-4 / MGT-7 / AGM / DPT-3 / DIR-3 KYC / CSR all displayed the **prior year's filing**, not the year being tested.

Same root cause: [TrackerContext.tsx:267-276 + 381-382](contexts/TrackerContext.tsx) filtered rows by \`due_date\` FY. The generator already stamps each recurring row with \`period_key\` (the FY the work covers), but the filter ignored that and used the deadline date — which sits in the *next* FY for end-of-FY monthly coverage and for every annual filing whose deadline lands in the following calendar year.

## What changed

- **New** [\`lib/utils/period-key-fy.ts\`](lib/utils/period-key-fy.ts) — parses every period_key shape the deadline-engine emits (\`YYYY-MM\`, \`YYYY-Q1..Q4\`, \`FYYYYY-YY\`) and decides FY membership against Indian FY conventions (April–March, FY label = start year).
- [\`contexts/TrackerContext.tsx\`](contexts/TrackerContext.tsx) — both filter sites (\`filteredRequirements\` + \`requirementsForPillCounts\`) now prefer \`period_key\` when present, fall back to \`due_date\` FY for one-time obligations.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] 13 unit-style cases pass for \`periodKeyInFY\` including:
  - \`('2027-03', '2026-27') → true\` (March-coverage row, the headline bug)
  - \`('2026-03', '2026-27') → false\` (March 2026 sits in FY 2025-26)
  - \`('FY2026-27', '2026-27') → true\` (annual direct match)
  - \`('2026-Q1', '2026-27') → true\` (Q1 of current FY)
- [ ] Wipe + regenerate compliance for a test company on FY 2026-27. Expect:
  - All 12 months of TDS / GST / PF / ESI / PT visible (March 2027 row included)
  - GSTR-9 / GSTR-9C show the FY 2026-27 row (due Dec 31 2027), not the FY 2025-26 row (due Dec 31 2026)
  - AOC-4 / MGT-7 / AGM / DPT-3 / DIR-3 KYC / CSR show FY 2026-27 versions with deadlines in 2027

## Related

This is **PR-B** of 4 fixes from the CA-tester audit. Independent of PR-A (#113 — addMonths). Together they resolve the bulk of the audit findings; PR-C handles the remaining QRMP-quarter labelling, PR-D renames the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)