### PR TITLE
perf(auth): resolve appUser server-side in layout RSC (PR-33)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -15,17 +15,49 @@ import { Analytics as VercelAnalytics } from '@vercel/analytics/next'
 import ToastContainer from '@/components/ui/Toast'
 import { ThemeProvider, THEME_INLINE_SCRIPT } from '@/lib/theme/ThemeProvider'
 import ThemeToggle from '@/components/ui/ThemeToggle'
+import { getSession } from '@/lib/auth/passport-session'
+import { createServerContainer } from '@/lib/composition/server-container'
+import type { AppUser } from '@/domain/models/AppUser'
 
 export const metadata: Metadata = {
   title: 'Finacra - Financial Compliance Management',
   description: 'Sign in to manage your financial compliance',
 }
 
-export default function RootLayout({
+/**
+ * Resolve the current user server-side once per request so the client
+ * Providers doesn't have to do its own getSession() + /api/auth/profile
+ * two-step on mount. Vercel iad1 ↔ Supabase ap-south-1 ≈ 250 ms RTT
+ * per round trip; absorbing this trip into the initial server render
+ * removes a visible ~250 ms "shell-then-fill" flash on every page mount
+ * (Header, useAuth-gated components stop flickering empty → filled).
+ *
+ * Returns null when there's no session or the user row no longer exists
+ * (e.g. DB wipe with a stale cookie still around) — matches the client
+ * adapter's fallback exactly. Failure here is non-fatal: client takes
+ * over with its original fetch chain if initialAppUser is null.
+ */
+async function resolveInitialAppUser(): Promise<AppUser | null> {
+  try {
+    const session = await getSession()
+    if (!session) return null
+    const { authService } = createServerContainer()
+    return await authService.getCurrentUser()
+  } catch (err) {
+    console.error('[layout] resolveInitialAppUser threw',
+      err instanceof Error ? err.message : err,
+      err instanceof Error ? err.stack : '')
+    return null
+  }
+}
+
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const initialAppUser = await resolveInitialAppUser()
+
   return (
     <html lang="en" className={`${GeistSans.variable} ${GeistMono.variable}`} suppressHydrationWarning>
       <head>
@@ -41,7 +73,7 @@ export default function RootLayout({
         <VercelAnalytics />
         <ThemeProvider>
           <QueryProvider>
-            <Providers>
+            <Providers initialAppUser={initialAppUser}>
               <AnalyticsWrapper>{children}</AnalyticsWrapper>
             </Providers>
           </QueryProvider>

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -9,11 +9,31 @@ import { AuthProvider, type AuthContextValue } from '@/contexts/AuthContext'
 import type { AppUser } from '@/domain/models/AppUser'
 import { useAppStore } from '@/lib/store/appStore'
 
-export function Providers({ children }: { children: React.ReactNode }) {
+export function Providers({
+  children,
+  initialAppUser = null,
+}: {
+  children: React.ReactNode
+  /**
+   * Pre-resolved AppUser from the server-rendered layout. When this is
+   * provided (Phase 1.5), the initial useEffect skips the client-side
+   * getSession() + fetch('/api/auth/profile') chain — both have already
+   * happened on the server during the initial page render. Saves
+   * ~250 ms of visible "shell-then-fill" flash on every page mount.
+   *
+   * When null (unauthenticated visitor OR server-side resolution
+   * failed), Providers falls back to the original two-step client
+   * dance — preserves the existing behavior for those paths.
+   */
+  initialAppUser?: AppUser | null
+}) {
   const queryClient = useQueryClient()
-  const [appUser, setAppUser] = useState<AppUser | null>(null)
-  const [loading, setLoading] = useState(true)
-  
+  const [appUser, setAppUser] = useState<AppUser | null>(initialAppUser)
+  // Seed loading=false when we already have the user — the page can
+  // render its full auth-gated state immediately. Otherwise stay
+  // loading until the client-side fetch chain resolves.
+  const [loading, setLoading] = useState(!initialAppUser)
+
   // Choose auth provider based on environment variable (default to Supabase for backward compatibility)
   // Composition: Only use Passport now
   const authAdapter = useMemo(() => {
@@ -21,7 +41,12 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }, [])
   const trackedLoginUserIdRef = useRef<string | null>(null)
   const appUserRequestIdRef = useRef(0)
-  const resolvedAppUserIdRef = useRef<string | null>(null)
+  // If we have an initialAppUser, seed resolvedAppUserIdRef so syncAppUser's
+  // "already resolved" short-circuit (line 75) kicks in immediately on any
+  // subsequent onAuthStateChange call for the same user.
+  const resolvedAppUserIdRef = useRef<string | null>(
+    initialAppUser?.id ?? null,
+  )
   // Track which user.id we've already resolved superadmin status for —
   // this lives in providers (mounted once at app root) instead of
   // Header.tsx so that Header unmount/remount cycles (e.g. /data-room
@@ -114,17 +139,41 @@ export function Providers({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     let initialLoadDone = false
 
-    // Initial load: wait for session AND app profile before releasing loading state
-    authAdapter.getSession().then(async (session) => {
-      const resolvedUser = await syncAppUser(session)
+    if (initialAppUser) {
+      // Server-rendered seed (Phase 1.5): the user is already known and
+      // the React state is already populated. Skip the client-side
+      // getSession + /api/auth/profile two-step entirely — they would
+      // just re-fetch what the layout already gave us, costing
+      // ~250 ms × 2 round-trips on every page mount.
+      //
+      // Mark initialLoadDone=true synchronously BEFORE we attach the
+      // onAuthStateChange listener, so the listener's "skip if not
+      // initial-load-done" gate (Rule 10) opens immediately for any
+      // subsequent SIGN_OUT/TOKEN_REFRESHED that fires.
       initialLoadDone = true
-      setLoading(false)
-      await trackLoginOnce(session, undefined, resolvedUser)
-    }).catch(err => {
-      console.error('[PROVIDERS] getSession error:', err)
-      initialLoadDone = true
-      setLoading(false)
-    })
+      // Fire-and-forget the login tracker. trackedLoginUserIdRef
+      // de-dupes — same user.id won't trigger a second POST. The
+      // accessToken is unused by trackLoginOnce / track-login API
+      // (they only need userId + appUser), so passing null is safe.
+      void trackLoginOnce(
+        { userId: initialAppUser.id, email: initialAppUser.email, accessToken: null },
+        undefined,
+        initialAppUser,
+      )
+    } else {
+      // No server-side seed (logged out OR layout resolver failed).
+      // Fall back to the original two-step dance.
+      authAdapter.getSession().then(async (session) => {
+        const resolvedUser = await syncAppUser(session)
+        initialLoadDone = true
+        setLoading(false)
+        await trackLoginOnce(session, undefined, resolvedUser)
+      }).catch(err => {
+        console.error('[PROVIDERS] getSession error:', err)
+        initialLoadDone = true
+        setLoading(false)
+      })
+    }
 
     const { unsubscribe } = authAdapter.onAuthStateChange(async (_event, session) => {
       // Skip if initial load hasn't finished — avoid racing with getSession above


### PR DESCRIPTION
## Summary

Before this PR, every page mount fired a 2-step client-side auth dance in `providers.tsx`:

1. `authAdapter.getSession()` → `fetch('/api/auth/passport/session')` — ~50 ms
2. `syncAppUser()` → `fetch('/api/auth/profile')` — ~300 ms (250 ms DB + RTT)

Total: **~350 ms BEFORE** auth-gated components (Header, `useAuth`-based hooks) could render their final state. The user saw a "shell-then-fill" flash on every navigation.

## Implementation

- **`app/layout.tsx`** — now async. Calls `resolveInitialAppUser()` (`getSession()` + `authService.getCurrentUser()`) and passes the result as `initialAppUser` prop to `<Providers>`. Failure is non-fatal — falls back to client path.
- **`app/providers.tsx`** — accepts `initialAppUser` (defaults null). Seeds `useState`, seeds `resolvedAppUserIdRef`, branches the useEffect: if seeded, skip the client-side getSession + profile fetch entirely; mark `initialLoadDone=true` synchronously BEFORE attaching `onAuthStateChange` listener (CLAUDE.md Rule 10 compliance). If not seeded, original two-step path runs unchanged.

## Rule 10 compliance

Both branches honor "onAuthStateChange must not fire until initial load completes":
- Fallback branch: identical to existing code.
- Pre-seeded branch: `initialLoadDone=true` is set synchronously before the listener attaches. **No concurrent `syncAppUser` callers added** — the prohibited pattern.

## Estimated impact

| Surface | Before | After |
|---|---|---|
| Time-to-final-render (user-perceived) | x + 300 ms | x (server absorbs the cost) |
| Header user-menu flicker on every nav | visible | gone |
| Client API roundtrips on every page mount | 2 | 0 (when seeded) |

## Branch hygiene
- Branched off `origin/main` after PR #122.
- Zero merge commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)