### PR TITLE
perf(auth): embed emailVerified in JWT — proxy skips DB gate on every protected request

### DIFF
--- a/app/api/auth/passport/callback/route.ts
+++ b/app/api/auth/passport/callback/route.ts
@@ -166,11 +166,14 @@ export async function GET(request: NextRequest) {
       }
     }
 
-    // Create session
+    // Create session. Google has verified the email, so we mint the JWT
+    // with emailVerified=true so the proxy middleware skips its DB
+    // gating query on every subsequent request.
     await setSession({
       appUserId: appUser.id,
       email: appUser.email,
       googleId,
+      emailVerified: true,
     })
 
     // Track login

--- a/app/api/auth/passport/link-password/route.ts
+++ b/app/api/auth/passport/link-password/route.ts
@@ -88,11 +88,14 @@ export async function POST(req: NextRequest) {
       data: { password_hash: hash } as any
     })
 
-    // 4. Create session
+    // 4. Create session. verifyEmailToken flipped email_verified=true on
+    // app_users, so mint the JWT with the matching claim — proxy
+    // middleware skips the DB gating query on every subsequent request.
     const sessionUser: PassportSessionUser = {
       appUserId: updatedUser.id,
       email: updatedUser.primary_email,
       googleId: '',
+      emailVerified: true,
     }
 
     const response = NextResponse.json({ 

--- a/app/api/auth/passport/login/route.ts
+++ b/app/api/auth/passport/login/route.ts
@@ -120,11 +120,13 @@ export async function POST(req: NextRequest) {
       })
     })
 
