### PR TITLE
fix(access): require invited team-member companies to be funded before listing as accessible

### DIFF
--- a/application/services/RepositoryAccessService.ts
+++ b/application/services/RepositoryAccessService.ts
@@ -188,12 +188,47 @@ export class RepositoryAccessService implements AccessService {
             const invitedCompanies = await Promise.all(
                 invitedCompanyIds.map(id => this.companyRepository.getById(id))
             )
-            
-            invitedCompanies.forEach((company) => {
-                if (company && company.ownerUserId !== userId && company.ownerAppUserId !== userId) {
-                    if (!accessibleIds.includes(company.id)) {
-                        accessibleIds.push(company.id)
-                    }
+
+            // Only count companies the user is invited to (not owns).
+            const invitedNotOwned = invitedCompanies.filter(
+                (company): company is NonNullable<typeof company> =>
+                    !!company &&
+                    company.ownerUserId !== userId &&
+                    company.ownerAppUserId !== userId,
+            )
+
+            // Mirror the data-room CTE's acc_ids gate: a team-member
+            // role grants data-room access only when the company has
+            // its own active subscription OR the owner has an active
+            // personal subscription. Without this check the /subscribe
+            // page listed invited-but-unfunded companies under
+            // "Companies You Can Still Access", users clicked through,
+            // and /data-room then bounced them right back — confusing
+            // dead-end UX. Keeping the gate identical in both places
+            // means the listing and the navigation target agree.
+            //
+            // Fan out the per-company subscription checks in parallel;
+            // typical user has only a handful of invited companies so
+            // the cost is bounded and stays under one RTT window.
+            const invitedSubscriptionResults = await Promise.all(
+                invitedNotOwned.map(async (company) => {
+                    const ownerId = company.ownerAppUserId || company.ownerUserId
+                    const [companySub, ownerSub] = await Promise.all([
+                        this.subscriptionRepository.getCompanySubscriptionState(company.id),
+                        ownerId
+                            ? this.subscriptionRepository.getUserSubscriptionState(ownerId)
+                            : Promise.resolve(null),
+                    ])
+                    const hasFundedAccess = Boolean(
+                        companySub?.hasSubscription || ownerSub?.hasSubscription,
+                    )
+                    return { companyId: company.id, hasFundedAccess }
+                }),
+            )
+
+            invitedSubscriptionResults.forEach((result) => {
+                if (result.hasFundedAccess && !accessibleIds.includes(result.companyId)) {
+                    accessibleIds.push(result.companyId)
                 }
             })
         }


### PR DESCRIPTION
## Summary
`RepositoryAccessService.getAccessibleCompanyIds` added every invited (team-member) company to the accessible list unconditionally. The `/data-room` atomic CTE meanwhile enforced the funded-access gate strictly — a team-member role grants data-room access only when the company has its own active subscription OR the owner has an active personal subscription. The two sources disagreed, and `/subscribe`'s 'Companies You Can Still Access' panel listed companies the user would then get bounced from.

## Repro
1. User is a team-member of JRS but JRS has no company subscription and the owner has no personal subscription.
2. User lands on /subscribe (their own current company is unfunded).
3. JRS appears under 'Companies You Can Still Access'.
4. Click JRS → /data-room?company_id=JRS → CTE rejects → bounces back to /subscribe.

## Fix
Apply the same funded-access gate inside `getAccessibleCompanyIds`: for each invited company, fan out parallel checks for company-level sub and owner-personal sub, and only include the company when at least one is active. Owned-company logic unchanged.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] After merge: log in as a user whose only access to a given company is via team-member role on an unfunded company — confirm that company no longer appears under 'Companies You Can Still Access'
- [ ] A user who IS funded (company sub or owner personal sub on the invited company) still sees the company in the panel and can click through to /data-room

🤖 Generated with [Claude Code](https://claude.com/claude-code)