### PR TITLE
feat(subscribe): discount-code support — super99 flat ₹1 across all tiers and cycles

### DIFF
--- a/app/api/payments/create-order/route.ts
+++ b/app/api/payments/create-order/route.ts
@@ -3,6 +3,7 @@ import { createClient } from '@/utils/supabase/server'
 import { createServerContainer } from '@/lib/composition/server-container'
 import { getRazorpayInstance } from '@/lib/razorpay/client'
 import { calculatePricing, getTierById, type BillingCycle, type PricingTier } from '@/lib/pricing/tiers'
+import { resolveDiscountCode } from '@/lib/pricing/discount-codes'
 import { checkRateLimit, getClientIp } from '@/lib/utils/rate-limiter'
 import { handleAPIError } from '@/lib/errors/handle-error'
 
@@ -29,7 +30,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { tier, billingCycle, companyId } = body
+    const { tier, billingCycle, companyId, discountCode } = body
 
     // Get company country_code for currency
     let countryCode = 'IN'
@@ -58,7 +59,24 @@ export async function POST(request: NextRequest) {
     }
 
     const pricing = calculatePricing(tierConfig, billingCycle as BillingCycle, countryCode)
-    const amountInPaise = Math.round(pricing.price * 100) // Convert to paise
+    const computedAmountInPaise = Math.round(pricing.price * 100) // Convert to paise
+
+    // Server-side discount-code resolution. The client may pass a
+    // `discountCode` in the body; we ignore anything we don't
+    // explicitly recognize in the server-side registry. Never trust
+    // a client-supplied price — only the registry decides the
+    // override. The applied code is stamped onto the Razorpay order
+    // notes and the Payment row's audit notes so finance can
+    // reconcile heavily-discounted orders without scanning logs.
+    const matchedDiscount = resolveDiscountCode(typeof discountCode === 'string' ? discountCode : null)
+    const amountInPaise = matchedDiscount?.overrideAmountPaise ?? computedAmountInPaise
+    const finalAmountRupees = amountInPaise / 100
+    if (matchedDiscount) {
+      console.log(
+        `[create-order] discount code applied: ${matchedDiscount.code} ` +
+        `(${tier}/${billingCycle}: ₹${pricing.price} → ₹${finalAmountRupees})`,
+      )
+    }
 
     // Validate Razorpay credentials
     if (!process.env.NEXT_PUBLIC_RAZORPAY_KEY_ID || !process.env.RAZORPAY_KEY_SECRET) {
@@ -89,7 +107,15 @@ export async function POST(request: NextRequest) {
         company_id: companyId || '',
         tier: tier,
         billing_cycle: billingCycle,
+        // Keep the ORIGINAL (un-discounted) tier price for audit
+        // history. The actual charged amount is order.amount in
+        // paise above. Finance can compare these to reconcile any
+        // discounted order without scanning server logs.
         amount_rupees: pricing.price.toString(),
+        final_amount_rupees: finalAmountRupees.toString(),
+        ...(matchedDiscount
+          ? { discount_code: matchedDiscount.code }
+          : {}),
       },
     })
 
@@ -101,7 +127,10 @@ export async function POST(request: NextRequest) {
         companyId: companyId || null,
         providerOrderId: order.id,
         paymentProvider: 'razorpay',
-        amount: pricing.price,
+        // Record what the user actually paid (post-discount), not the
+        // sticker tier price. Finance can recover the original via
+        // notes.amount_rupees if needed.
+        amount: finalAmountRupees,
         currency: pricing.currency || 'INR',
         tier: tier as PricingTier,
         billingCycle: billingCycle as BillingCycle,

--- a/app/subscribe/page.tsx
+++ b/app/subscribe/page.tsx
@@ -40,6 +40,11 @@ function SubscribePageInner() {
   
   const [companyName, setCompanyName] = useState<string>('')
   const [selectedBillingCycle, setSelectedBillingCycle] = useState<BillingCycle>('annual')
+  // Discount code state. Server-side allow-list in
+  // lib/pricing/discount-codes.ts decides whether to apply an
+  // override on /api/payments/create-order — this field's value is
+  // purely a passthrough to that server endpoint.
+  const [discountCode, setDiscountCode] = useState<string>('')
   const [isStartingTrial, setIsStartingTrial] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [userCompanies, setUserCompanies] = useState<Array<{ id: string; name: string }>>([])
@@ -463,6 +468,29 @@ function SubscribePageInner() {
           ))}
         </div>
 
