### PR TITLE
perf(data-room): add loading.tsx for instant feedback during streaming SSR fetch

### DIFF
--- a/app/data-room/loading.tsx
+++ b/app/data-room/loading.tsx
@@ -1,0 +1,21 @@
+import DataRoomBootShell from './components/DataRoomBootShell'
+
+/**
+ * Route-level loading UI rendered by Next.js while the /data-room RSC
+ * is fetching server-side (PR-44 streaming SSR runs
+ * `getDataRoomInitState` in the page.tsx server component, which can
+ * take 2-5s on a cold lambda).
+ *
+ * Without this file, Next.js shows the *previous* page (e.g.
+ * /subscribe, /home) until the RSC payload is ready — that's
+ * disorienting on click. With loading.tsx the boot shell renders
+ * instantly the moment the user navigates, then the real
+ * DataRoomClient replaces it when the data arrives.
+ *
+ * Re-uses the same DataRoomBootShell already used by the client
+ * component, so the visual handoff is seamless — the post-load tree
+ * lands in the exact same DOM positions, no layout shift.
+ */
+export default function Loading() {
+  return <DataRoomBootShell />
+}


### PR DESCRIPTION
## Summary
PR-44's streaming SSR moved `getDataRoomInitState` from the client `useEffect` into the `page.tsx` RSC. The trade-off: during the 2-5 s server-side fetch, Next.js' default behavior is to keep showing the *previous* page until the new RSC payload is ready. On a click that means no visible feedback — felt like the navigation didn't register.

This PR adds `app/data-room/loading.tsx` which Next.js renders the moment the user clicks, replaced by the real route content when the RSC stream completes. Re-uses the existing `DataRoomBootShell`, so the visual handoff is seamless (same DOM positions, no layout shift).

Together with PR-44 this gives the full streaming SSR experience: instant boot-shell feedback → data arrives → populated UI swaps in. No `getDataRoomInitState` round-trip is visible to the user.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Smoke: click any link that lands on /data-room — confirm boot shell appears immediately instead of the previous page lingering

🤖 Generated with [Claude Code](https://claude.com/claude-code)