### PR TITLE
perf(onboarding): batch folder seed + parallelize post-create writes (PR-31)

### DIFF
--- a/app/onboarding/actions.ts
+++ b/app/onboarding/actions.ts
@@ -210,45 +210,51 @@ export async function completeOnboarding(
     })
     .filter((r): r is { gstin: string; state: string | null } => r !== null && validateGSTN(r.gstin))
 
-  if (normalizedGstRegistrations.length > 0) {
-    await prisma.gstRegistration.createMany({
-      data: normalizedGstRegistrations.map((r) => ({
-        company_id: company.id,
-        gstin: r.gstin,
-        state: r.state,
-      })),
-      skipDuplicates: true,
-    })
-  }
+  // ─── Post-create writes, fanned out in parallel ──────────────────────
+  // Everything below only needs company.id (which we have) — so they're
+  // all independent and race-safe across DIFFERENT tables. Wrapping them
+  // in Promise.all collapses 5–6 sequential 250 ms round-trips (Vercel
+  // iad1 ↔ Supabase ap-south-1) into one parallel batch.
+  //
+  // Each task catches its own error so a single failure doesn't void the
+  // whole company create — preserves the prior per-step try/catch
+  // semantics (role / folder / facts were all "non-fatal log and
+  // continue" before). createMany rejections still surface for GST /
+  // directors / docs templates because those are user-typed data and
+  // silent loss there would be worse than failing the onboarding loudly.
+  // ──────────────────────────────────────────────────────────────────────
+  await Promise.all([
+    // 1a. GST registrations (skipped if user added none).
+    normalizedGstRegistrations.length > 0
+      ? prisma.gstRegistration.createMany({
+          data: normalizedGstRegistrations.map((r) => ({
+            company_id: company.id,
+            gstin: r.gstin,
+            state: r.state,
+          })),
+          skipDuplicates: true,
+        })
+      : Promise.resolve(),
 
-  // 1b. Assign admin role to the company creator
-  try {
-    // For Passport users, use app_user_id (user.id) and set user_id to NULL
-    await companyMembershipRepository.addRole(
-      user.id,
-      company.id,
-      'admin',
-      user.id // Pass user.id as app_user_id for Passport users
-    )
-  } catch (roleError) {
-    console.error('Role assignment error:', roleError)
-    // Don't throw - the company owner can still access via user_id on companies table
-  }
+    // 1b. Admin role for the creator. Non-fatal — owner still has access
+    // via the companies.user_id back-reference if this fails.
+    companyMembershipRepository
+      .addRole(user.id, company.id, 'admin', user.id)
+      .catch((roleError) => {
+        console.error('Role assignment error:', roleError)
+      }),
 
-  // 1d. Seed the five system top-level folders + their nested sub-folders
-  // (PRD §2.2 / §3.1). Idempotent; safe to call again later if a company
-  // onboarded before this rollout.
-  try {
-    await ensureSystemFolders(company.id)
-  } catch (folderErr) {
-    console.error('[onboarding] Vault folder seed failed (non-fatal):', folderErr instanceof Error ? folderErr.message : folderErr)
-  }
+    // 1d. Seed system vault folders. Already a single createMany after
+    // PR-31 — see lib/vault/folders.ts. Non-fatal.
+    ensureSystemFolders(company.id).catch((folderErr) => {
+      console.error(
+        '[onboarding] Vault folder seed failed (non-fatal):',
+        folderErr instanceof Error ? folderErr.message : folderErr,
+      )
+    }),
 
-  // 1c. Record declared facts into the fact store so the new applicability
-  // engine can reason over them alongside document-extracted evidence.
-  // Non-blocking — a failure here must not prevent company creation.
-  try {
-    await recordOnboardingFacts({
+    // 1c. Onboarding facts → applicability engine. Non-fatal but loud.
+    recordOnboardingFacts({
       companyId: company.id,
       createdBy: user.id,
       employeeCount: formData.employeeCount ? parseInt(formData.employeeCount, 10) : null,
@@ -263,36 +269,34 @@ export async function completeOnboarding(
       msmeCategory: formData.msmeCategory || null,
       hasImportsExports: formData.hasImportsExports ?? null,
       isStartupDpiit: formData.isStartupDpiit ?? null,
-    })
-  } catch (factErr) {
-    // Non-fatal but loud: a silent swallow here is exactly what made
-    // intake re-prompt for users who DID fill onboarding — facts never
-    // landed and refreshIntakeStatus correctly reported needsIntake=true.
-    // Log full stack so the failure mode is debuggable next time.
-    console.error('[onboarding] recordOnboardingFacts failed (non-fatal, but intake will re-prompt):',
-      factErr instanceof Error ? factErr.message : factErr,
-      factErr instanceof Error ? factErr.stack : '')
-  }
+    }).catch((factErr) => {
+      console.error(
+        '[onboarding] recordOnboardingFacts failed (non-fatal, but intake will re-prompt):',
+        factErr instanceof Error ? factErr.message : factErr,
+        factErr instanceof Error ? factErr.stack : '',
+      )
+    }),
 
-  // 2. Insert Directors
-  if (directors.length > 0) {
-    await directorRepository.createMany(
-      directors.map((dir) => ({
-        companyId: company.id,
-        firstName: dir.firstName,
-        lastName: dir.lastName,
-        middleName: dir.middleName || null,
-        din: dir.din || null,
-        designation: dir.designation || null,
-        dob: dir.dob || null,
-        pan: dir.pan || null,
-        email: dir.email || null,
-        mobile: dir.mobile || null,
-        isVerified: dir.verified || false,
-        source: dir.source || 'manual'
-      }))
-    )
-  }
+    // 2. Directors (skipped if user added none).
+    directors.length > 0
+      ? directorRepository.createMany(
+          directors.map((dir) => ({
+            companyId: company.id,
+            firstName: dir.firstName,
+            lastName: dir.lastName,
+            middleName: dir.middleName || null,
+            din: dir.din || null,
+            designation: dir.designation || null,
+            dob: dir.dob || null,
+            pan: dir.pan || null,
+            email: dir.email || null,
+            mobile: dir.mobile || null,
+            isVerified: dir.verified || false,
+            source: dir.source || 'manual',
+          })),
+        )
+      : Promise.resolve(),
+  ])
 
   // 3. Insert document metadata into internal table
   if (formData.documents.length > 0) {
@@ -322,12 +326,18 @@ export async function completeOnboarding(
       })
     )
 
