### PR TITLE
fix(supabase): disable Supabase Auth machinery for Passport JWT project

### DIFF
--- a/utils/supabase/client.ts
+++ b/utils/supabase/client.ts
@@ -1,8 +1,32 @@
 import { createBrowserClient } from '@supabase/ssr'
 
+/**
+ * Browser-side Supabase client.
+ *
+ * This project's auth provider is Passport JWT, NOT Supabase Auth.
+ * The Supabase client is used only for PostgREST (`from(...).select`)
+ * and Storage operations, which authenticate via the anon key in
+ * request headers — no session, no cookies, no refresh tokens.
+ *
+ * By default `createBrowserClient` enables the full auth machinery
+ * (persistSession, autoRefreshToken, detectSessionInUrl). With no
+ * Supabase Auth session ever present, that machinery sits in a
+ * retry loop hammering `/auth/v1/token?grant_type=refresh_token`,
+ * flooding the console with `AuthRetryableFetchError` whenever
+ * Supabase's auth endpoint hiccups (we observed 504s in prod).
+ *
+ * Turn it all off so the client only ever talks to PostgREST/Storage.
+ */
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
   )
 }

--- a/utils/supabase/server.ts
+++ b/utils/supabase/server.ts
@@ -2,6 +2,21 @@ import 'server-only'
 import { createServerClient } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 
+/**
+ * Server-side Supabase client.
+ *
+ * Same rationale as the browser client (utils/supabase/client.ts):
+ * this project authenticates users via Passport JWT, not Supabase
+ * Auth. The Supabase client is only used for PostgREST and Storage
+ * — both of which authenticate via the anon key, not via Supabase
+ * Auth cookies/sessions.
+ *
+ * Turning off `persistSession` + `autoRefreshToken` +
+ * `detectSessionInUrl` stops the SDK from reading/writing Supabase
+ * auth cookies and from firing background refresh requests against
+ * /auth/v1/token. Keeps the cookie adapter wired for forward
+ * compatibility but it'll be a no-op while auth is off.
+ */
 export async function createClient() {
   const cookieStore = await cookies()
 
@@ -9,6 +24,11 @@ export async function createClient() {
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
       cookies: {
         getAll() {
           return cookieStore.getAll()


### PR DESCRIPTION
Stops Supabase JS SDK from auto-refreshing tokens against /auth/v1/token (returning 504 + flooding console with AuthRetryableFetchError). This project uses Passport JWT auth — Supabase client is only used for PostgREST + Storage. Passes auth options to both browser and server clients to disable persistSession + autoRefreshToken + detectSessionInUrl.