+        {/* Discount Code */}
+        <div className="max-w-md mx-auto mb-8">
+          <label
+            htmlFor="discount-code"
+            className="block text-xs uppercase tracking-[0.15em] text-fg-muted mb-2 text-center"
+          >
+            Have a code?
+          </label>
+          <input
+            id="discount-code"
+            type="text"
+            value={discountCode}
+            onChange={(e) => setDiscountCode(e.target.value)}
+            placeholder="Enter discount code"
+            autoComplete="off"
+            spellCheck={false}
+            className="w-full px-4 py-2.5 bg-bg-card border border-line/15 rounded-lg text-fg-primary placeholder:text-fg-muted/60 font-light text-center tracking-wide focus:outline-none focus:border-line/30 focus:ring-1 focus:ring-gray-600 transition-colors uppercase"
+          />
+          <p className="text-xs text-fg-muted/70 mt-2 text-center font-light">
+            Applied at checkout. Codes are case-insensitive.
+          </p>
+        </div>
+
         {/* Pricing Cards */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8 max-w-6xl mx-auto">
           {PRICING_TIERS.map((tier) => {
@@ -565,6 +593,7 @@ function SubscribePageInner() {
                   companyId={
                       selectedCompanyForSubscription || companyId || undefined
                   }
+                  discountCode={discountCode}
                   className={`w-full py-3 px-6 rounded-lg font-light transition-all mb-6 ${
                     tier.popular
                       ? 'bg-bg-hover hover:bg-bg-hover text-fg-primary'

--- a/components/features/PaymentButton.tsx
+++ b/components/features/PaymentButton.tsx
@@ -10,10 +10,17 @@ interface PaymentButtonProps {
   billingCycle: BillingCycle
   price: number
   companyId?: string
+  /**
+   * Optional discount code the user typed on /subscribe. Passed
+   * through to the server; the server validates against an
+   * allow-list and silently ignores unknown codes — the value here
+   * never affects the price client-side.
+   */
+  discountCode?: string
   className?: string
 }
 
-export default function PaymentButton({ tier, billingCycle, price, companyId, className }: PaymentButtonProps) {
+export default function PaymentButton({ tier, billingCycle, price, companyId, discountCode, className }: PaymentButtonProps) {
   const { user, displayName, displayEmail } = useAuth()
   const [isLoading, setIsLoading] = useState(false)
   const [isScriptLoaded, setIsScriptLoaded] = useState(false)
@@ -40,8 +47,9 @@ export default function PaymentButton({ tier, billingCycle, price, companyId, cl
     setIsLoading(true)
 
     try {
-      // Create order
-      const orderData = await createRazorpayOrder(tier, billingCycle, companyId)
+      // Create order — server-side rules validate `discountCode` and
+      // decide whether to override the amount.
+      const orderData = await createRazorpayOrder(tier, billingCycle, companyId, discountCode)
 
       // Open Razorpay checkout
       openRazorpayCheckout({

--- a/lib/pricing/discount-codes.ts
+++ b/lib/pricing/discount-codes.ts
@@ -1,0 +1,57 @@
+/**
+ * Server-only discount-code registry.
+ *
+ * Each entry maps a case-insensitive code string to a price override
+ * applied during Razorpay order creation. The first matching active
+ * code overrides the computed tier+cycle price; the original price is
+ * still recorded on the Payment row's `notes.original_amount_rupees`
+ * for accounting, and the applied code is recorded on
+ * `notes.discount_code` for audit.
+ *
+ * KEEP THIS FILE SERVER-ONLY. It is imported only from
+ * `app/api/payments/create-order/route.ts`. Don't import it from
+ * client components — the codes shouldn't ship to the browser.
+ *
+ * To add a code, just push to the array. To revoke a code, flip
+ * `active: false` (preserves historical Payment.notes audit trail) or
+ * delete the entry.
+ */
+
+export interface DiscountCode {
+  /** Display code as users type it. Matched case-insensitively. */
+  code: string
+  /** False to disable a code without removing it. */
+  active: boolean
+  /**
+   * Override the final order amount, in paise. 100 = ₹1.
+   * Applies regardless of tier or billing cycle.
+   */
+  overrideAmountPaise: number
+  /** Free-form note shown only in server logs / Payment.notes audit. */
+  description: string
+}
+
+export const DISCOUNT_CODES: DiscountCode[] = [
+  {
+    code: 'super99',
+    active: true,
+    overrideAmountPaise: 100, // ₹1
+    description:
+      'super99 promo — flat ₹1 across all tiers and billing cycles.',
+  },
+]
+
+/**
+ * Resolve a user-entered code to its override, or null if not valid.
+ * Case-insensitive, trims whitespace, ignores inactive entries.
+ */
+export function resolveDiscountCode(input: string | null | undefined): DiscountCode | null {
+  if (!input) return null
+  const normalized = input.trim().toLowerCase()
+  if (!normalized) return null
+  return (
+    DISCOUNT_CODES.find(
+      (entry) => entry.active && entry.code.toLowerCase() === normalized,
+    ) ?? null
+  )
+}

--- a/lib/razorpay/payment.ts
+++ b/lib/razorpay/payment.ts
@@ -59,7 +59,8 @@ export async function loadRazorpayScript(): Promise<void> {
 export async function createRazorpayOrder(
   tier: string,
   billingCycle: string,
-  companyId?: string
+  companyId?: string,
+  discountCode?: string,
 ): Promise<{ orderId: string; amount: number; currency: string; keyId: string }> {
   const response = await fetch('/api/payments/create-order', {
     method: 'POST',
@@ -70,6 +71,10 @@ export async function createRazorpayOrder(
       tier,
       billingCycle,
       companyId,
+      // The server validates the code against an allow-list in
+      // lib/pricing/discount-codes.ts. Unrecognized codes are
+      // silently ignored — never trust the client to apply a price.
+      discountCode: discountCode?.trim() || undefined,
     }),
   })
 


### PR DESCRIPTION
## Summary
Adds a discount-code feature on `/subscribe`: when the user enters a code, the server validates it against an allow-list and overrides the Razorpay order amount. First code shipped: `super99` → flat ₹1 (100 paise) across all tiers (Starter / Professional / Enterprise) and all billing cycles (monthly / quarterly / half-yearly / annual).

## Architecture

```
/subscribe (user types code)
    │
    ▼ prop: discountCode
PaymentButton
    │
    ▼ 4th arg
createRazorpayOrder()
    │
    ▼ POST body
/api/payments/create-order
    │
    ▼ resolveDiscountCode(input) → DiscountCode | null
lib/pricing/discount-codes.ts  (server-only allow-list)
    │
    ▼ overrideAmountPaise if matched
Razorpay order: amount = override OR computed tier price
```

## Files
| File | Change |
|---|---|
| `lib/pricing/discount-codes.ts` (NEW) | Server-only registry: `DISCOUNT_CODES` + `resolveDiscountCode()` |
| `app/api/payments/create-order/route.ts` | Reads `discountCode` from body, applies override, stamps audit notes |
| `lib/razorpay/payment.ts` | `createRazorpayOrder` takes optional 4th `discountCode` |
| `components/features/PaymentButton.tsx` | Optional `discountCode` prop, forwards to client lib |
| `app/subscribe/page.tsx` | New `discountCode` state + centered input row above the pricing cards |

## Security
- The registry is **server-only**. `lib/pricing/discount-codes.ts` is imported exclusively by the server route — the codes do not ship to the browser bundle.
- Unknown / missing / inactive codes silently fall through to the computed price; the client cannot inject an override.
- The existing `/api/payments/create-order` rate limit (10 attempts per IP per 15 min) caps brute-force code guessing.

## Audit trail
On a discounted order the Razorpay order's `notes` carry:
- `discount_code` — the matched code (e.g. `super99`)
- `amount_rupees` — original tier price (un-discounted)
- `final_amount_rupees` — actual charged amount

The `Payment` row's `amount` column also records the post-discount value, so finance reconciliation works without reading the JSON notes.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Smoke: load /subscribe, type `super99` in the discount input, click Subscribe on any tier/cycle. Razorpay modal should open showing **₹1.00**.
- [ ] Smoke: type random code (`abc123`), click Subscribe. Razorpay should show the regular tier price (silent fallback).
- [ ] Smoke: leave input empty, Subscribe. Regular tier price.
- [ ] After test payment: verify `Payment.amount` row reflects the actual charged amount, and `notes.discount_code = 'super99'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)