### PR TITLE
fix(onboarding): redirect to /data-room after consent when user has existing access

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -196,6 +196,22 @@ export default function OnboardingPage() {
     try {
       const result = await recordTermsAcceptance()
       if (result.success) {
+        // After consent: if the user already has companies and an
+        // active subscription/trial, they don't need the onboarding
+        // form — drop them straight into /data-room. /onboarding only
+        // makes sense as a destination for users who genuinely need
+        // to create their FIRST company.
+        //
+        // We read both signals from the existing useUserSubscription
+        // state (already loaded for the page's auth/sub gates above);
+        // no extra round-trip needed. `currentCompanyCount > 0` covers
+        // owners; team-member-only users wouldn't be on this route in
+        // the first place.
+        if (hasActiveAccess && currentCompanyCount > 0) {
+          console.log('[onboarding:consent] user has companies + access — redirecting to /data-room')
+          router.push('/data-room')
+          return
+        }
         setTermsAccepted(true)
       } else {
         showToast(result.error || 'Failed to record consent. Please try again.', 'error')


### PR DESCRIPTION
## Summary
After PR-49's consent gate, users were always landing on the company-creation form post-consent — even returning users who already own companies with an active subscription. This was confusing UX: 'why am I being asked to create another company?'

## Fix
In `handleAcceptTerms`, after the server confirms the acceptance, check `currentCompanyCount > 0 && hasActiveAccess` (both already loaded by the existing auth/sub gates on the page — no extra round trip). When both are true, `router.push('/data-room')`. When either is false, fall through to showing the form as before.

This mirrors the same logic `GetRootDestination` uses for post-auth routing throughout the rest of the app — applied here to the specific moment immediately after consent.

## Cases
| User state | Post-consent behavior |
|---|---|
| First-time signup, 0 companies | Show company-creation form (unchanged) |
| Returning user, has companies, active sub | Redirect to `/data-room` |
| Returning user, has companies, expired sub | Show form (`hasActiveAccess` is false, so falls through — `/subscribe` gate above already would have caught this case earlier in the page) |
| Team-member-only, 0 owned companies | Show form (rare — they shouldn't typically reach this page anyway) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] As Ibrahim (has BIOREFORM + super99 sub): go to `/onboarding`, accept consent — should redirect to `/data-room`
- [ ] Verify a brand-new user (0 companies, fresh subscription) still lands on the form after consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)