### PR TITLE
fix(onboarding): broaden post-consent redirect signal to cover company-level subs

### DIFF
--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -11,7 +11,7 @@ import {
 import { parseCIN, type ParsedCIN } from '@/utils/cin-parser'
 import { parseGSTN, extractPANFromGSTN } from '@/lib/utils/gstn'
 import { useAuth } from '@/hooks/useAuth'
-import { useUserSubscription } from '@/hooks/useCompanyAccess'
+import { useUserSubscription, useAnyCompanyAccess } from '@/hooks/useCompanyAccess'
 import { completeOnboarding, uploadFileToStorage } from './actions'
 import { getTermsAcceptanceState, recordTermsAcceptance } from './actions-consent'
 import { showToast } from '@/components/ui/Toast'
@@ -45,6 +45,13 @@ export default function OnboardingPage() {
   const router = useRouter()
   const { user, loading } = useAuth()
   const { hasSubscription, isTrial, trialDaysRemaining, companyLimit, currentCompanyCount, canCreateCompany, tier, isLoading: subLoading } = useUserSubscription()
+  // Broader access signal — covers user-level subscription AND
+  // company-level subscription AND being a team member of a funded
+  // company. The handleAcceptTerms redirect below uses this; the
+  // original `hasSubscription || (isTrial && trialDaysRemaining > 0)`
+  // check only catches the user-level case and misses users like
+  // Ibrahim who paid via super99 for a specific company.
+  const { hasAnyAccess } = useAnyCompanyAccess()
   
   // All hooks must be called before any conditional returns
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -196,19 +203,20 @@ export default function OnboardingPage() {
     try {
       const result = await recordTermsAcceptance()
       if (result.success) {
-        // After consent: if the user already has companies and an
-        // active subscription/trial, they don't need the onboarding
-        // form — drop them straight into /data-room. /onboarding only
-        // makes sense as a destination for users who genuinely need
-        // to create their FIRST company.
+        // After consent: if the user already has access to any
+        // company (via personal sub, company sub, OR team-member role
+        // on a funded company), they don't need the onboarding form.
+        // Drop them straight into /data-room. The form only makes
+        // sense for users who genuinely need to create their first
+        // company.
         //
-        // We read both signals from the existing useUserSubscription
-        // state (already loaded for the page's auth/sub gates above);
-        // no extra round-trip needed. `currentCompanyCount > 0` covers
-        // owners; team-member-only users wouldn't be on this route in
-        // the first place.
-        if (hasActiveAccess && currentCompanyCount > 0) {
-          console.log('[onboarding:consent] user has companies + access — redirecting to /data-room')
+        // `hasAnyAccess` is the authoritative signal — it returns
+        // true if `accessibleCompanyIds.length > 0` regardless of
+        // which subscription type funds the access. Catches the
+        // super99 case (Ibrahim has company-level sub but no
+        // user-level sub) that the previous narrower check missed.
+        if (hasAnyAccess) {
+          console.log('[onboarding:consent] user has accessible companies — redirecting to /data-room')
           router.push('/data-room')
           return
         }


### PR DESCRIPTION
## Summary
PR-50 used `hasActiveAccess && currentCompanyCount > 0` to decide whether to redirect to `/data-room` after consent. `hasActiveAccess` only covers **user-level** subscription state — it misses users who are funded only at the **company** level (super99 buyers, Starter/Professional subscribers on a specific company, team-members on a funded company).

Smoke test caught it: Ibrahim paid super99 → Starter Annual for BIOREFORM (company-level sub). His user-level subscription is the expired Enterprise trial. PR-50's check returned false → post-consent he still landed on the company-creation form despite owning 4 companies and being able to access /data-room.

## Fix
Switch the redirect predicate to `useAnyCompanyAccess().hasAnyAccess`, the same signal `/data-room` uses for its own gate. It returns `true` iff `accessibleCompanyIds.length > 0`, which covers:

| Access source | Caught? |
|---|---|
| Personal subscription (Enterprise user sub) | ✓ |
| Personal trial (active) | ✓ |
| Company-level subscription (super99 / Starter / Professional) | ✓ |
| Company-level trial | ✓ |
| Team-member role on a funded company | ✓ |
| No companies, fresh signup | shows form (correct) |

## Test plan
- [x] `npx tsc --noEmit` clean
- [ ] As Ibrahim (only company-level sub via super99): reset `terms_accepted_at = NULL`, hit /onboarding, accept consent → should redirect to /data-room
- [ ] Brand-new test user with 0 companies: still lands on form post-consent

🤖 Generated with [Claude Code](https://claude.com/claude-code)