### PR TITLE
perf(db): annotate five hot read paths with Accelerate cache strategies

### DIFF
--- a/infrastructure/persistence/prisma/PrismaCompanyMembershipRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaCompanyMembershipRepository.ts
@@ -20,19 +20,28 @@ export class PrismaCompanyMembershipRepository implements CompanyMembershipRepos
     }
 
     async getAdminUserIds(companyId: string): Promise<string[]> {
-        // Get admin user IDs - for Passport users, use app_user_id; for legacy, use user_id
-        const rows = await prisma.userRole.findMany({
+        // Cached via Prisma Accelerate (60s TTL + 30s SWR). The admin
+        // roster for a company is stable across hours — additions and
+        // removals are rare ops. This query fires on every team-invite
+        // email, comment notification, and audit-event broadcast to
+        // pick recipients. Auto-invalidates when userRole rows are
+        // written (addRole/upsertRole/updateRole/removeRole below all
+        // go through Prisma, so Accelerate sees them).
+        const rows = await (prisma.userRole.findMany({
             where: {
                 company_id: companyId,
                 role: { in: ['admin', 'superadmin'] },
             },
-            select: { 
+            select: {
                 user_id: true,
                 app_user_id: true
-            }
-        })
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any).cacheStrategy({ ttl: 60, swr: 30 })
         // Return app_user_id for Passport users, user_id for legacy users
-        return rows.map((row) => row.app_user_id || row.user_id).filter((id): id is string => id !== null)
+        return rows
+          .map((row: { user_id: string | null; app_user_id: string | null }) => row.app_user_id || row.user_id)
+          .filter((id: string | null): id is string => id !== null)
     }
 
     async getRoles(companyId?: string | null): Promise<(CompanyMembership & { appUserId?: string | null })[]> {

--- a/infrastructure/persistence/prisma/PrismaCompanyRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaCompanyRepository.ts
@@ -257,10 +257,16 @@ export class PrismaCompanyRepository implements CompanyRepository {
   }
 
   async getCountryCode(companyId: string): Promise<string | null> {
-    const row = await prisma.company.findUnique({
+    // Cached via Prisma Accelerate (5 min TTL + 2 min SWR). Country
+    // code is set at company creation and effectively immutable
+    // afterwards. This fires on every regulatory-requirement query
+    // (~250 ms iad1↔ap-south-1 RTT) to drive country-specific deadline
+    // calculations. Auto-invalidates if a company is updated via Prisma.
+    const row = await (prisma.company.findUnique({
       where: { id: companyId },
-      select: { country_code: true }
-    })
+      select: { country_code: true },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any).cacheStrategy({ ttl: 300, swr: 120 })
     return row?.country_code ?? null
   }
 

--- a/infrastructure/persistence/prisma/PrismaEmailPreferenceRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaEmailPreferenceRepository.ts
@@ -8,9 +8,15 @@ import { prisma } from '@/lib/prisma'
 
 export class PrismaEmailPreferenceRepository implements EmailPreferenceRepository {
     async getByUserId(userId: string): Promise<EmailPreferenceRecord | null> {
-        const row = await prisma.emailPreference.findUnique({
+        // Cached via Prisma Accelerate (60s TTL + 30s SWR). User
+        // preferences change rarely (settings UI edit, maybe once a
+        // month) but this fires on every notification-routing decision
+        // and team-update broadcast. Auto-invalidates on saveForUser's
+        // upsert below.
+        const row = await (prisma.emailPreference.findUnique({
             where: { user_id: userId },
-        })
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any).cacheStrategy({ ttl: 60, swr: 30 })
 
         if (!row) return null
 

--- a/infrastructure/persistence/prisma/PrismaVaultTemplateManagementRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaVaultTemplateManagementRepository.ts
@@ -30,14 +30,20 @@ export class PrismaVaultTemplateManagementRepository implements VaultTemplateMan
     }
 
     async getById(id: string): Promise<VaultTemplateDetails | null> {
-        const row = await prisma.documentTemplate.findUnique({
+        // Cached via Prisma Accelerate (5 min TTL + 2 min SWR). Template
+        // metadata is admin-controlled, static across user sessions, and
+        // queried on every document-requirement breadcrumb render.
+        // Auto-invalidates when documentTemplate rows are written via
+        // this same repository's create/update/delete methods.
+        const row = await (prisma.documentTemplate.findUnique({
             where: { id },
             select: {
                 id: true,
                 document_name: true,
                 folder_name: true,
             },
-        })
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any).cacheStrategy({ ttl: 300, swr: 120 })
 
         if (!row) return null
 

--- a/infrastructure/persistence/prisma/PrismaVaultTemplateRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaVaultTemplateRepository.ts
@@ -3,27 +3,38 @@ import { prisma } from '@/lib/prisma'
 
 export class PrismaVaultTemplateRepository implements VaultTemplateRepository {
     async getFolderPaths(): Promise<string[]> {
-        const rows = await prisma.documentTemplate.findMany({
+        // Cached via Prisma Accelerate (5 min TTL + 2 min SWR). The
+        // documentTemplate catalog is admin-controlled and effectively
+        // static between maintenance windows, but this query fires on
+        // every data-room page load to populate the vault sidebar.
+        // Auto-invalidates when documentTemplate rows are written via
+        // the management repository.
+        const rows = await (prisma.documentTemplate.findMany({
             where: {
                 NOT: { folder_name: null },
             },
             select: { folder_name: true },
-        })
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any).cacheStrategy({ ttl: 300, swr: 120 })
 
         const paths = rows
-            .map((row) => row.folder_name)
-            .filter((folderName): folderName is string => Boolean(folderName))
+            .map((row: { folder_name: string | null }) => row.folder_name)
+            .filter((folderName: string | null): folderName is string => Boolean(folderName))
 
-        return Array.from(new Set(paths)).sort()
+        return Array.from(new Set<string>(paths)).sort()
     }
 
     async getTemplates(folderPath?: string | null): Promise<VaultTemplateRecord[]> {
-        const rows = await prisma.documentTemplate.findMany({
+        // Same justification as getFolderPaths above — static catalog,
+        // fires on every page load, 5 min cache.
+        const rows = await (prisma.documentTemplate.findMany({
             where: folderPath ? { folder_name: folderPath } : {},
             orderBy: { document_name: 'asc' },
-        })
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any).cacheStrategy({ ttl: 300, swr: 120 })
 
-        return rows.map((row) => ({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return rows.map((row: any) => ({
             id: row.id,
             documentName: row.document_name || '',
             folderName: row.folder_name,


### PR DESCRIPTION
## Summary
Extends PR-35's Accelerate wiring with `.cacheStrategy({ ttl, swr })` on five additional read paths. Each fires on every authenticated page load or notification dispatch, and each reads data that changes rarely enough that a 60s–5min cache is safe (with auto-invalidation handling the rare write case).

| Path | TTL / SWR | Fires on |
|---|---|---|
| `PrismaVaultTemplateRepository.getFolderPaths` | 5 min / 2 min | Every /data-room page load |
| `PrismaVaultTemplateRepository.getTemplates` | 5 min / 2 min | Every /data-room page load |
| `PrismaVaultTemplateManagementRepository.getById` | 5 min / 2 min | Document-requirement breadcrumb render |
| `PrismaCompanyRepository.getCountryCode` | 5 min / 2 min | Every regulatory-requirement query |
| `PrismaEmailPreferenceRepository.getByUserId` | 60 s / 30 s | Every notification routing decision |
| `PrismaCompanyMembershipRepository.getAdminUserIds` | 60 s / 30 s | Every team-invite / notification broadcast |

## Why these are safe
- All six paths use Prisma client `findUnique`/`findMany` (not `$queryRaw`), so Accelerate's automatic same-model invalidation does the heavy lifting — every `create`/`update`/`delete` against the same model bumps the cache entry.
- Template catalog and country code are admin-controlled and effectively static between maintenance windows.
- Admin roster and email preferences are session-stable for the user's lifetime; 60-second staleness is invisible in practice.

## Activation
Same as PR-35 — these are no-ops with a plain Postgres `DATABASE_URL` and activate the moment the URL points at the Accelerate proxy.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Smoke: /data-room cold load on Accelerate `DATABASE_URL` — confirm subsequent loads within 5 min hit Accelerate dashboard cache for `documentTemplate`
- [ ] Smoke: switch country/edit notification preferences — confirm UI sees fresh values within one cache window (≤60 s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Implemented enhanced database caching to improve application responsiveness across multiple core operations. Optimizations include faster user membership retrieval, company information lookups, email preference queries, and template management. These improvements reduce database load and deliver noticeably faster load times and smoother user interactions throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finacra/tracker/pull/127)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->