### PR TITLE
hotfix(db): make Accelerate cacheStrategy a runtime no-op when method missing

### DIFF
--- a/infrastructure/persistence/prisma/PrismaCompanyMembershipRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaCompanyMembershipRepository.ts
@@ -3,7 +3,7 @@ import type {
     CompanyMembershipRepository,
 } from '@/application/interfaces/CompanyMembershipRepository'
 import type { AppRole } from '@/domain/types/Role'
-import { prisma } from '@/lib/prisma'
+import { prisma, cached } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 
 export class PrismaCompanyMembershipRepository implements CompanyMembershipRepository {
@@ -27,21 +27,23 @@ export class PrismaCompanyMembershipRepository implements CompanyMembershipRepos
         // pick recipients. Auto-invalidates when userRole rows are
         // written (addRole/upsertRole/updateRole/removeRole below all
         // go through Prisma, so Accelerate sees them).
-        const rows = await (prisma.userRole.findMany({
-            where: {
-                company_id: companyId,
-                role: { in: ['admin', 'superadmin'] },
-            },
-            select: {
-                user_id: true,
-                app_user_id: true
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any).cacheStrategy({ ttl: 60, swr: 30 })
+        const rows = await cached(
+            prisma.userRole.findMany({
+                where: {
+                    company_id: companyId,
+                    role: { in: ['admin', 'superadmin'] },
+                },
+                select: {
+                    user_id: true,
+                    app_user_id: true
+                },
+            }),
+            { ttl: 60, swr: 30 },
+        )
         // Return app_user_id for Passport users, user_id for legacy users
         return rows
-          .map((row: { user_id: string | null; app_user_id: string | null }) => row.app_user_id || row.user_id)
-          .filter((id: string | null): id is string => id !== null)
+          .map((row) => row.app_user_id || row.user_id)
+          .filter((id): id is string => id !== null)
     }
 
     async getRoles(companyId?: string | null): Promise<(CompanyMembership & { appUserId?: string | null })[]> {

--- a/infrastructure/persistence/prisma/PrismaCompanyRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaCompanyRepository.ts
@@ -3,7 +3,7 @@ import type {
   CompanyRecord,
   CompanyRepository,
 } from '@/application/interfaces/CompanyRepository'
-import { prisma } from '@/lib/prisma'
+import { prisma, cached } from '@/lib/prisma'
 import { Prisma } from '@prisma/client'
 import { parseFlexibleDate } from '@/lib/utils/parse-date'
 
@@ -262,11 +262,13 @@ export class PrismaCompanyRepository implements CompanyRepository {
     // afterwards. This fires on every regulatory-requirement query
     // (~250 ms iad1↔ap-south-1 RTT) to drive country-specific deadline
     // calculations. Auto-invalidates if a company is updated via Prisma.
-    const row = await (prisma.company.findUnique({
-      where: { id: companyId },
-      select: { country_code: true },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any).cacheStrategy({ ttl: 300, swr: 120 })
+    const row = await cached(
+      prisma.company.findUnique({
+        where: { id: companyId },
+        select: { country_code: true },
+      }),
+      { ttl: 300, swr: 120 },
+    )
     return row?.country_code ?? null
   }
 

--- a/infrastructure/persistence/prisma/PrismaEmailPreferenceRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaEmailPreferenceRepository.ts
@@ -4,7 +4,7 @@ import type {
     EmailPreferenceRepository,
     SaveEmailPreferenceInput,
 } from '@/application/interfaces/EmailPreferenceRepository'
-import { prisma } from '@/lib/prisma'
+import { prisma, cached } from '@/lib/prisma'
 
 export class PrismaEmailPreferenceRepository implements EmailPreferenceRepository {
     async getByUserId(userId: string): Promise<EmailPreferenceRecord | null> {
@@ -13,10 +13,12 @@ export class PrismaEmailPreferenceRepository implements EmailPreferenceRepositor
         // month) but this fires on every notification-routing decision
         // and team-update broadcast. Auto-invalidates on saveForUser's
         // upsert below.
-        const row = await (prisma.emailPreference.findUnique({
-            where: { user_id: userId },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any).cacheStrategy({ ttl: 60, swr: 30 })
+        const row = await cached(
+            prisma.emailPreference.findUnique({
+                where: { user_id: userId },
+            }),
+            { ttl: 60, swr: 30 },
+        )
 
         if (!row) return null
 

--- a/infrastructure/persistence/prisma/PrismaUserRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaUserRepository.ts
@@ -1,6 +1,6 @@
 import type { UserRepository } from '@/application/interfaces/UserRepository'
 import type { AppUser } from '@/domain/models/AppUser'
-import { prisma } from '@/lib/prisma'
+import { prisma, cached } from '@/lib/prisma'
 
 export class PrismaUserRepository implements UserRepository {
   private mapCanonicalUser(
@@ -33,15 +33,17 @@ export class PrismaUserRepository implements UserRepository {
     // Auto-invalidation: Accelerate invalidates AppUser cache entries
     // on .update / .create / .delete from the same model, so a profile
     // update doesn't leave stale reads beyond a single roundtrip.
-    const appUserRow = await (prisma.appUser.findUnique({
-      where: { id: userId },
-      select: {
-        id: true,
-        primary_email: true,
-        full_name: true,
-      },
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    }) as any).cacheStrategy({ ttl: 60, swr: 30 })
+    const appUserRow = await cached(
+      prisma.appUser.findUnique({
+        where: { id: userId },
+        select: {
+          id: true,
+          primary_email: true,
+          full_name: true,
+        },
+      }),
+      { ttl: 60, swr: 30 },
+    )
 
     if (appUserRow) {
       return this.mapCanonicalUser(appUserRow, 'supabase', null)

--- a/infrastructure/persistence/prisma/PrismaVaultTemplateManagementRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaVaultTemplateManagementRepository.ts
@@ -4,7 +4,7 @@ import type {
     VaultTemplateManagementRepository,
     VaultTemplateMutationInput,
 } from '@/application/interfaces/VaultTemplateManagementRepository'
-import { prisma } from '@/lib/prisma'
+import { prisma, cached } from '@/lib/prisma'
 
 export class PrismaVaultTemplateManagementRepository implements VaultTemplateManagementRepository {
     private mapRow(row: any): VaultTemplateManagementRecord {
@@ -35,15 +35,17 @@ export class PrismaVaultTemplateManagementRepository implements VaultTemplateMan
         // queried on every document-requirement breadcrumb render.
         // Auto-invalidates when documentTemplate rows are written via
         // this same repository's create/update/delete methods.
-        const row = await (prisma.documentTemplate.findUnique({
-            where: { id },
-            select: {
-                id: true,
-                document_name: true,
-                folder_name: true,
-            },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any).cacheStrategy({ ttl: 300, swr: 120 })
+        const row = await cached(
+            prisma.documentTemplate.findUnique({
+                where: { id },
+                select: {
+                    id: true,
+                    document_name: true,
+                    folder_name: true,
+                },
+            }),
+            { ttl: 300, swr: 120 },
+        )
 
         if (!row) return null
 

--- a/infrastructure/persistence/prisma/PrismaVaultTemplateRepository.ts
+++ b/infrastructure/persistence/prisma/PrismaVaultTemplateRepository.ts
@@ -1,5 +1,5 @@
 import type { VaultTemplateRecord, VaultTemplateRepository } from '@/application/interfaces/VaultTemplateRepository'
-import { prisma } from '@/lib/prisma'
+import { prisma, cached } from '@/lib/prisma'
 
 export class PrismaVaultTemplateRepository implements VaultTemplateRepository {
     async getFolderPaths(): Promise<string[]> {
@@ -9,17 +9,19 @@ export class PrismaVaultTemplateRepository implements VaultTemplateRepository {
         // every data-room page load to populate the vault sidebar.
         // Auto-invalidates when documentTemplate rows are written via
         // the management repository.
-        const rows = await (prisma.documentTemplate.findMany({
-            where: {
-                NOT: { folder_name: null },
-            },
-            select: { folder_name: true },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any).cacheStrategy({ ttl: 300, swr: 120 })
+        const rows = await cached(
+            prisma.documentTemplate.findMany({
+                where: {
+                    NOT: { folder_name: null },
+                },
+                select: { folder_name: true },
+            }),
+            { ttl: 300, swr: 120 },
+        )
 
         const paths = rows
-            .map((row: { folder_name: string | null }) => row.folder_name)
-            .filter((folderName: string | null): folderName is string => Boolean(folderName))
+            .map((row) => row.folder_name)
+            .filter((folderName): folderName is string => Boolean(folderName))
 
         return Array.from(new Set<string>(paths)).sort()
     }
@@ -27,14 +29,15 @@ export class PrismaVaultTemplateRepository implements VaultTemplateRepository {
     async getTemplates(folderPath?: string | null): Promise<VaultTemplateRecord[]> {
         // Same justification as getFolderPaths above — static catalog,
         // fires on every page load, 5 min cache.
-        const rows = await (prisma.documentTemplate.findMany({
-            where: folderPath ? { folder_name: folderPath } : {},
-            orderBy: { document_name: 'asc' },
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        }) as any).cacheStrategy({ ttl: 300, swr: 120 })
+        const rows = await cached(
+            prisma.documentTemplate.findMany({
+                where: folderPath ? { folder_name: folderPath } : {},
+                orderBy: { document_name: 'asc' },
+            }),
+            { ttl: 300, swr: 120 },
+        )
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        return rows.map((row: any) => ({
+        return rows.map((row) => ({
             id: row.id,
             documentName: row.document_name || '',
             folderName: row.folder_name,

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -51,3 +51,37 @@ declare const globalThis: {
 export const prisma: PrismaClient = globalThis.prismaGlobal ?? prismaClientSingleton()
 
 if (process.env.NODE_ENV !== 'production') globalThis.prismaGlobal = prisma
+
+/**
+ * Runtime-safe wrapper for Prisma Accelerate's `.cacheStrategy(...)`.
+ *
+ * The earlier PRs (#125, #127) claimed the extension was a no-op when
+ * DATABASE_URL points at plain Postgres. That was wrong — `withAccelerate()`
+ * only attaches `.cacheStrategy` to query promises when the underlying
+ * connection actually goes through the Accelerate proxy. With a plain
+ * Postgres URL the method is missing and every annotated call site threw
+ * `TypeError: cacheStrategy is not a function`, hosing every server action
+ * that ran through `requireCurrentUser` in production.
+ *
+ * Wrap the query promise in this helper so the call site looks the same
+ * but tolerates both worlds:
+ *
+ *   const row = await cached(prisma.appUser.findUnique({...}), { ttl: 60, swr: 30 })
+ *
+ * When the method exists → cache strategy is applied as intended.
+ * When it doesn't → the bare query is awaited, no perf change, no crash.
+ *
+ * Once DATABASE_URL is flipped to the Accelerate proxy URL, every call
+ * site automatically picks up caching with no further code change.
+ */
+export function cached<T>(
+  queryPromise: Promise<T>,
+  options: { ttl: number; swr?: number },
+): Promise<T> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const maybeStrategy = (queryPromise as any).cacheStrategy
+  if (typeof maybeStrategy === 'function') {
+    return maybeStrategy.call(queryPromise, options) as Promise<T>
+  }
+  return queryPromise
+}


### PR DESCRIPTION
## URGENT — production OAuth + every protected page is broken

**Root cause**: PRs #125 and #127 assumed `withAccelerate()` was a clean no-op when DATABASE_URL points at plain Postgres. That assumption was wrong — `.cacheStrategy(...)` is only attached to query promises when the connection actually routes through the Accelerate proxy. With a plain Postgres URL the method is missing.

**Symptom in Vercel logs**:
```
TypeError: i.prisma.appUser.findUnique(...).cacheStrategy is not a function
  at j.getById (/var/task/.next/server/chunks/.../server-container_ts...)
  at e.getCurrentUser (...)
  at e.requireCurrentUser (...)
```
Followed by `PrismaClientInitializationError: Timed out fetching a new connection from the connection pool` as lambdas retry.

**User-visible**: Google OAuth lands on `?error=callback_failed`. /subscribe, /data-room, and every page that goes through `requireCurrentUser` errors out.

## Fix
New `cached(queryPromise, opts)` helper in `lib/prisma.ts` that:
- Calls `.cacheStrategy(opts)` only when the method exists at runtime.
- Otherwise awaits the bare query.

Every previously-annotated call site (7 total across 6 repositories) is migrated to use it. Behavior matches pre-PR-125 versions until DATABASE_URL is flipped — then caching activates automatically with no further code change.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] After merge: load /login → Continue with Google → confirm callback redirects to /data-room (not `?error=callback_failed`)
- [ ] /data-room loads, `[DataRoomInit] 🔍 SERVER-SIDE BREAKDOWN:` console line surfaces with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)