-    // Background process: Extract text content from each PDF for AI understanding
-    if (insertedDocs) {
+    // Background process: Extract text content from each PDF for AI
+    // understanding + queue OCR-based fact ingest. Both are
+    // fire-and-forget so they don't block the response.
+    //
+    // Hoist the ingest-worker import OUT of the loop: it used to be
+    // re-resolved on every iteration. With cold module cache that adds
+    // a measurable hit on the first onboarding submit of each lambda.
+    if (insertedDocs && insertedDocs.length > 0) {
+      const { enqueueIngestJob } = await import('@/lib/compliance/ingest-worker')
       for (const doc of insertedDocs) {
-        // We don't await this so the user doesn't wait for parsing
-        processDocumentContent(doc.id, company.id, doc.filePath).catch(err =>
-          console.error(`Async processing failed for ${doc.id}:`, err)
+        processDocumentContent(doc.id, company.id, doc.filePath).catch((err) =>
+          console.error(`Async processing failed for ${doc.id}:`, err),
         )
 
         // Smart-ingest queue: PAN / GST / COI / MOA-AOA / etc. cert
@@ -338,16 +348,16 @@ export async function completeOnboarding(
         // already in `company_facts` carry `confidence=1.0,
         // sourceKind=user_declared` — the reader prefers typed on
         // conflict, so OCR fills gaps without overriding correct
-        // entries. Fire-and-forget; failure logs but doesn't block
-        // onboarding completion.
-        const { enqueueIngestJob } = await import('@/lib/compliance/ingest-worker')
+        // entries.
         enqueueIngestJob({
           documentId: doc.id,
           companyId: company.id,
           source: 'onboarding',
-        }).catch(err => {
-          console.error(`Onboarding ingest enqueue failed for ${doc.id}:`,
-            err instanceof Error ? err.message : err)
+        }).catch((err) => {
+          console.error(
+            `Onboarding ingest enqueue failed for ${doc.id}:`,
+            err instanceof Error ? err.message : err,
+          )
         })
       }
     }

--- a/lib/vault/folders.ts
+++ b/lib/vault/folders.ts
@@ -1,4 +1,5 @@
 import 'server-only'
+import { randomUUID } from 'crypto'
 import { prisma } from '@/lib/prisma'
 import { SYSTEM_TAXONOMY, LEGACY_FOLDER_MAP, type SystemFolderDef } from './taxonomy'
 
@@ -16,6 +17,22 @@ const EXPECTED_SYSTEM_FOLDER_COUNT = (() => {
   return count(SYSTEM_TAXONOMY)
 })()
 
+/**
+ * Seed every system folder for a company in TWO database roundtrips:
+ *   1. findMany — read whatever's already there.
+ *   2. createMany — insert everything missing in a single batch.
+ *
+ * Children can reference parents in the same INSERT because we generate
+ * UUIDs in code upfront (Postgres' uuid_generate_v4 produces RFC 4122 v4
+ * UUIDs; randomUUID() from node:crypto produces the same shape — they're
+ * interchangeable from the DB's perspective).
+ *
+ * Previous implementation did N sequential prisma.vaultFolder.create()
+ * calls (one per missing folder, ~18 in a fresh company). With Vercel in
+ * iad1 and Supabase in ap-south-1, every create round-trip cost ~250 ms,
+ * so a fresh onboarding paid ~4.5 s just for folder seeding. This drops
+ * that to ~500 ms total (one findMany + one createMany).
+ */
 export async function ensureSystemFolders(companyId: string): Promise<void> {
   // Single query: pull id + slug + parent_id for every existing system row.
   const existing = await prisma.vaultFolder.findMany({
@@ -30,33 +47,56 @@ export async function ensureSystemFolders(companyId: string): Promise<void> {
   const idByKey = new Map<string, string>()
   for (const r of existing) idByKey.set(keyFor(r.slug, r.parent_id), r.id)
 
+  // Walk the taxonomy once, queueing missing nodes for batch insert. Each
+  // new node gets a UUID generated in code so its children (which we
+  // encounter later in the same walk) can reference it via parent_id
+  // even though Postgres hasn't seen the parent row yet — the whole tree
+  // lands in one createMany.
+  type FolderInsert = {
+    id: string
+    company_id: string
+    parent_id: string | null
+    slug: string
+    name: string
+    kind: string
+    sort_order: number
+  }
+  const toInsert: FolderInsert[] = []
+
   let sort = 0
-  const insertTree = async (nodes: SystemFolderDef[], parentId: string | null) => {
+  const collect = (nodes: SystemFolderDef[], parentId: string | null) => {
     for (const node of nodes) {
       const key = keyFor(node.slug, parentId)
       let folderId = idByKey.get(key)
       if (!folderId) {
-        const row = await prisma.vaultFolder.create({
-          data: {
-            company_id: companyId,
-            parent_id: parentId,
-            slug: node.slug,
-            name: node.name,
-            kind: 'system',
-            sort_order: sort++,
-          },
-          select: { id: true },
-        })
-        folderId = row.id
+        folderId = randomUUID()
         idByKey.set(key, folderId)
+        toInsert.push({
+          id: folderId,
+          company_id: companyId,
+          parent_id: parentId,
+          slug: node.slug,
+          name: node.name,
+          kind: 'system',
+          sort_order: sort++,
+        })
       }
       if (node.children?.length) {
-        await insertTree(node.children, folderId)
+        collect(node.children, folderId)
       }
     }
   }
+  collect(SYSTEM_TAXONOMY, null)
 
-  await insertTree(SYSTEM_TAXONOMY, null)
+  if (toInsert.length > 0) {
+    // skipDuplicates handles the race where two concurrent onboardings
+    // for the same companyId try to seed at once (rare but possible —
+    // see CLAUDE.md §12, can't wrap in interactive $transaction).
+    await prisma.vaultFolder.createMany({
+      data: toInsert,
+      skipDuplicates: true,
+    })
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

Vercel `iad1` ↔ Supabase `ap-south-1` is a **~250ms RTT per database call** (cross-Atlantic + Indian Ocean). Two hot spots in `completeOnboarding` were costing the user **5+ seconds**:

1. **`ensureSystemFolders` ran N sequential `prisma.vaultFolder.create()` calls** (one per missing folder, up to 18 for a fresh company). ~18 × 250 ms = **~4.5 s** of pure round-trip latency just for folder seeding.

2. **Five post-create writes were awaited one after another** (GST, role, folders, facts, directors). ~5 × 250 ms = **~1.25 s** even though every write hits a different table and is independent once `company.id` exists.

## Phase 1.1 — `lib/vault/folders.ts`

- Generate UUIDs for new folder nodes upfront via `crypto.randomUUID()` so children can reference `parent_id` even though Postgres hasn't seen the parent row yet. The whole tree lands in one `createMany`.
- **Now: 1 findMany + 1 createMany = 2 round-trips total.** Was: 1 findMany + up to 18 sequential creates = up to 19.
- Estimated savings: **~4 s** on first-time onboarding, ~0 on repeat visits (the existing fast-path early-return already handles that).
- `skipDuplicates: true` preserves race-safety (two concurrent seeds for the same `companyId` would otherwise hit the `@@unique([company_id, parent_id, slug])` constraint).

## Phase 1.3 — `app/onboarding/actions.ts`

- Wrapped the five post-create writes (GST / role / folders / facts / directors) in a single `Promise.all` so they all run in one round-trip window instead of five sequentially.
- Each task catches its own error to preserve the prior per-step "non-fatal, log-and-continue" semantics for role / folder / facts writes. createMany rejections still surface for GST/directors because those are user-typed data and silent loss there would be worse than failing onboarding loudly.
- Hoisted the dynamic `import('@/lib/compliance/ingest-worker')` out of the per-document for-loop. Was re-resolving per iteration on cold module cache.

## Estimated impact

| Surface | Before | After |
|---|---|---|
| `completeOnboarding` end-to-end (no docs, 1 director) | ~7.5 s | ~2.5 s |
| `completeOnboarding` end-to-end (3 docs, 3 directors) | ~9.5 s | ~3.5 s |
| `ensureSystemFolders` first-time | ~4.5 s | ~500 ms |
| `ensureSystemFolders` repeat | ~250 ms (fast-path) | ~250 ms (unchanged) |

## Functional safety
- 2 files, 144 ins / 94 del.
- No schema, contract, or external-call changes. Pure restructure.
- Folder seed remains idempotent — repeat calls find existing rows via `(company_id, parent_id, slug)` and short-circuit.
- Per-step error handling preserved (role / folder / facts continue to be "non-fatal log-and-continue").
- `tsc --noEmit` clean.

## Branch hygiene
- Branched off `origin/main` after PR #110.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized company onboarding workflow by parallelizing registration, role assignment, and folder setup tasks.
  * Improved system folder seeding efficiency through batched database operations.

* **Improvements**
  * Enhanced error logging and reporting for document ingestion during onboarding processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finacra/tracker/pull/121)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->