-    await setSessionInResponse(user, response)
-    // Pre-populate the proxy middleware's verification cache so the
-    // next request (redirect target after login) doesn't pay the
-    // ~250 ms Vercel iad1 ↔ Supabase ap-south-1 DB query just to check
-    // email_verified. We already know the value from line 98 above.
+    // PR-36 carries emailVerified inside the JWT itself, so the proxy
+    // middleware no longer needs the separate email_verified cookie for
+    // freshly-issued sessions. We still call setVerificationCookies for
+    // belt-and-braces compatibility — old code paths that pre-date PR-36
+    // may continue to read the cookie until the next rotate-out.
+    const userWithVerified = { ...user, emailVerified }
+    await setSessionInResponse(userWithVerified, response)
     setVerificationCookiesInResponse(response, {
       userId: user.appUserId,
       verified: emailVerified,

--- a/app/api/auth/passport/register/route.ts
+++ b/app/api/auth/passport/register/route.ts
@@ -110,6 +110,11 @@ export async function POST(req: NextRequest) {
       appUserId: user.id,
       email: user.primary_email,
       googleId: '',
+      // Fresh email/password signup — verification email just sent,
+      // claim starts false. The proxy will keep redirecting them to
+      // /verify-email until they click the link, at which point a fresh
+      // session (carrying emailVerified=true) is minted.
+      emailVerified: false,
     }
 
     const response = NextResponse.json({ 

--- a/app/api/auth/verify-email/route.ts
+++ b/app/api/auth/verify-email/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from 'next/server'
 import { verifyEmailToken, peekVerificationToken, resendVerificationEmail } from '@/lib/email/verification'
 import { prisma } from '@/lib/prisma'
 import { handleAPIError } from '@/lib/errors/handle-error'
-import { setVerificationCookiesInResponse } from '@/lib/auth/passport-session'
+import {
+  setVerificationCookiesInResponse,
+  setSessionInResponse,
+  verifySession,
+} from '@/lib/auth/passport-session'
 
 /**
  * Email verification endpoint
@@ -111,6 +115,22 @@ export async function GET(request: NextRequest) {
         userId: nowVerifiedUserId,
         verified: true,
       })
+      // PR-36: if the verifying user has an active JWT session on this
+      // device, rotate the cookie so emailVerified=true is baked into
+      // the signed claim. Subsequent requests skip the proxy DB gating
+      // query entirely instead of relying on the email_verified cookie
+      // fallback. Other devices stay on the cookie fallback until they
+      // next sign in (then the new JWT is minted with the live value).
+      const existingToken = request.cookies.get('passport_session')?.value
+      if (existingToken) {
+        const existing = await verifySession(existingToken)
+        if (existing && existing.appUserId === nowVerifiedUserId) {
+          await setSessionInResponse(
+            { ...existing, emailVerified: true },
+            response,
+          )
+        }
+      }
     }
 
     return response

--- a/app/api/invite/signup-with-invite/route.ts
+++ b/app/api/invite/signup-with-invite/route.ts
@@ -112,11 +112,15 @@ export async function POST(req: NextRequest) {
       await companyMembershipRepository.upsertRole(user.id, invite.companyId, invite.role, user.id)
     }
 
-    // 5. Create session
+    // 5. Create session — fresh invite signup, verification email just
+    // sent, claim starts false. Proxy will redirect to /verify-email
+    // until they click the link, at which point a fresh session
+    // (carrying emailVerified=true) is minted.
     const sessionUser: PassportSessionUser = {
       appUserId: user.id,
       email: user.primary_email,
       googleId: '',
+      emailVerified: false,
     }
 
     const response = NextResponse.json({

--- a/application/interfaces/MiddlewareAuthCheck.ts
+++ b/application/interfaces/MiddlewareAuthCheck.ts
@@ -10,6 +10,14 @@ import type { NextRequest } from 'next/server'
 export interface MiddlewareAuthResult {
   authenticated: boolean
   userId: string | null
+  /**
+   * Optional verification flag surfaced from the session token itself.
+   * When true, proxy middleware can skip its DB gating query (PR-36 —
+   * shaves ~250 ms iad1↔ap-south-1 RTT on every protected request).
+   * When false/undefined, fall back to the existing DB check (old JWTs
+   * without the claim default to undefined here).
+   */
+  emailVerified?: boolean
 }
 
 export interface MiddlewareAuthCheck {

--- a/infrastructure/auth/passport/PassportMiddlewareAuthCheck.ts
+++ b/infrastructure/auth/passport/PassportMiddlewareAuthCheck.ts
@@ -52,6 +52,7 @@ export class PassportMiddlewareAuthCheck implements MiddlewareAuthCheck {
         result: {
           authenticated: true,
           userId: session.appUserId,
+          emailVerified: session.emailVerified,
         },
         response,
       }

--- a/lib/auth/passport-callback-handler.ts
+++ b/lib/auth/passport-callback-handler.ts
@@ -260,12 +260,15 @@ export async function handlePassportCallback(
     // Create redirect response and set session cookie
     let response = NextResponse.redirect(redirectUrl)
     
-    // Set session in response
+    // Set session in response — Google has verified the email, so the
+    // JWT carries emailVerified=true and the proxy middleware skips its
+    // DB gating query on every subsequent request.
     response = await setSessionInResponse(
       {
         appUserId: appUser.id,
         email: appUser.email,
         googleId,
+        emailVerified: true,
       },
       response
     )

--- a/lib/auth/passport-config.ts
+++ b/lib/auth/passport-config.ts
@@ -29,6 +29,20 @@ export interface PassportSessionUser {
   appUserId: string // Canonical app_users.id
   email: string
   googleId: string // Google user ID (sub)
+  /**
+   * Email verification status, embedded in the session JWT so the proxy
+   * middleware can short-circuit its DB check (~250 ms Vercel iad1 ↔
+   * Supabase ap-south-1 RTT). PR-32 cached this in a separate cookie;
+   * PR-36 hoists it into the JWT payload itself so a single signed
+   * artifact carries everything we need to decide gate access.
+   *
+   * Set true at every session-creation site where the email is known to
+   * be verified (Google OAuth, post-link-password, login for verified
+   * accounts, verify-email consume). Set false for fresh email/password
+   * signups — middleware then falls through to the existing DB check,
+   * which still works as before.
+   */
+  emailVerified: boolean
 }
 
 /**
@@ -71,10 +85,20 @@ export function initializePassport() {
       const identities = await authIdentityRepository.findByAppUserId(appUser.id)
       const passportIdentity = identities.find((id) => id.provider === 'passport')
 
+      // Pull current email_verified so deserialization reflects DB truth.
+      // This path runs rarely (passport.deserializeUser is mostly unused
+      // in the App Router flow — we go through verifySession + JWT) so
+      // the extra read is a non-issue.
+      const appUserRow = await prisma.appUser.findUnique({
+        where: { id: appUser.id },
+        select: { email_verified: true },
+      })
+
       const sessionUser: PassportSessionUser = {
         appUserId: appUser.id,
         email: appUser.email,
         googleId: passportIdentity?.legacyAuthId || appUser.legacyAuthId || '',
+        emailVerified: appUserRow?.email_verified === true,
       }
 
       done(null, sessionUser)
@@ -114,6 +138,8 @@ export function initializePassport() {
               appUserId: appUser.id,
               email: appUser.email,
               googleId,
+              // Google has confirmed the email — verified for the proxy gate.
+              emailVerified: true,
             }
 
             return done(null, sessionUser)
@@ -141,6 +167,7 @@ export function initializePassport() {
               appUserId: appUser.id,
               email: appUser.email,
               googleId,
+              emailVerified: true,
             }
 
             return done(null, sessionUser)
@@ -173,6 +200,7 @@ export function initializePassport() {
             appUserId: newAppUserRow.id,
             email: newAppUserRow.primary_email,
             googleId,
+            emailVerified: true,
           }
 
           return done(null, sessionUser)
@@ -218,6 +246,7 @@ export function initializePassport() {
                 appUserId: appUserRow.id,
                 email: appUserRow.primary_email,
                 googleId: '', // No google ID for local
+                emailVerified: userWithHash.email_verified === true,
               }
               return done(null, sessionUser)
             } else {

--- a/lib/auth/passport-session.ts
+++ b/lib/auth/passport-session.ts
@@ -24,6 +24,13 @@ export async function createSession(user: PassportSessionUser): Promise<string> 
     appUserId: user.appUserId,
     email: user.email,
     googleId: user.googleId,
+    // PR-36: ship verification status with the signed session so the
+    // proxy middleware can gate access without a round trip to
+    // ap-south-1 Postgres on every protected request. Old tokens from
+    // PR-32 and earlier won't carry this claim; verifySession() below
+    // defaults missing claims to false, which keeps the existing DB
+    // fallback path correct until the JWT rotates on next sign-in.
+    emailVerified: user.emailVerified,
   })
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt()
@@ -45,6 +52,11 @@ export async function verifySession(token: string): Promise<PassportSessionUser 
       appUserId: payload.appUserId as string,
       email: payload.email as string,
       googleId: payload.googleId as string,
+      // Default to false when the claim is missing (pre-PR-36 tokens).
+      // The proxy middleware's existing DB fallback then runs, and the
+      // user's next session creation (login/OAuth/link-password) will
+      // mint a fresh JWT carrying the actual value.
+      emailVerified: payload.emailVerified === true,
     }
   } catch (error) {
     return null

--- a/proxy.ts
+++ b/proxy.ts
@@ -57,7 +57,19 @@ export default async function proxy(request: NextRequest) {
   ]
   
   if (result.authenticated && result.userId && !excludedFromVerificationCheck.includes(pathname)) {
-    // Check if we've already verified this session (cached in cookie)
+    // PR-36 fast path: the session JWT itself carries emailVerified.
+    // When it's true, we trust it and skip both the cookie fallback and
+    // the ~250 ms DB gating query entirely. The JWT is freshly signed
+    // by us at every session-creation site (login, OAuth callback,
+    // link-password, verify-email re-issue), so it's the authoritative
+    // value at session-creation time.
+    if (result.emailVerified === true) {
+      return response
+    }
+
+    // Fallback path for tokens that pre-date PR-36 (the claim defaults
+    // to undefined for them). Check if we've already verified this
+    // session via the legacy email_verified cookie.
     const verificationCookie = request.cookies.get('email_verified')
     const cachedVerificationStatus = verificationCookie?.value === 'true'
     const cachedUserId = request.cookies.get('email_verified_user_id')?.value


### PR DESCRIPTION
## Summary
- Adds an `emailVerified: boolean` claim to the Passport session JWT itself, hoisting the cached verification status out of the separate `email_verified` cookie (PR-32) and into the signed session token.
- The proxy middleware short-circuits the moment it sees the claim is `true` — zero DB round trips, no cookie read.
- Every session-creation site sets the claim to its real value at mint time: Google OAuth callback (`true`), login (real DB value, already fetched there), register/invite signup (`false`), link-password (`true`), and a new verify-email JWT rotation on consume.

## Why
At Vercel iad1 ↔ Supabase ap-south-1 ≈ 250 ms RTT, the proxy's email-verification gate paid that round trip on every first request after sign-up, after OAuth callback, and after each verify-email transition — i.e., every redirect in the signup → /subscribe → /onboarding → /data-room chain. PR-32 absorbed most of those into a separate cookie cache, but unverified users still hit the DB on every request, and the cookie was an extra signed-state artifact alongside the JWT. PR-36 collapses both concerns into the JWT: it's the only signed claim we need.

## Backward compatibility
Old JWTs that pre-date this PR carry no `emailVerified` claim. `verifySession` decodes them with the field as `false` (default for missing claims), so the existing cookie-cache + DB fallback still gates them correctly until the next sign-in rotates the token. The cookie-cache code path is left intact for this transition window.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Smoke verified user: sign in with email/password where DB has `email_verified=true` — confirm /data-room loads with zero `email_verified` DB queries in proxy logs
- [ ] Smoke fresh signup: register a new email/password user — confirm proxy keeps redirecting to /verify-email until token consumed
- [ ] Smoke verify-email mid-session: while signed in unverified, click email link — confirm subsequent navigation flows skip the DB check (JWT rotated)
- [ ] Smoke Google OAuth: sign in via Google — confirm /data-room loads with zero verification DB queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)