### PR TITLE
perf(data-room): tab switch should not refetch the streaming-SSR RSC

### DIFF
--- a/app/data-room/DataRoomClient.tsx
+++ b/app/data-room/DataRoomClient.tsx
@@ -1185,11 +1185,30 @@ function DataRoomPageInner({
   const setActiveTab = useCallback((tab: string) => {
     setActiveTabLocal(tab);
     setStoredTab(tab as import("@/lib/store/appStore").DataRoomTab);
-    // Reflect in URL without adding to browser history
-    const params = new URLSearchParams(window.location.search);
-    params.set("tab", tab);
-    router.replace(`?${params.toString()}`, { scroll: false });
-  }, [setStoredTab, router]);
+    // Reflect in URL without triggering a Next.js RSC re-fetch.
+    //
+    // Previously this used `router.replace(?tab=...)`. Because PR-44's
+    // streaming-SSR page.tsx reads searchParams in its RSC and awaits
+    // getDataRoomInitState before rendering, a router-driven URL
+    // change with new query params caused Next to re-execute page.tsx
+    // (5+ seconds on a cold lambda), repopulate the prop, and ripple
+    // into a cascade of post-mount server actions — 9 sequential
+    // POST /data-room calls totalling ~30-44s on every Overview →
+    // Tracker click (measured).
+    //
+    // history.replaceState updates the address-bar URL synchronously
+    // without involving Next.js's router or RSC payload. Tab state is
+    // purely a client concern (read from URL on first mount, then
+    // owned by React state + Zustand below), so bypassing the router
+    // is safe — refreshing the page still lands on the right tab via
+    // searchParams.get("tab") at component init.
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      params.set("tab", tab);
+      const newUrl = `${window.location.pathname}?${params.toString()}`;
+      window.history.replaceState(window.history.state, '', newUrl);
+    }
+  }, [setStoredTab]);
 
   // GST Integration States
   // GST tab state moved to GSTTab component


### PR DESCRIPTION
## Summary
After PR-44 turned `/data-room` into a server-prefetched RSC route, every tab click was triggering a full server-side re-render of page.tsx (and a fresh `getDataRoomInitState` call) because `setActiveTab` used `router.replace('?tab=…')` and the new query param made Next.js treat it as a navigation.

Measured impact on the live signed-in app: **clicking Overview → Tracker fires 9 sequential server actions over ~44 seconds**. The first one is a 5.5 s `/data-room?tab=tracker&_rsc=…` RSC refetch; the rest are post-mount effects that re-fire because the route just "re-mounted."

## Fix
Tab state is purely a client concern (read from URL once at mount, then owned by `useState` + Zustand). Swap `router.replace` for `window.history.replaceState` — the address bar still updates, browser back/forward still works (`history.state` is preserved), and Next.js's router stays out of it.

## Expected impact
- Tab switching should drop from ~30-44 s sequential server actions → **near-instant** (just React state update + tab content render with already-loaded data).
- No RSC refetch on tab click.
- No `getDataRoomInitState` re-execution.

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] Smoke: load /data-room, click Tracker. Network tab should show zero new POSTs to /data-room. Address bar should still show `?tab=tracker`.
- [ ] Verify back/forward still works between tabs (history.state preserved).
- [ ] Reload page with `?tab=tracker` in URL: confirm Tracker tab is the active one on first paint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the tab navigation behavior in the data room component. Tab switching operations have been refined to improve responsiveness and efficiency. URL parameters continue to remain synchronized with the active tab state, ensuring consistent browser navigation behavior. This optimization delivers a more streamlined experience when navigating between tabs within the data room.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finacra/tracker/pull/137)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->