### PR TITLE
perf(keepalive): /api/keepalive endpoint for Supabase pg_cron warm-pool ping

### DIFF
--- a/app/api/keepalive/route.ts
+++ b/app/api/keepalive/route.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+
+/**
+ * Lightweight keep-alive endpoint hit by Supabase pg_cron (via
+ * pg_net.http_post) every ~4 minutes. Two warm-cache effects:
+ *
+ *   1. Vercel keeps the lambda instance in its warm-pool because
+ *      invocations are recent. Subsequent real user requests skip
+ *      the ~600 ms cold-start tax.
+ *   2. The singleton PrismaClient in lib/prisma.ts establishes its
+ *      PgBouncer connection on first query and reuses it. A real
+ *      user's first request after a long idle period otherwise pays
+ *      the ~2.8 s TLS-handshake + pool-setup we measured in PR-38.
+ *      Firing a trivial query here keeps that connection alive.
+ *
+ * Fire-and-forget from cron's perspective: pg_net doesn't wait for
+ * or care about the response body, so the response is intentionally
+ * tiny. Latency on this endpoint doesn't affect anything.
+ *
+ * Concurrency: pg_cron schedules at fixed intervals; if two ticks
+ * overlap (e.g. cold lambda lag) both will hit different lambda
+ * instances and each will warm its own pool — that's fine.
+ *
+ * Auth: shared secret in `x-keepalive-secret` header against env var
+ * `KEEPALIVE_SECRET`. Same pattern as /api/jobs/run-ingest.
+ */
+
+export const maxDuration = 30
+
+export async function POST(request: NextRequest) {
+  const expectedSecret = process.env.KEEPALIVE_SECRET
+  if (!expectedSecret) {
+    console.error('[keepalive] KEEPALIVE_SECRET not configured')
+    return NextResponse.json({ error: 'keepalive not configured' }, { status: 500 })
+  }
+
+  const provided = request.headers.get('x-keepalive-secret')
+  if (provided !== expectedSecret) {
+    console.warn('[keepalive] auth failed — invalid secret header')
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const t0 = performance.now()
+  try {
+    await prisma.$queryRaw`SELECT 1 as ping`
+    const elapsed = performance.now() - t0
+    console.log(`[keepalive] ok ${elapsed.toFixed(0)}ms`)
+    return NextResponse.json({ ok: true, elapsed_ms: Math.round(elapsed) })
+  } catch (err) {
+    const elapsed = performance.now() - t0
+    const message = err instanceof Error ? err.message : String(err)
+    console.error(`[keepalive] db ping failed after ${elapsed.toFixed(0)}ms`, message,
+      err instanceof Error ? err.stack : '')
+    return NextResponse.json({ ok: false, error: message }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
Adds a POST `/api/keepalive` that authenticates via `x-keepalive-secret` header against `KEEPALIVE_SECRET` and runs `SELECT 1` against the singleton Prisma client. Designed to be hit by Supabase `pg_cron` (via `pg_net.http_post`) every 4 minutes.

## Why
We measured cold lambda `/data-room` init at ~2.8 s where almost all of that time is the PgBouncer TLS handshake (PR-38 confirmed `serverExec ≈ 0`, all bottleneck is connection establishment). Keeping the Vercel lambda warm and the Prisma connection initialized eliminates that cost for real user requests that land within ~15 min of the last keep-alive.

## Wiring (outside repo — needs setup in Supabase SQL)
1. **Set the secret** in Vercel: `KEEPALIVE_SECRET` (Production) — any 32+ char random string.
2. **In Supabase SQL editor**, enable `pg_net` + `pg_cron`:
   ```sql
   CREATE EXTENSION IF NOT EXISTS pg_net;
   CREATE EXTENSION IF NOT EXISTS pg_cron;
   ```
3. **Schedule the job:**
   ```sql
   SELECT cron.schedule(
     'finacra-keepalive',
     '*/4 * * * *',
     $$
     SELECT net.http_post(
       url := 'https://www.finacra.com/api/keepalive',
       headers := jsonb_build_object('x-keepalive-secret', '<KEEPALIVE_SECRET value>'),
       body := '{}'::jsonb
     );
     $$
   );
   ```

## Budget
- 360 invocations/day = ~11K/month, ~11% of Vercel Hobby's 100K-invocations/month budget.
- pg_cron + pg_net are free on Supabase any tier.
- Lambda execution is ~50 ms × 256 MB = 0.013 GB-s/invocation × 11K = 143 GB-s/month, negligible.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Set `KEEPALIVE_SECRET` in Vercel prod env
- [ ] Schedule the pg_cron job in Supabase
- [ ] Tail Vercel logs — confirm `[keepalive] ok Nms` messages every 4 min
- [ ] Compare cold-start /data-room load times over 24 h vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a keep-alive endpoint that monitors database connection health with authentication and performance metrics tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finacra/tracker/pull/133)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->