### PR TITLE
feat(tracker): rename FILING MONTH column → FILING PERIOD

### DIFF
--- a/app/data-room/components/tracker/RequirementDesktopTableView.tsx
+++ b/app/data-room/components/tracker/RequirementDesktopTableView.tsx
@@ -223,7 +223,7 @@ export default function RequirementDesktopTableView({
             REQUIREMENT
           </th>
           <th className="px-6 py-4 text-left text-xs font-medium text-fg-muted uppercase tracking-wider">
-            FILING MONTH
+            FILING PERIOD
           </th>
           <th className="px-6 py-4 text-left text-xs font-medium text-fg-muted uppercase tracking-wider">
             STATUS


### PR DESCRIPTION
## Summary

CA tester noted that the new \"FILING MONTH\" column header only fits monthly rows. Quarterly QRMP and annual rows show \"Q1 2026-27\" / \"FY 2026-27\" in this column already, so the more generic header is correct.

Single-line change in [\`RequirementDesktopTableView.tsx\`](app/data-room/components/tracker/RequirementDesktopTableView.tsx). Mobile card already uses a generic \"Filing:\" prefix and needs no edit.

## Related

This is **PR-D** of 4 fixes from the CA-tester audit. Independent of A / B / C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)